### PR TITLE
Add support for custom errors in the `throw-new-error` rule

### DIFF
--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -9,14 +9,14 @@ const errorTypes = [
 	'TypeError',
 	'URIError'
 ];
-const customerError = /^(?:[A-Z][a-z0-9]*)*Error$/;
+const customeError = /^(?:[A-Z][a-z0-9]*)*Error$/;
 
 const create = context => ({
 	ThrowStatement: node => {
 		const arg = node.argument;
 		const error = arg.callee;
 
-		if (arg.type === 'CallExpression' && (errorTypes.indexOf(error.name) !== -1 || customerError.test(error.name))) {
+		if (arg.type === 'CallExpression' && customeError.test(error.name)) {
 			context.report({
 				node,
 				message: 'Use `new` when throwing an error.',

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -1,14 +1,5 @@
 'use strict';
 
-const errorTypes = [
-	'Error',
-	'EvalError',
-	'RangeError',
-	'ReferenceError',
-	'SyntaxError',
-	'TypeError',
-	'URIError'
-];
 const customeError = /^(?:[A-Z][a-z0-9]*)*Error$/;
 
 const create = context => ({

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const customeError = /^(?:[A-Z][a-z0-9]*)*Error$/;
+const customError = /^(?:[A-Z][a-z0-9]*)*Error$/;
 
 const create = context => ({
 	ThrowStatement: node => {
 		const arg = node.argument;
 		const error = arg.callee;
 
-		if (arg.type === 'CallExpression' && customeError.test(error.name)) {
+		if (arg.type === 'CallExpression' && customError.test(error.name)) {
 			context.report({
 				node,
 				message: 'Use `new` when throwing an error.',

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -9,13 +9,14 @@ const errorTypes = [
 	'TypeError',
 	'URIError'
 ];
+const customerError = /^(?:[A-Z][a-z0-9]*)*Error$/;
 
 const create = context => ({
 	ThrowStatement: node => {
 		const arg = node.argument;
 		const error = arg.callee;
 
-		if (arg.type === 'CallExpression' && errorTypes.indexOf(error.name) !== -1) {
+		if (arg.type === 'CallExpression' && (errorTypes.indexOf(error.name) !== -1 || customerError.test(error.name))) {
 			context.report({
 				node,
 				message: 'Use `new` when throwing an error.',

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -14,7 +14,8 @@ ruleTester.run('new-error', rule, {
 	valid: [
 		'throw new Error()',
 		'new Error()',
-		'throw new TypeError()'
+		'throw new TypeError()',
+		'throw new CustomeError()'
 	],
 	invalid: [
 		{
@@ -25,6 +26,11 @@ ruleTester.run('new-error', rule, {
 		{
 			code: `throw Error('foo')`,
 			output: `throw new Error('foo')`,
+			errors
+		},
+		{
+			code: `throw CustomeError('foo')`,
+			output: `throw new CustomeError('foo')`,
 			errors
 		},
 		{

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -41,11 +41,6 @@ ruleTester.run('new-error', rule, {
 			errors
 		},
 		{
-			code: `throw fooBarBazError('foo')`,
-			output: `throw new fooBarBazError('foo')`,
-			errors
-		},
-		{
 			code: `throw ABCError('foo')`,
 			output: `throw new ABCError('foo')`,
 			errors

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -20,7 +20,7 @@ ruleTester.run('new-error', rule, {
 		'throw new ReferenceError()',
 		'throw new SyntaxError()',
 		'throw new URIError()',
-		'throw new CustomeError()',
+		'throw new CustomError()',
 		'throw new FooBarBazError()',
 		'throw new ABCError()'
 	],
@@ -36,8 +36,8 @@ ruleTester.run('new-error', rule, {
 			errors
 		},
 		{
-			code: `throw CustomeError('foo')`,
-			output: `throw new CustomeError('foo')`,
+			code: `throw CustomError('foo')`,
+			output: `throw new CustomError('foo')`,
 			errors
 		},
 		{

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -15,6 +15,11 @@ ruleTester.run('new-error', rule, {
 		'throw new Error()',
 		'new Error()',
 		'throw new TypeError()',
+		'throw new EvalError()',
+		'throw new RangeError()',
+		'throw new ReferenceError()',
+		'throw new SyntaxError()',
+		'throw new URIError()',
 		'throw new CustomeError()',
 		'throw new FooBarBazError()',
 		'throw new ABCError()'
@@ -53,6 +58,31 @@ ruleTester.run('new-error', rule, {
 		{
 			code: `throw TypeError()`,
 			output: 'throw new TypeError()',
+			errors
+		},
+		{
+			code: `throw EvalError()`,
+			output: 'throw new EvalError()',
+			errors
+		},
+		{
+			code: `throw RangeError()`,
+			output: 'throw new RangeError()',
+			errors
+		},
+		{
+			code: `throw ReferenceError()`,
+			output: 'throw new ReferenceError()',
+			errors
+		},
+		{
+			code: `throw SyntaxError()`,
+			output: 'throw new SyntaxError()',
+			errors
+		},
+		{
+			code: `throw URIError()`,
+			output: 'throw new URIError()',
 			errors
 		}
 	]

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -30,7 +30,7 @@ ruleTester.run('new-error', rule, {
 		},
 		{
 			code: `throw CustomerError('foo')`,
-			output: `throw new CustomeError('foo')`,
+			output: `throw new CustomerError('foo')`,
 			errors
 		},
 		{

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -15,7 +15,7 @@ ruleTester.run('new-error', rule, {
 		'throw new Error()',
 		'new Error()',
 		'throw new TypeError()',
-		'throw new CustomeError()'
+		'throw new CustomerError()'
 	],
 	invalid: [
 		{
@@ -29,7 +29,7 @@ ruleTester.run('new-error', rule, {
 			errors
 		},
 		{
-			code: `throw CustomeError('foo')`,
+			code: `throw CustomerError('foo')`,
 			output: `throw new CustomeError('foo')`,
 			errors
 		},

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -15,7 +15,9 @@ ruleTester.run('new-error', rule, {
 		'throw new Error()',
 		'new Error()',
 		'throw new TypeError()',
-		'throw new CustomerError()'
+		'throw new CustomeError()',
+		'throw new FooBarBazError()',
+		'throw new ABCError()'
 	],
 	invalid: [
 		{
@@ -29,8 +31,28 @@ ruleTester.run('new-error', rule, {
 			errors
 		},
 		{
-			code: `throw CustomerError('foo')`,
-			output: `throw new CustomerError('foo')`,
+			code: `throw CustomeError('foo')`,
+			output: `throw new CustomeError('foo')`,
+			errors
+		},
+		{
+			code: `throw FooBarBazError('foo')`,
+			output: `throw new FooBarBazError('foo')`,
+			errors
+		},
+		{
+			code: `throw fooBarBazError('foo')`,
+			output: `throw new fooBarBazError('foo')`,
+			errors
+		},
+		{
+			code: `throw ABCError('foo')`,
+			output: `throw new ABCError('foo')`,
+			errors
+		},
+		{
+			code: `throw Abc3Error('foo')`,
+			output: `throw new Abc3Error('foo')`,
 			errors
 		},
 		{


### PR DESCRIPTION
added customer error by using /^(?:[A-Z][a-z0-9]*)*Error$/

fixes #4