### PR TITLE
Add `prefer-starts-ends-with` rule - fixes #13

### DIFF
--- a/docs/rules/prefer-starts-ends-with.md
+++ b/docs/rules/prefer-starts-ends-with.md
@@ -1,6 +1,6 @@
-# Prefer String#startsWidth & String#endsWidth over more complex alternatives
+# Prefer `String#startsWidth` & `String#endsWidth` over more complex alternatives
 
-To know whether a string starts or ends, you have several methods, such as `string.indexOf('foo') === 0` or using regexes with `/^foo/` or `/foo$/`. ES2015 introduces simpler alternatives named `.startsWith` and `.endsWith`. This rule enforces the use of those whenever possible.
+To know whether a string starts or ends, you have several methods, such as `string.indexOf('foo') === 0` or using regexes with `/^foo/` or `/foo$/`. ES2015 introduces simpler alternatives named [`String#startsWith`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) and [`String#endsWith`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith). This rule enforces the use of those whenever possible.
 
 
 ## Fail

--- a/docs/rules/prefer-starts-ends-with.md
+++ b/docs/rules/prefer-starts-ends-with.md
@@ -1,0 +1,18 @@
+# Prefer `.startsWith` and `.endsWith` 
+
+Determine whether a string begins/ends with characters with `.startWith` and `.endsWith` over using regex
+
+## Fail
+
+```js
+/^bar/.test(foo)
+/bar$/.test(foo)
+```
+
+
+## Pass
+
+```js
+foo.startsWith('bar')
+foo.endsWith('bar')
+```

--- a/docs/rules/prefer-starts-ends-with.md
+++ b/docs/rules/prefer-starts-ends-with.md
@@ -1,6 +1,7 @@
 # Prefer `.startsWith` and `.endsWith` 
 
-Determine whether a string begins/ends with characters with `.startWith` and `.endsWith` over using regex.
+To know whether a string starts or ends, you have several methods, such as `string.indexOf('foo') === 0` or using regexes with `/^foo/` or `/foo$/`. ES2015 introduces simpler alternatives named `.startsWith` and `.endsWith`. This rule enforces the use of those whenever possible.
+
 
 ## Fail
 

--- a/docs/rules/prefer-starts-ends-with.md
+++ b/docs/rules/prefer-starts-ends-with.md
@@ -1,18 +1,18 @@
 # Prefer `.startsWith` and `.endsWith` 
 
-Determine whether a string begins/ends with characters with `.startWith` and `.endsWith` over using regex
+Determine whether a string begins/ends with characters with `.startWith` and `.endsWith` over using regex.
 
 ## Fail
 
 ```js
-/^bar/.test(foo)
-/bar$/.test(foo)
+/^bar/.test(foo);
+/bar$/.test(foo);
 ```
 
 
 ## Pass
 
 ```js
-foo.startsWith('bar')
-foo.endsWith('bar')
+foo.startsWith('bar');
+foo.endsWith('bar');
 ```

--- a/docs/rules/prefer-starts-ends-with.md
+++ b/docs/rules/prefer-starts-ends-with.md
@@ -1,4 +1,4 @@
-# Prefer `.startsWith` and `.endsWith` 
+# Prefer String#startsWidth & String#endsWidth over more complex alternatives
 
 To know whether a string starts or ends, you have several methods, such as `string.indexOf('foo') === 0` or using regexes with `/^foo/` or `/foo$/`. ES2015 introduces simpler alternatives named `.startsWith` and `.endsWith`. This rule enforces the use of those whenever possible.
 

--- a/docs/rules/prefer-starts-ends-with.md
+++ b/docs/rules/prefer-starts-ends-with.md
@@ -1,6 +1,6 @@
 # Prefer `String#startsWidth` & `String#endsWidth` over more complex alternatives
 
-To know whether a string starts or ends, you have several methods, such as `string.indexOf('foo') === 0` or using regexes with `/^foo/` or `/foo$/`. ES2015 introduces simpler alternatives named [`String#startsWith`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) and [`String#endsWith`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith). This rule enforces the use of those whenever possible.
+There are several ways of checking whether a string starts or ends with a certain string, such as `string.indexOf('foo') === 0` or using regexes with `/^foo/` or `/foo$/`. ES2015 introduced simpler alternatives named [`String#startsWith`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) and [`String#endsWith`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith). This rule enforces the use of those whenever possible.
 
 
 ## Fail

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = {
 				'unicorn/no-process-exit': 'error',
 				'unicorn/throw-new-error': 'error',
 				'unicorn/number-literal-case': 'error',
-				'unicorn/no-array-instanceof': 'error'
+				'unicorn/no-array-instanceof': 'error',
+				'unicorn/prefer-starts-ends-with': 'error'
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,8 @@ Configure it in `package.json`.
 			"unicorn/no-process-exit": "error",
 			"unicorn/throw-new-error": "error",
 			"unicorn/number-literal-case": "error",
-			"unicorn/no-array-instanceof": "error"
+			"unicorn/no-array-instanceof": "error",
+			"unicorn/prefer-starts-ends-with": "error"
 		}
 	}
 }
