### PR TITLE
Add `prefer-string-slice` rule - fixes #65

### DIFF
--- a/docs/rules/prefer-string-slice.md
+++ b/docs/rules/prefer-string-slice.md
@@ -1,0 +1,16 @@
+# Prefer the use of `String.slice` instead of `String.substr` or `String.substring`
+
+Prefer a convention of using `String.slice` instead of `String.substr` or `String.substring`. `String.slice()` has clearer behavior and has a counterpart with arrays. It is also better to be consistent. Anything that can be done with `String.substr()` or `String.substring()` can be done with `String.slice()`.
+
+## Fail
+
+```js
+const foo = bar.substr(1, 2);
+const baz = quux.substring(1, 3);
+```
+
+## Pass
+
+```js
+const foo = bar.slice(1, 3);
+```

--- a/docs/rules/prefer-string-slice.md
+++ b/docs/rules/prefer-string-slice.md
@@ -1,6 +1,6 @@
-# Prefer the use of `String#slice` instead of `String#substr` or `String#substring`
+# Prefer the use of `String#slice()` instead of `String#substr()` or `String#substring()`
 
-Prefer a convention of using [`String#slice`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/slice) instead of [`String#substr`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/substr) or [`String#substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring). `String#slice()` has clearer behavior and has a counterpart with arrays. It is also better to be consistent. Anything that can be done with `String#substr()` or `String#substring()` can be done with `String#slice()`.
+Prefer a convention of using [`String#slice()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/slice) instead of [`String#substr()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/substr) or [`String#substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring). `String#slice()` has clearer behavior and has a counterpart with arrays. It is also better to be consistent. Anything that can be done with `String#substr()` or `String#substring()` can be done with `String#slice()`.
 
 Read more in [this Stack Overflow question](http://stackoverflow.com/questions/2243824/what-is-the-difference-between-string-slice-and-string-substring)
 

--- a/docs/rules/prefer-string-slice.md
+++ b/docs/rules/prefer-string-slice.md
@@ -1,6 +1,8 @@
-# Prefer the use of `String.slice` instead of `String.substr` or `String.substring`
+# Prefer the use of `String#slice` instead of `String#substr` or `String#substring`
 
-Prefer a convention of using `String.slice` instead of `String.substr` or `String.substring`. `String.slice()` has clearer behavior and has a counterpart with arrays. It is also better to be consistent. Anything that can be done with `String.substr()` or `String.substring()` can be done with `String.slice()`.
+Prefer a convention of using [`String#slice`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/slice) instead of [`String#substr`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/substr) or [`String#substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring). `String#slice()` has clearer behavior and has a counterpart with arrays. It is also better to be consistent. Anything that can be done with `String#substr()` or `String#substring()` can be done with `String#slice()`.
+
+Read more in [this Stack Overflow question](http://stackoverflow.com/questions/2243824/what-is-the-difference-between-string-slice-and-string-substring)
 
 ## Fail
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ module.exports = {
 				'unicorn/number-literal-case': 'error',
 				'unicorn/no-array-instanceof': 'error',
 				'unicorn/no-new-buffer': 'error',
-				'unicorn/no-hex-escape': 'error'
+				'unicorn/no-hex-escape': 'error',
+				'unicorn/prefer-string-slice': 'error'
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Configure it in `package.json`.
 - [no-array-instanceof](docs/rules/no-array-instanceof.md) - Require `Array.isArray()` instead of `instanceof Array`. *(fixable)*
 - [no-new-buffer](docs/rules/no-new-buffer.md) - Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`. *(fixable)*
 - [no-hex-escape](docs/rules/no-hex-escape.md) - Enforce the use of unicode escapes instead of hexadecimal escapes. *(fixable)*
+- [prefer-string-slice](docs/rules/prefer-string-slice) - Prefer the use of `String.slice` instead of `String.substr` or `String.substring`
 
 
 ## Recommended config

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,8 @@ Configure it in `package.json`.
 			"unicorn/number-literal-case": "error",
 			"unicorn/no-array-instanceof": "error",
 			"unicorn/no-new-buffer": "error",
-			"unicorn/no-hex-escape": "error"
+			"unicorn/no-hex-escape": "error",
+			"unicorn/prefer-string-slice": "error"
 		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Configure it in `package.json`.
 - [no-array-instanceof](docs/rules/no-array-instanceof.md) - Require `Array.isArray()` instead of `instanceof Array`. *(fixable)*
 - [no-new-buffer](docs/rules/no-new-buffer.md) - Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`. *(fixable)*
 - [no-hex-escape](docs/rules/no-hex-escape.md) - Enforce the use of unicode escapes instead of hexadecimal escapes. *(fixable)*
-- [prefer-string-slice](docs/rules/prefer-string-slice) - Prefer the use of `String.slice` instead of `String.substr` or `String.substring`
+- [prefer-string-slice](docs/rules/prefer-string-slice) - Prefer the use of `String#slice()` instead of `String#substr()` or `String#substring()`
 
 
 ## Recommended config

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -6,7 +6,7 @@ const create = context => {
 			if (['substr', 'substring'].indexOf(node.name) !== -1) {
 				context.report({
 					node,
-					message: `Use \`String.slice\` instead of \`String.${node.name}\`.`
+					message: `Use \`String#slice\` instead of \`String#${node.name}\`.`
 				});
 			}
 		}

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -3,12 +3,12 @@
 const create = context => {
 	return {
 		Identifier: node => {
-			const name = node.name;
-
-			if (name === 'substr' || name === 'substring') {
+			if (['substr', 'substring'].indexOf(node.name) > -1) {
+				const args = node.parent.parent.arguments;
+				console.dir(args[0].type);
 				context.report({
 					node,
-					message: `Use \`String.slice\` instead of \`String.${name}\`.`
+					message: `Use \`String.slice\` instead of \`String.${node.name}\`.`
 				});
 			}
 		}

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -3,9 +3,7 @@
 const create = context => {
 	return {
 		Identifier: node => {
-			if (['substr', 'substring'].indexOf(node.name) > -1) {
-				const args = node.parent.parent.arguments;
-				console.dir(args[0].type);
+			if (['substr', 'substring'].indexOf(node.name) !== -1) {
 				context.report({
 					node,
 					message: `Use \`String.slice\` instead of \`String.${node.name}\`.`

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -8,7 +8,7 @@ const create = context => {
 			if (name === 'substr' || name === 'substring') {
 				context.report({
 					node,
-					message: 'Use String.slice instead of String.substr or String.substring.'
+					message: `Use String.slice instead of String.${name}.`
 				});
 			}
 		}

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -8,7 +8,7 @@ const create = context => {
 			if (name === 'substr' || name === 'substring') {
 				context.report({
 					node,
-					message: `Use String.slice instead of String.${name}.`
+					message: `Use \`String.slice\` instead of \`String.${name}\`.`
 				});
 			}
 		}

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const create = context => {
+	return {
+		Identifier: node => {
+			const name = node.name;
+
+			if (name === 'substr' || name === 'substring') {
+				context.report({
+					node,
+					message: 'Use String.slice instead of String.substr or String.substring.'
+				});
+			}
+		}
+	};
+};
+
+module.exports = {
+	create
+};

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -16,7 +16,8 @@ const error = name => ({
 ruleTester.run('prefer-string-slice', rule, {
 	valid: [
 		'const foo = bar.slice(1)',
-		`const foo = bar.slice(function() { return 1; }, 2);`
+		`const foo = bar.slice(baz, 2);`,
+		`const foo = bar.slice(baz - 1, 2);`
 	],
 	invalid: [
 		{
@@ -28,7 +29,11 @@ ruleTester.run('prefer-string-slice', rule, {
 			errors: [error('substr')]
 		},
 		{
-			code: `const foo = bar.substr(function() { return 1; }, 2);`,
+			code: `const foo = bar.substr(baz, 2);`,
+			errors: [error('substr')]
+		},
+		{
+			code: `const foo = bar.substr(baz - 1, 2);`,
 			errors: [error('substr')]
 		},
 		{
@@ -40,7 +45,11 @@ ruleTester.run('prefer-string-slice', rule, {
 			errors: [error('substring')]
 		},
 		{
-			code: `const foo = bar.substring(function() { return 1; }, 2);`,
+			code: `const foo = bar.substring(baz, 2);`,
+			errors: [error('substring')]
+		},
+		{
+			code: `const foo = bar.substring(baz - 1, 2);`,
 			errors: [error('substring')]
 		}
 	]

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -10,7 +10,7 @@ const ruleTester = avaRuleTester(test, {
 
 const error = name => ({
 	ruleId: 'prefer-string-slice',
-	message: `Use \`String.slice\` instead of \`String.${name}\`.`
+	message: `Use \`String#slice\` instead of \`String#${name}\`.`
 });
 
 ruleTester.run('prefer-string-slice', rule, {

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -10,7 +10,7 @@ const ruleTester = avaRuleTester(test, {
 
 const error = name => ({
 	ruleId: 'prefer-string-slice',
-	message: `Use String.slice instead of String.${name}.`
+	message: `Use \`String.slice\` instead of \`String.${name}\`.`
 });
 
 ruleTester.run('prefer-string-slice', rule, {

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -8,10 +8,10 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-const error = {
+const error = name => ({
 	ruleId: 'prefer-string-slice',
-	message: 'Use String.slice instead of String.substr or String.substring.'
-};
+	message: `Use String.slice instead of String.${name}.`
+});
 
 ruleTester.run('prefer-string-slice', rule, {
 	valid: [
@@ -21,27 +21,27 @@ ruleTester.run('prefer-string-slice', rule, {
 	invalid: [
 		{
 			code: 'const foo = bar.substr(1)',
-			errors: [error]
+			errors: [error('substr')]
 		},
 		{
 			code: 'const foo = bar.substr(1,2)',
-			errors: [error]
+			errors: [error('substr')]
 		},
 		{
 			code: `const foo = bar.substr(function() { return 1; }, 2);`,
-			errors: [error]
+			errors: [error('substr')]
 		},
 		{
 			code: 'const foo = bar.substring(1)',
-			errors: [error]
+			errors: [error('substring')]
 		},
 		{
 			code: 'const foo = bar.substring(1,2)',
-			errors: [error]
+			errors: [error('substring')]
 		},
 		{
-			code: `const foo = bar.substr(function() { return 1; }, 2);`,
-			errors: [error]
+			code: `const foo = bar.substring(function() { return 1; }, 2);`,
+			errors: [error('substring')]
 		}
 	]
 });

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -1,0 +1,47 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-string-slice';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const error = {
+	ruleId: 'prefer-string-slice',
+	message: 'Use String.slice instead of String.substr or String.substring.'
+};
+
+ruleTester.run('prefer-string-slice', rule, {
+	valid: [
+		'const foo = bar.slice(1)',
+		`const foo = bar.slice(function() { return 1; }, 2);`
+	],
+	invalid: [
+		{
+			code: 'const foo = bar.substr(1)',
+			errors: [error]
+		},
+		{
+			code: 'const foo = bar.substr(1,2)',
+			errors: [error]
+		},
+		{
+			code: `const foo = bar.substr(function() { return 1; }, 2);`,
+			errors: [error]
+		},
+		{
+			code: 'const foo = bar.substring(1)',
+			errors: [error]
+		},
+		{
+			code: 'const foo = bar.substring(1,2)',
+			errors: [error]
+		},
+		{
+			code: `const foo = bar.substr(function() { return 1; }, 2);`,
+			errors: [error]
+		}
+	]
+});


### PR DESCRIPTION
Prefer `String.slice` instead of `String.substr` or `String.substring`.
- [x] Documentation
- [ ] Process feedback
- [ ] Add fixer
