### PR TITLE
Add `no-new-buffer` rule - fixes #59

### DIFF
--- a/docs/rules/no-new-buffer.md
+++ b/docs/rules/no-new-buffer.md
@@ -1,0 +1,27 @@
+# Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`
+
+Enforces the use of [Buffer.from](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_array) and [Buffer.alloc()](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding) instead of [new Buffer()](https://nodejs.org/api/buffer.html#buffer_new_buffer_array), which has been deprecated since Node.js 4.
+
+
+## Fail
+
+```js
+const buf = new Buffer('7468697320697320612074c3a97374', 'hex');
+const buf = new Buffer([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
+```
+
+```js
+const buf = new Buffer(10);
+```
+
+
+## Pass
+
+```js
+const buf = Buffer.from('7468697320697320612074c3a97374', 'hex');
+const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])
+```
+
+```js
+const buf = Buffer.alloc(10);
+```

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = {
 				'unicorn/no-process-exit': 'error',
 				'unicorn/throw-new-error': 'error',
 				'unicorn/number-literal-case': 'error',
-				'unicorn/no-array-instanceof': 'error'
+				'unicorn/no-array-instanceof': 'error',
+				'unicorn/no-new-buffer': 'error'
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,8 @@ Configure it in `package.json`.
 			"unicorn/no-process-exit": "error",
 			"unicorn/throw-new-error": "error",
 			"unicorn/number-literal-case": "error",
-			"unicorn/no-array-instanceof": "error"
+			"unicorn/no-array-instanceof": "error",
+			"unicorn/no-new-buffer": "error"
 		}
 	}
 }
@@ -57,6 +58,7 @@ Configure it in `package.json`.
 - [throw-new-error](docs/rules/throw-new-error.md) - Require `new` when throwing an error. *(fixable)*
 - [number-literal-case](docs/rules/number-literal-case.md) - Enforce lowercase identifier and uppercase value for number literals. *(fixable)*
 - [no-array-instanceof](docs/rules/no-array-instanceof.md) - Require `Array.isArray()` instead of `instanceof Array`. *(fixable)*
+- [no-new-buffer](docs/rules/no-new-buffer.md) - Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`. *(fixable)*
 
 
 ## Recommended config

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -1,0 +1,29 @@
+'use strict';
+const inferMethod = args => (args.length > 0 && typeof args[0].value === 'number') ? 'alloc' : 'from';
+
+const create = context => {
+	return {
+		NewExpression: node => {
+			if (node.callee.name === 'Buffer') {
+				const method = inferMethod(node.arguments);
+				const range = [
+					node.start,
+					node.callee.end
+				];
+
+				context.report({
+					node,
+					message: `\`new Buffer()\` is deprecated, use \`Buffer.${method}()\` instead.`,
+					fix: fixer => fixer.replaceTextRange(range, `Buffer.${method}`)
+				});
+			}
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		fixable: 'code'
+	}
+};

--- a/test/no-new-buffer.js
+++ b/test/no-new-buffer.js
@@ -1,0 +1,80 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-new-buffer';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	},
+	parserOptions: {
+		sourceType: 'module'
+	}
+});
+
+const allocError = {
+	ruleId: 'no-new-buffer',
+	message: '`new Buffer()` is deprecated, use `Buffer.alloc()` instead.'
+};
+
+const fromError = {
+	ruleId: 'no-new-buffer',
+	message: '`new Buffer()` is deprecated, use `Buffer.from()` instead.'
+};
+
+ruleTester.run('no-new-buffer', rule, {
+	valid: [
+		`const buf = Buffer.from('buf')`,
+		`const buf = Buffer.from('7468697320697320612074c3a97374', 'hex')`,
+		'const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])',
+		'const buf = Buffer.alloc(10)'
+	],
+	invalid: [
+		{
+			code: 'const buf = new Buffer()',
+			errors: [fromError],
+			output: 'const buf = Buffer.from()'
+		},
+		{
+			code: `const buf = new Buffer('buf')`,
+			errors: [fromError],
+			output: `const buf = Buffer.from('buf')`
+		},
+		{
+			code: `const buf = new Buffer('7468697320697320612074c3a97374', 'hex')`,
+			errors: [fromError],
+			output: `const buf = Buffer.from('7468697320697320612074c3a97374', 'hex')`
+		},
+		{
+			code: 'const buf = new Buffer([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])',
+			errors: [fromError],
+			output: 'const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])'
+		},
+		{
+			code: 'const buf = new Buffer(10)',
+			errors: [allocError],
+			output: 'const buf = Buffer.alloc(10)'
+		},
+		{
+			code: `
+				const ab = new ArrayBuffer(10);
+				const buf = new Buffer(ab, 0, 2);
+			`,
+			errors: [fromError],
+			output: `
+				const ab = new ArrayBuffer(10);
+				const buf = Buffer.from(ab, 0, 2);
+			`
+		},
+		{
+			code: `
+				const buf1 = new Buffer('buf');
+				const buf2 = new Buffer(buf1);
+			`,
+			errors: [fromError, fromError],
+			output: `
+				const buf1 = Buffer.from('buf');
+				const buf2 = Buffer.from(buf1);
+			`
+		}
+	]
+});


### PR DESCRIPTION
:tada: Feedback more then welcome!

I was struggling with using `fixer.replaceText` and thought I had to parse the arguments myself untill I found out about `fixer.replaceTextRange` :).