### PR TITLE
Add missing rule to example package.json

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,8 @@ Configure it in `package.json`.
 			"unicorn/throw-new-error": "error",
 			"unicorn/number-literal-case": "error",
 			"unicorn/no-array-instanceof": "error",
-			"unicorn/no-new-buffer": "error"
+			"unicorn/no-new-buffer": "error",
+			"unicorn/no-hex-escape": "error"
 		}
 	}
 }


### PR DESCRIPTION
Missed adding the rule to the example package.json in readme.md