### PR TITLE
Make `no-hex-escape` more concise

### DIFF
--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -1,25 +1,21 @@
 'use strict';
 
-function checkEscape(context, node, value) {
-	const fixedValue = typeof value === 'string' ? value.replace(/\\x/g, '\\u00') : value;
-
-	if (value !== fixedValue) {
-		context.report({
-			node,
-			message: 'Use unicode escapes instead of hexadecimal escapes.',
-			fix: fixer => fixer.replaceTextRange([node.start, node.end], fixedValue)
-		});
-	}
-}
-
 const create = context => {
-	return {
-		Literal: node => {
-			checkEscape(context, node, node.raw);
-		},
-		TemplateElement: node => {
-			checkEscape(context, node, node.value.raw);
+	const checkEscape = (node, value) => {
+		const fixedValue = typeof value === 'string' ? value.replace(/\\x/g, '\\u00') : value;
+
+		if (value !== fixedValue) {
+			context.report({
+				node,
+				message: 'Use unicode escapes instead of hexadecimal escapes.',
+				fix: fixer => fixer.replaceTextRange([node.start, node.end], fixedValue)
+			});
 		}
+	};
+
+	return {
+		Literal: node => checkEscape(node, node.raw),
+		TemplateElement: node => checkEscape(node, node.value.raw)
 	};
 };
 


### PR DESCRIPTION
Was tinkering with #67 and realised I could clean up a few things in `no-hex-escape`. 
