### PR TITLE
Fixes `xo` typo in `catch-error-name` documentation.

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -52,5 +52,5 @@ try {
 You can set the `name` option like this:
 
 ```js
-"xo/catch-error-name": ["error", {"name": "err"}]
+"unicorn/catch-error-name": ["error", {"name": "err"}]
 ```


### PR DESCRIPTION
Should be `unicorn` instead of `xo`.