@@ -57,6 +58,7 @@ Configure it in `package.json`.
 - [throw-new-error](docs/rules/throw-new-error.md) - Require `new` when throwing an error. *(fixable)*
 - [number-literal-case](docs/rules/number-literal-case.md) - Enforce lowercase identifier and uppercase value for number literals. *(fixable)*
 - [no-array-instanceof](docs/rules/no-array-instanceof.md) - Require `Array.isArray()` instead of `instanceof Array`. *(fixable)*
+- [prefer-starts-ends-with](docs/rules/prefer-starts-ends-with.md) - Prefer `foo.startsWith('bar)` over `/^bar/.test(foo)`.
 
 
 ## Recommended config

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ Configure it in `package.json`.
 - [throw-new-error](docs/rules/throw-new-error.md) - Require `new` when throwing an error. *(fixable)*
 - [number-literal-case](docs/rules/number-literal-case.md) - Enforce lowercase identifier and uppercase value for number literals. *(fixable)*
 - [no-array-instanceof](docs/rules/no-array-instanceof.md) - Require `Array.isArray()` instead of `instanceof Array`. *(fixable)*
-- [prefer-starts-ends-with](docs/rules/prefer-starts-ends-with.md) - Prefer `foo.startsWith('bar)` over `/^bar/.test(foo)`.
+- [prefer-starts-ends-with](docs/rules/prefer-starts-ends-with.md) - Prefer `String#startsWidth` & `String#endsWidth` over more complex alternatives.
 
 
 ## Recommended config

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -1,0 +1,43 @@
+'use strict';
+const doesNotContain = (string, chars) => chars.every(char => string.indexOf(char) === -1);
+
+const isSimpleString = string => doesNotContain(
+	string,
+	['^', '$', '+', '[', '{', '(', '\\', '.', '?', '*']
+);
+
+const create = context => {
+	return {
+		CallExpression(node) {
+			const callee = node.callee;
+			const args = node.arguments;
+
+			let pattern;
+			if (callee.property.name === 'test' && callee.object.regex) {
+				pattern = callee.object.regex.pattern;
+			} else if (callee.property.name === 'match' && args && args[0] && args[0].regex) {
+				pattern = args[0].regex.pattern;
+			} else {
+				return;
+			}
+
+			if (pattern.startsWith('^') && isSimpleString(pattern.substr(1))) {
+				context.report({
+					node,
+					message: 'Prefer `.startsWith` over regex with `^`'
+				});
+			} else if (pattern.endsWith('$') && isSimpleString(pattern.substr(0, pattern.length - 1))) {
+				context.report({
+					node,
+					message: 'Prefer `.endsWith` over regex with `$`'
+				});
+			}
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {}
+};
+

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -12,15 +12,20 @@ const create = context => {
 			const callee = node.callee;
 			const args = node.arguments;
 
-			let pattern;
+			let regex;
 			if (callee.property.name === 'test' && callee.object.regex) {
-				pattern = callee.object.regex.pattern;
+				regex = callee.object.regex;
 			} else if (callee.property.name === 'match' && args && args[0] && args[0].regex) {
-				pattern = args[0].regex.pattern;
+				regex = args[0].regex;
 			} else {
 				return;
 			}
 
+			if (regex.flags.includes('i')) {
+				return;
+			}
+
+			const pattern = regex.pattern;
 			if (pattern.startsWith('^') && isSimpleString(pattern.slice(1))) {
 				context.report({
 					node,

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -1,5 +1,5 @@
 'use strict';
-const doesNotContain = (string, chars) => chars.every(char => string.indexOf(char) === -1);
+const doesNotContain = (string, chars) => chars.every(char => !string.includes(char));
 
 const isSimpleString = string => doesNotContain(
 	string,

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -24,12 +24,12 @@ const create = context => {
 			if (pattern.startsWith('^') && isSimpleString(pattern.substr(1))) {
 				context.report({
 					node,
-					message: 'Prefer `.startsWith` over regex with `^`'
+					message: 'Prefer `.startsWith` over regex with `^`.'
 				});
 			} else if (pattern.endsWith('$') && isSimpleString(pattern.substr(0, pattern.length - 1))) {
 				context.report({
 					node,
-					message: 'Prefer `.endsWith` over regex with `$`'
+					message: 'Prefer `.endsWith` over regex with `$`.'
 				});
 			}
 		}

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -24,12 +24,12 @@ const create = context => {
 			if (pattern.startsWith('^') && isSimpleString(pattern.slice(1))) {
 				context.report({
 					node,
-					message: 'Prefer `.startsWith` over regex with `^`.'
+					message: 'Prefer `String#startsWith` over a regex with `^`.'
 				});
 			} else if (pattern.endsWith('$') && isSimpleString(pattern.slice(0, -1))) {
 				context.report({
 					node,
-					message: 'Prefer `.endsWith` over regex with `$`.'
+					message: 'Prefer `String#endsWith` over a regex with `$`.'
 				});
 			}
 		}

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -21,12 +21,12 @@ const create = context => {
 				return;
 			}
 
-			if (pattern.startsWith('^') && isSimpleString(pattern.substr(1))) {
+			if (pattern.startsWith('^') && isSimpleString(pattern.slice(1))) {
 				context.report({
 					node,
 					message: 'Prefer `.startsWith` over regex with `^`.'
 				});
-			} else if (pattern.endsWith('$') && isSimpleString(pattern.substr(0, pattern.length - 1))) {
+			} else if (pattern.endsWith('$') && isSimpleString(pattern.slice(0, -1))) {
 				context.report({
 					node,
 					message: 'Prefer `.endsWith` over regex with `$`.'

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -21,7 +21,7 @@ const create = context => {
 				return;
 			}
 
-			if (regex.flags.includes('i')) {
+			if (regex.flags && regex.flags.includes('i')) {
 				return;
 			}
 

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -1,0 +1,60 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-starts-ends-with';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const errors = {
+	startsWith: [{
+		ruleId: 'prefer-starts-ends-with',
+		message: 'Prefer `.startsWith` over regex with `^`'
+	}],
+	endsWith: [{
+		ruleId: 'prefer-starts-ends-with',
+		message: 'Prefer `.endsWith` over regex with `$`'
+	}]
+};
+
+const validRegex = [
+	/foo/,
+	/^foo$/,
+	/^foo+/,
+	/foo+$/,
+	/^[f,a]/,
+	/[f,a]$/,
+	/^\w/,
+	/\w$/,
+	/^foo./,
+	/foo.$/
+];
+
+const invalidRegex = [
+	/^foo/,
+	/foo$/,
+	/^!/,
+	/!$/,
+	/^ /,
+	/ $/
+];
+
+ruleTester.run('prefer-starts-ends-with', rule, {
+	valid: [
+		'foo.startsWith(\'bar\')',
+		'foo.endsWith(\'bar\')'
+	]
+		.concat(validRegex.map(re => `${re}.test(bar)`))
+		.concat(validRegex.map(re => `bar.match(${re})`)),
+	invalid: []
+		.concat(invalidRegex.map(re => ({
+			code: `${re}.test(bar)`,
+			errors: errors[`${re}`.startsWith('/^') ? 'startsWith' : 'endsWith']
+		})))
+		.concat(invalidRegex.map(re => ({
+			code: `bar.match(${re})`,
+			errors: errors[`${re}`.startsWith('/^') ? 'startsWith' : 'endsWith']
+		})))
+});

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -31,7 +31,7 @@ const validRegex = [
 	/^foo./,
 	/foo.$/,
 	/\^foo/,
-	/^foo/i,
+	/^foo/i
 ];
 
 const invalidRegex = [

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -30,7 +30,8 @@ const validRegex = [
 	/\w$/,
 	/^foo./,
 	/foo.$/,
-	/\^foo/
+	/\^foo/,
+	/^foo/i,
 ];
 
 const invalidRegex = [

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -43,8 +43,8 @@ const invalidRegex = [
 
 ruleTester.run('prefer-starts-ends-with', rule, {
 	valid: [
-		'foo.startsWith(\'bar\')',
-		'foo.endsWith(\'bar\')'
+		'foo.startsWith("bar")',
+		'foo.endsWith("bar")'
 	]
 		.concat(validRegex.map(re => `${re}.test(bar)`))
 		.concat(validRegex.map(re => `bar.match(${re})`)),

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -11,11 +11,11 @@ const ruleTester = avaRuleTester(test, {
 const errors = {
 	startsWith: [{
 		ruleId: 'prefer-starts-ends-with',
-		message: 'Prefer `.startsWith` over regex with `^`'
+		message: 'Prefer `.startsWith` over regex with `^`.'
 	}],
 	endsWith: [{
 		ruleId: 'prefer-starts-ends-with',
-		message: 'Prefer `.endsWith` over regex with `$`'
+		message: 'Prefer `.endsWith` over regex with `$`.'
 	}]
 };
 

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -11,11 +11,11 @@ const ruleTester = avaRuleTester(test, {
 const errors = {
 	startsWith: [{
 		ruleId: 'prefer-starts-ends-with',
-		message: 'Prefer `.startsWith` over regex with `^`.'
+		message: 'Prefer `String#startsWith` over a regex with `^`.'
 	}],
 	endsWith: [{
 		ruleId: 'prefer-starts-ends-with',
-		message: 'Prefer `.endsWith` over regex with `$`.'
+		message: 'Prefer `String#endsWith` over a regex with `$`.'
 	}]
 };
 

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -29,7 +29,8 @@ const validRegex = [
 	/^\w/,
 	/\w$/,
 	/^foo./,
-	/foo.$/
+	/foo.$/,
+	/\^foo/
 ];
 
 const invalidRegex = [


### PR DESCRIPTION
The changes here add the `prefer-starts-ends-with` for ONLY the regex cases.

I am not so sure how people use `.match` for the purpose of `.startsWith` and `.endsWith` and am concerned that the way I had currently might cause false negative because `str.match(/^foo/)` could be a valid use. Should we test if the code only checks whether the returned result is empty? Please advise. 

Also, this rule doesn't report error for cases like `/^\\/` (false negative), I am not sure what's the best thing to do there. Please shed some light. Thanks!
