### PR TITLE
Fixes `xo` typo in `filename-case` documentation.

### DIFF
--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -33,5 +33,5 @@ Enforces all linted files to have their names in a certain case style. Default i
 You can set the `case` option like this:
 
 ```js
-"xo/filename-case": ["error", {"case": "kebabCase"}]
+"unicorn/filename-case": ["error", {"case": "kebabCase"}]
 ```


### PR DESCRIPTION
Should be `unicorn` instead of `xo`.