### PR TITLE
Add non-zero length style option to `explicit-length-check` rule

### DIFF
--- a/docs/rules/explicit-length-check.md
+++ b/docs/rules/explicit-length-check.md
@@ -39,17 +39,17 @@ if (array.length !== 0) {}
 ## Non-Zero Comparisons
 
 You can define your preferred way of checking non-zero length by providing a `non-zero` option:
-```json
+```js
 {
-  "unicorn/explicit-length-check": ["error", {
-    "non-zero": "not-equal"
+  'unicorn/explicit-length-check': ['error', {
+    'non-zero': 'not-equal'
   }]
 }
 ```
-where `"non-zero"` can be configured with one of the following:
-- `"not-equal"`
+where `non-zero` can be configured with one of the following:
+- `not-equal`
 	- this option makes sure that non-zero is checked with: `array.length !== 0`
-- `"greater-than"`
+- `greater-than`
 	- this option makes sure that non-zero is checked with: `array.length > 0`
-- `"greater-than-or-equal"`
+- `greater-than-or-equal`
 	- this option makes sure that non-zero is checked with: `array.length >= 1`

--- a/docs/rules/explicit-length-check.md
+++ b/docs/rules/explicit-length-check.md
@@ -2,7 +2,7 @@
 
 Enforce explicitly checking the length of a value array in an `if` condition, rather than checking the truthiness of the length.
 
-## Fail
+### Fail
 
 ```js
 if (string.length) {}
@@ -11,7 +11,7 @@ if (!array.length) {}
 ```
 
 
-## Pass
+### Pass
 
 ```js
 if (string.length > 0) {}
@@ -20,28 +20,37 @@ if (array.length !== 0) {}
 if (array.length === 0) {}
 ```
 
-## Options
+## Empty Comparisons
 
-You can set options for `empty` and `not-empty` comparisons like this:
+Enforce length comparison with `!== 0` when checking for an empty array.
 
-```json
-"unicorn/explicit-length-check": ["error", {
-  "empty": "emptyOption",
-  "not-empty": "notEmptyOption"
-}]
+### Fail
+
+```js
+if (string.length < 1) {}
 ```
 
-where:
-- `"emptyOption"` can be one of the following:
-	- `"eq"` (equal)
-		- this option makes sure that empty is checked with: `a.length === 0 `
-	- `"lt"` (less-than)
-		- this option makes sure that empty is checked with: `a.length < 1`
+### Pass
 
-- `"notEmptyOption"` can be one of the following:
-	- `"ne"` (not-equal)
-		- this option makes sure that empty is checked with: `a.length !== 0`
-	- `"gt"` (greater-than)
-		- this option makes sure that empty is checked with: `a.length > 0`
-	- `"gte"` (greater-than or equal-to)
-		- this option makes sure that empty is checked with: `a.length >= 1`
+```js
+if (array.length !== 0) {}
+```
+
+## Non Zero Comparisons
+
+You can define your preferred way of checking non zero length by providing an option:
+```js
+{
+  "unicorn/explicit-length-check": ["error", {
+    "not-empty": "notEmptyOption"
+  }]
+}
+```
+where `"notEmptyOption"` can be one of the following:
+- `"ne"` (not-equal)
+	- this option makes sure that non zero is checked with: `array.length !== 0`
+- `"gt"` (greater-than)
+	- this option makes sure that non zero is checked with: `array.length > 0`
+- `"gte"` (greater-than or equal-to)
+	- this option makes sure that non zero is checked with: `array.length >= 1`
+

--- a/docs/rules/explicit-length-check.md
+++ b/docs/rules/explicit-length-check.md
@@ -19,3 +19,29 @@ if (array.length > 0) {}
 if (array.length !== 0) {}
 if (array.length === 0) {}
 ```
+
+## Options
+
+You can set options for `empty` and `not-empty` comparisons like this:
+
+```json
+"unicorn/explicit-length-check": ["error", {
+  "empty": "emptyOption",
+  "not-empty": "notEmptyOption"
+}]
+```
+
+where:
+- `"emptyOption"` can be one of the following:
+	- `"eq"` (equal)
+		- this option makes sure that empty is checked with: `a.length === 0 `
+	- `"lt"` (less-than)
+		- this option makes sure that empty is checked with: `a.length < 1`
+
+- `"notEmptyOption"` can be one of the following:
+	- `"ne"` (not-equal)
+		- this option makes sure that empty is checked with: `a.length !== 0`
+	- `"gt"` (greater-than)
+		- this option makes sure that empty is checked with: `a.length > 0`
+	- `"gte"` (greater-than or equal-to)
+		- this option makes sure that empty is checked with: `a.length >= 1`

--- a/docs/rules/explicit-length-check.md
+++ b/docs/rules/explicit-length-check.md
@@ -20,9 +20,9 @@ if (array.length !== 0) {}
 if (array.length === 0) {}
 ```
 
-## Empty Comparisons
+## Zero Comparisons
 
-Enforce length comparison with `!== 0` when checking for an empty array.
+Enforce comparison with `!== 0` when checking for zero length.
 
 ### Fail
 
@@ -36,21 +36,20 @@ if (string.length < 1) {}
 if (array.length !== 0) {}
 ```
 
-## Non Zero Comparisons
+## Non-Zero Comparisons
 
-You can define your preferred way of checking non zero length by providing an option:
-```js
+You can define your preferred way of checking non-zero length by providing a `non-zero` option:
+```json
 {
   "unicorn/explicit-length-check": ["error", {
-    "not-empty": "notEmptyOption"
+    "non-zero": "not-equal"
   }]
 }
 ```
-where `"notEmptyOption"` can be one of the following:
-- `"ne"` (not-equal)
-	- this option makes sure that non zero is checked with: `array.length !== 0`
-- `"gt"` (greater-than)
-	- this option makes sure that non zero is checked with: `array.length > 0`
-- `"gte"` (greater-than or equal-to)
-	- this option makes sure that non zero is checked with: `array.length >= 1`
-
+where `"non-zero"` can be configured with one of the following:
+- `"not-equal"`
+	- this option makes sure that non-zero is checked with: `array.length !== 0`
+- `"greater-than"`
+	- this option makes sure that non-zero is checked with: `array.length > 0`
+- `"greater-than-or-equal"`
+	- this option makes sure that non-zero is checked with: `array.length >= 1`

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -1,6 +1,62 @@
 'use strict';
 
+const types = {
+	eq: ['===', '=='],
+	lt: ['<']
+};
+
+function checkComparisionType(type, operator, value) {
+	switch (type) {
+		case 'eq':
+			if (types.lt.includes(operator) && value === 1) {
+				return 'empty `length` should be compared with `=== 0`';
+			}
+			break;
+		case 'lt':
+			if (types.eq.includes(operator) && value === 0) {
+				return 'empty `length` should be compared with `< 1`';
+			}
+			break;
+		default:
+			break;
+	}
+}
+
+function checkBinaryExpression(context, node, empty) {
+	let arrayNode;
+	let valueNode;
+
+	if (node.left.type === 'Literal' && node.right.type === 'MemberExpression') {
+		context.report({
+			node,
+			message: '`length` property should be first argument of comparision'
+		});
+		return;
+	}
+
+	if (node.left.type === 'MemberExpression' && node.right.type === 'Literal') {
+		arrayNode = node.left;
+		valueNode = node.right;
+	}
+
+	if (arrayNode &&
+		valueNode &&
+		arrayNode.property.type === 'Identifier' &&
+		arrayNode.property.name === 'length'
+	) {
+		const compTypeRes = checkComparisionType(empty, node.operator, valueNode.value);
+		if (typeof compTypeRes === 'string') {
+			context.report({
+				node,
+				message: compTypeRes
+			});
+		}
+	}
+}
+
 function checkExpression(context, node) {
+	const {empty} = context.options[0] || {};
+
 	if (node.type === 'LogicalExpression') {
 		checkExpression(context, node.left);
 		checkExpression(context, node.right);
@@ -10,6 +66,10 @@ function checkExpression(context, node) {
 	if (node.type === 'UnaryExpression' && node.operator === '!') {
 		checkExpression(context, node.argument);
 		return;
+	}
+
+	if (node.type === 'BinaryExpression') {
+		checkBinaryExpression(context, node, empty);
 	}
 
 	if (node.type === 'MemberExpression' &&

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -21,12 +21,12 @@ function checkEmptyType(type, operator, value) {
 	switch (type) {
 		case 'eq':
 			if (types.lt.includes(operator) && value === 1) {
-				return 'empty `length` should be compared with `=== 0`';
+				return 'empty `length` should be compared with `=== 0`.';
 			}
 			break;
 		case 'lt':
 			if (types.eq.includes(operator) && value === 0) {
-				return 'empty `length` should be compared with `< 1`';
+				return 'empty `length` should be compared with `< 1`.';
 			}
 			break;
 		default:
@@ -40,21 +40,21 @@ function checkNotEmptyType(type, operator, value) {
 			if ((types.gte.includes(operator) && value === 1) ||
 				(types.ne.includes(operator) && value === 0)
 			) {
-				return 'not empty `length` should be compared with `> 0`';
+				return 'not empty `length` should be compared with `> 0`.';
 			}
 			break;
 		case 'gte':
 			if ((types.gt.includes(operator) && value === 0) ||
 				(types.ne.includes(operator) && value === 0)
 			) {
-				return 'not empty `length` should be compared with `>= 1`';
+				return 'not empty `length` should be compared with `>= 1`.';
 			}
 			break;
 		case 'ne':
 			if ((types.gt.includes(operator) && value === 0) ||
 				(types.gte.includes(operator) && value === 1)
 			) {
-				return 'not empty `length` should be compared with `!== 1`';
+				return 'not empty `length` should be compared with `!== 1`.';
 			}
 			break;
 		default:
@@ -68,7 +68,7 @@ function checkBinaryExpression(context, node, options = {}) {
 		node.right.property.type === 'Identifier' &&
 		node.right.property.name === 'length'
 	) {
-		reportError(context, node, '`length` property should be first argument of comparision');
+		reportError(context, node, '`length` property should be first argument of comparision.');
 		return;
 	}
 

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -20,12 +20,12 @@ function reportError(context, node, message) {
 function checkEmptyType(type, operator, value) {
 	switch (type) {
 		case 'eq':
-			if (types.lt.includes(operator) && value === 1) {
+			if (types.lt.indexOf(operator) >= 0 && value === 1) {
 				return 'empty `length` should be compared with `=== 0`.';
 			}
 			break;
 		case 'lt':
-			if (types.eq.includes(operator) && value === 0) {
+			if (types.eq.indexOf(operator) >= 0 && value === 0) {
 				return 'empty `length` should be compared with `< 1`.';
 			}
 			break;
@@ -37,22 +37,22 @@ function checkEmptyType(type, operator, value) {
 function checkNotEmptyType(type, operator, value) {
 	switch (type) {
 		case 'gt':
-			if ((types.gte.includes(operator) && value === 1) ||
-				(types.ne.includes(operator) && value === 0)
+			if ((types.gte.indexOf(operator) >= 0 && value === 1) ||
+				(types.ne.indexOf(operator) >= 0 && value === 0)
 			) {
 				return 'not empty `length` should be compared with `> 0`.';
 			}
 			break;
 		case 'gte':
-			if ((types.gt.includes(operator) && value === 0) ||
-				(types.ne.includes(operator) && value === 0)
+			if ((types.gt.indexOf(operator) >= 0 && value === 0) ||
+				(types.ne.indexOf(operator) >= 0 && value === 0)
 			) {
 				return 'not empty `length` should be compared with `>= 1`.';
 			}
 			break;
 		case 'ne':
-			if ((types.gt.includes(operator) && value === 0) ||
-				(types.gte.includes(operator) && value === 1)
+			if ((types.gt.indexOf(operator) >= 0 && value === 0) ||
+				(types.gte.indexOf(operator) >= 0 && value === 1)
 			) {
 				return 'not empty `length` should be compared with `!== 1`.';
 			}
@@ -62,7 +62,7 @@ function checkNotEmptyType(type, operator, value) {
 	}
 }
 
-function checkBinaryExpression(context, node, options = {}) {
+function checkBinaryExpression(context, node, options) {
 	if (node.left.type === 'Literal' &&
 		node.right.type === 'MemberExpression' &&
 		node.right.property.type === 'Identifier' &&
@@ -101,7 +101,7 @@ function checkExpression(context, node) {
 	}
 
 	if (node.type === 'BinaryExpression') {
-		checkBinaryExpression(context, node, context.options[0]);
+		checkBinaryExpression(context, node, context.options[0] || {});
 		return;
 	}
 

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -25,14 +25,14 @@ const errorMessages = {
 	notEmptyGreaterEqual: error('not empty `length` should be compared with `>= 1`.')
 };
 
-function testCase(code, emptyType, notEmptyType, errors = []) {
+function testCase(code, emptyType, notEmptyType, errors) {
 	return {
 		code,
 		options: (emptyType || notEmptyType) && [{
 			empty: emptyType,
 			'not-empty': notEmptyType
 		}],
-		errors
+		errors: errors || []
 	};
 }
 

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -8,58 +8,97 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-const errors = [{
-	ruleId: 'explicit-length-check',
-	message: '`length` property should be compared to a value.'
-}];
+const errorMessages = {
+	lengthFirst: '`length` property should be first argument of comparision',
+	compareToValue: '`length` property should be compared to a value.',
+	emptyEqual: 'empty `length` should be compared with `=== 0`',
+	emptyLess: 'empty `length` should be compared with `< 1`'
+};
+
+function testCase(code, emptyType, error) {
+	return {
+		code,
+		options: [{empty: emptyType}],
+		errors: [{
+			ruleId: 'explicit-length-check',
+			message: error
+		}]
+	};
+}
 
 ruleTester.run('explicit-length-check', rule, {
 	valid: [
-		'array.foo',
-		'array.length',
-		'array.length === 0',
-		'array.length !== 0',
-		'array.length > 0',
-		'if (array.foo) {}',
-		'if (length) {}',
-		'if ([].length > 0) {}',
-		'if ("".length > 0) {}',
-		'if (array.length === 0) {}',
-		'if (array.length !== 0) {}',
-		'if (array.length !== 0 && array[0] === 1) {}'
+		testCase('array.foo'),
+		testCase('array.length'),
+		testCase('array.length === 0'),
+		testCase('array.length !== 0'),
+		testCase('array.length > 0'),
+		testCase('if (array.foo) {}'),
+		testCase('if (length) {}'),
+		testCase('if ([].length > 0) {}'),
+		testCase('if ("".length > 0) {}'),
+		testCase('if (array.length === 0) {}'),
+		testCase('if (array.length !== 0) {}'),
+		testCase('if (array.length !== 0 && array[0] === 1) {}'),
+		testCase('if (array.length == 0) {}', 'eq'),
+		testCase('if (array.length === 0) {}', 'eq'),
+		testCase('if (array.length === 1) {}', 'eq'),
+		testCase('if (array.length <= 1) {}', 'eq'),
+		testCase('if (array.length > 1) {}', 'eq'),
+		testCase('if ([].length < 1) {}', 'lt')
 	],
 	invalid: [
-		{
-			code: 'if ([].length) {}',
-			errors
-		},
-		{
-			code: 'if ("".length) {}',
-			errors
-		},
-		{
-			code: 'if (array.length) {}',
-			errors
-		},
-		{
-			code: 'if (!array.length) {}',
-			errors
-		},
-		{
-			code: 'if (array.foo.length) {}',
-			errors
-		},
-		{
-			code: 'if (!!array.length) {}',
-			errors
-		},
-		{
-			code: 'if (array.length && array[0] === 1) {}',
-			errors
-		},
-		{
-			code: 'if (array[0] === 1 || array.length) {}',
-			errors
-		}
+		testCase('if ([].length) {}',
+			undefined,
+			errorMessages.compareToValue
+		),
+		testCase('if ("".length) {}',
+			undefined,
+			errorMessages.compareToValue
+		),
+		testCase('if (array.length) {}',
+			undefined,
+			errorMessages.compareToValue
+		),
+		testCase('if (!array.length) {}',
+			undefined,
+			errorMessages.compareToValue
+		),
+		testCase('if (array.foo.length) {}',
+			undefined,
+			errorMessages.compareToValue
+		),
+		testCase('if (!!array.length) {}',
+			undefined,
+			errorMessages.compareToValue
+		),
+		testCase('if (array.length && array[0] === 1) {}',
+			undefined,
+			errorMessages.compareToValue
+		),
+		testCase('if (array[0] === 1 || array.length) {}',
+			undefined,
+			errorMessages.compareToValue
+		),
+		testCase('if (1 === array.length) {}',
+			undefined,
+			errorMessages.lengthFirst
+		),
+		testCase('if ([].length === 0 || 0 < array.length) {}',
+			undefined,
+			errorMessages.lengthFirst
+		),
+		testCase('if (array.length < 1) {}',
+			'eq',
+			errorMessages.emptyEqual
+		),
+		testCase('if (array.length === 0) {}',
+			'lt',
+			errorMessages.emptyLess
+		),
+		testCase('if (array.length == 0) {}',
+			'lt',
+			errorMessages.emptyLess
+		)
 	]
 });

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -17,19 +17,19 @@ const error = message => {
 
 const errorMessages = {
 	compareToValue: error('`length` property should be compared to a value.'),
-	emptyEqual: error('Empty `.length` should be compared with `=== 0`.'),
-	notEmptyEqual: error('Non-zero `.length` should be compared with `!== 0`.'),
-	notEmptyGreater: error('Non-zero `.length` should be compared with `> 0`.'),
-	notEmptyGreaterEqual: error('Non-zero `.length` should be compared with `>= 1`.')
+	zeroEqual: error('Zero `.length` should be compared with `=== 0`.'),
+	nonZeroEqual: error('Non-zero `.length` should be compared with `!== 0`.'),
+	nonZeroGreater: error('Non-zero `.length` should be compared with `> 0`.'),
+	nonZeroGreaterEqual: error('Non-zero `.length` should be compared with `>= 1`.')
 };
 
-function testCase(code, notEmptyType, errors, output) {
+function testCase(code, nonZeroType, errors, output) {
 	return {
 		code,
 		output: output || code,
 		errors: errors || [],
-		options: notEmptyType && [{
-			'not-empty': notEmptyType
+		options: nonZeroType && [{
+			'non-zero': nonZeroType
 		}]
 	};
 }
@@ -53,28 +53,28 @@ ruleTester.run('explicit-length-check', rule, {
 		testCase('if (array.length <= 1) {}'),
 		testCase('if (array.length > 1) {}'),
 		testCase('if (array.length < 2) {}'),
-		testCase('array.length', 'ne'),
-		testCase('array.length > 0', 'ne'),
-		testCase('array.length >= 1', 'ne'),
-		testCase('if ("".length !== 0) {}', 'ne'),
-		testCase('if ([].length === 0) {}', 'ne'),
-		testCase('if ([].length === 1) {}', 'ne'),
-		testCase('if ([].length <= 1) {}', 'ne'),
-		testCase('if ("".length == 0) {}', 'ne'),
-		testCase('array.length !== 0', 'gt'),
-		testCase('array.length >= 1', 'gt'),
-		testCase('if ("".length > 0) {}', 'gt'),
-		testCase('if ("".length >= 0) {}', 'gt'),
-		testCase('if ("".length >= 2) {}', 'gt'),
-		testCase('if ("".length >= 1) {}', 'gte'),
-		testCase('array.length !== 0', 'gte'),
-		testCase('array.length > 0', 'gte'),
-		testCase('if ("".length === 0) {}', 'gte'),
-		testCase('if ("".length > 2) {}', 'gte'),
-		testCase('if ("".length === 2) {}', 'gte'),
-		testCase('if ("".length === 0 && array.length >= 1) {}', 'gte'),
-		testCase('if ("".length === 0 && array.length > 0) {}', 'gt'),
-		testCase('if ("".length === 0 && array.length !== 0) {}', 'ne')
+		testCase('array.length', 'not-equal'),
+		testCase('array.length > 0', 'not-equal'),
+		testCase('array.length >= 1', 'not-equal'),
+		testCase('if ("".length !== 0) {}', 'not-equal'),
+		testCase('if ([].length === 0) {}', 'not-equal'),
+		testCase('if ([].length === 1) {}', 'not-equal'),
+		testCase('if ([].length <= 1) {}', 'not-equal'),
+		testCase('if ("".length == 0) {}', 'not-equal'),
+		testCase('array.length !== 0', 'greater-than'),
+		testCase('array.length >= 1', 'greater-than'),
+		testCase('if ("".length > 0) {}', 'greater-than'),
+		testCase('if ("".length >= 0) {}', 'greater-than'),
+		testCase('if ("".length >= 2) {}', 'greater-than'),
+		testCase('if ("".length >= 1) {}', 'greater-than-or-equal'),
+		testCase('array.length !== 0', 'greater-than-or-equal'),
+		testCase('array.length > 0', 'greater-than-or-equal'),
+		testCase('if ("".length === 0) {}', 'greater-than-or-equal'),
+		testCase('if ("".length > 2) {}', 'greater-than-or-equal'),
+		testCase('if ("".length === 2) {}', 'greater-than-or-equal'),
+		testCase('if ("".length === 0 && array.length >= 1) {}', 'greater-than-or-equal'),
+		testCase('if ("".length === 0 && array.length > 0) {}', 'greater-than'),
+		testCase('if ("".length === 0 && array.length !== 0) {}', 'not-equal')
 	],
 	invalid: [
 		testCase('if ([].length) {}',
@@ -110,58 +110,58 @@ ruleTester.run('explicit-length-check', rule, {
 			[errorMessages.compareToValue]
 		),
 		testCase('if (array.length < 1) {}',
-			'eq',
-			[errorMessages.emptyEqual],
+			undefined,
+			[errorMessages.zeroEqual],
 			'if (array.length === 0) {}'
 		),
 		testCase('if (array.length<1) {}',
-			'eq',
-			[errorMessages.emptyEqual],
+			undefined,
+			[errorMessages.zeroEqual],
 			'if (array.length === 0) {}'
 		),
 		testCase('if (array.length > 0) {}',
-			'ne',
-			[errorMessages.notEmptyEqual],
+			'not-equal',
+			[errorMessages.nonZeroEqual],
 			'if (array.length !== 0) {}'
 		),
 		testCase('if (array.length >= 1) {}',
-			'ne',
-			[errorMessages.notEmptyEqual],
+			'not-equal',
+			[errorMessages.nonZeroEqual],
 			'if (array.length !== 0) {}'
 		),
 		testCase('if (array.length != 0) {}',
-			'gt',
-			[errorMessages.notEmptyGreater],
+			'greater-than',
+			[errorMessages.nonZeroGreater],
 			'if (array.length > 0) {}'
 		),
 		testCase('if (array.length !== 0) {}',
-			'gt',
-			[errorMessages.notEmptyGreater],
+			'greater-than',
+			[errorMessages.nonZeroGreater],
 			'if (array.length > 0) {}'
 		),
 		testCase('if (array.length >= 1) {}',
-			'gt',
-			[errorMessages.notEmptyGreater],
+			'greater-than',
+			[errorMessages.nonZeroGreater],
 			'if (array.length > 0) {}'
 		),
 		testCase('if (array.length != 0) {}',
-			'gte',
-			[errorMessages.notEmptyGreaterEqual],
+			'greater-than-or-equal',
+			[errorMessages.nonZeroGreaterEqual],
 			'if (array.length >= 1) {}'
 		),
 		testCase('if (array.length !== 0) {}',
-			'gte',
-			[errorMessages.notEmptyGreaterEqual],
+			'greater-than-or-equal',
+			[errorMessages.nonZeroGreaterEqual],
 			'if (array.length >= 1) {}'
 		),
 		testCase('if (array.length > 0) {}',
-			'gte',
-			[errorMessages.notEmptyGreaterEqual],
+			'greater-than-or-equal',
+			[errorMessages.nonZeroGreaterEqual],
 			'if (array.length >= 1) {}'
 		),
 		testCase('if (array.length < 1 || array.length >= 1) {}',
-			'ne',
-			[errorMessages.emptyEqual, errorMessages.notEmptyEqual],
+			'not-equal',
+			[errorMessages.zeroEqual, errorMessages.nonZeroEqual],
 			'if (array.length === 0 || array.length !== 0) {}'
 		)
 	]

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -16,23 +16,21 @@ const error = message => {
 };
 
 const errorMessages = {
-	lengthFirst: error('`length` property should be first argument of comparision.'),
 	compareToValue: error('`length` property should be compared to a value.'),
-	emptyEqual: error('empty `length` should be compared with `=== 0`.'),
-	emptyLess: error('empty `length` should be compared with `< 1`.'),
-	notEmptyEqual: error('not empty `length` should be compared with `!== 1`.'),
-	notEmptyGreater: error('not empty `length` should be compared with `> 0`.'),
-	notEmptyGreaterEqual: error('not empty `length` should be compared with `>= 1`.')
+	emptyEqual: error('Empty `.length` should be compared with `=== 0`.'),
+	notEmptyEqual: error('Non-zero `.length` should be compared with `!== 0`.'),
+	notEmptyGreater: error('Non-zero `.length` should be compared with `> 0`.'),
+	notEmptyGreaterEqual: error('Non-zero `.length` should be compared with `>= 1`.')
 };
 
-function testCase(code, emptyType, notEmptyType, errors) {
+function testCase(code, notEmptyType, errors, output) {
 	return {
 		code,
-		options: (emptyType || notEmptyType) && [{
-			empty: emptyType,
+		output: output || code,
+		errors: errors || [],
+		options: notEmptyType && [{
 			'not-empty': notEmptyType
-		}],
-		errors: errors || []
+		}]
 	};
 }
 
@@ -48,158 +46,123 @@ ruleTester.run('explicit-length-check', rule, {
 		testCase('if ([].length > 0) {}'),
 		testCase('if ("".length > 0) {}'),
 		testCase('if (array.length === 0) {}'),
+		testCase('if (array.length == 0) {}'),
 		testCase('if (array.length !== 0) {}'),
 		testCase('if (array.length !== 0 && array[0] === 1) {}'),
-		testCase('if (array.length == 0) {}', 'eq'),
-		testCase('if (array.length === 0) {}', 'eq'),
-		testCase('if (array.length === 1) {}', 'eq'),
-		testCase('if (array.length <= 1) {}', 'eq'),
-		testCase('if (array.length > 1) {}', 'eq'),
-		testCase('if (array.length < 2) {}', 'eq'),
-		testCase('if ([].length < 1) {}', 'lt'),
-		testCase('if ([].length === 1) {}', 'lt'),
-		testCase('if (array.length === 0) {}', ['eq', 'lt']),
-		testCase('if (array.length < 1) {}', ['eq', 'lt']),
-		testCase('if (array.length <= 1) {}', ['eq', 'lt']),
-		testCase('if ("".length !== 0) {}', undefined, 'ne'),
-		testCase('if ([].length === 0) {}', undefined, 'ne'),
-		testCase('if ([].length === 1) {}', undefined, 'ne'),
-		testCase('if ([].length <= 1) {}', undefined, 'ne'),
-		testCase('if ("".length == 0) {}', undefined, 'ne'),
-		testCase('if ("".length > 0) {}', undefined, 'gt'),
-		testCase('if ("".length >= 0) {}', undefined, 'gt'),
-		testCase('if ("".length >= 2) {}', undefined, 'gt'),
-		testCase('if ("".length >= 1) {}', undefined, 'gte'),
-		testCase('if ("".length === 0) {}', undefined, 'gte'),
-		testCase('if ("".length > 2) {}', undefined, 'gte'),
-		testCase('if ("".length === 2) {}', undefined, 'gte'),
-		testCase('if ("".length === 0 && array.length >= 1) {}', 'eq', 'gte'),
-		testCase('if ("".length === 0 && array.length > 0) {}', 'eq', 'gt'),
-		testCase('if ("".length === 0 && array.length !== 0) {}', 'eq', 'ne'),
-		testCase('if ("".length < 1 && array.length >= 1) {}', 'lt', 'gte'),
-		testCase('if ("".length < 1 && array.length > 0) {}', 'lt', 'gt'),
-		testCase('if ("".length < 1 && array.length != 0) {}', 'lt', 'ne')
+		testCase('if (array.length === 1) {}'),
+		testCase('if (array.length <= 1) {}'),
+		testCase('if (array.length > 1) {}'),
+		testCase('if (array.length < 2) {}'),
+		testCase('array.length', 'ne'),
+		testCase('array.length > 0', 'ne'),
+		testCase('array.length >= 1', 'ne'),
+		testCase('if ("".length !== 0) {}', 'ne'),
+		testCase('if ([].length === 0) {}', 'ne'),
+		testCase('if ([].length === 1) {}', 'ne'),
+		testCase('if ([].length <= 1) {}', 'ne'),
+		testCase('if ("".length == 0) {}', 'ne'),
+		testCase('array.length !== 0', 'gt'),
+		testCase('array.length >= 1', 'gt'),
+		testCase('if ("".length > 0) {}', 'gt'),
+		testCase('if ("".length >= 0) {}', 'gt'),
+		testCase('if ("".length >= 2) {}', 'gt'),
+		testCase('if ("".length >= 1) {}', 'gte'),
+		testCase('array.length !== 0', 'gte'),
+		testCase('array.length > 0', 'gte'),
+		testCase('if ("".length === 0) {}', 'gte'),
+		testCase('if ("".length > 2) {}', 'gte'),
+		testCase('if ("".length === 2) {}', 'gte'),
+		testCase('if ("".length === 0 && array.length >= 1) {}', 'gte'),
+		testCase('if ("".length === 0 && array.length > 0) {}', 'gt'),
+		testCase('if ("".length === 0 && array.length !== 0) {}', 'ne')
 	],
 	invalid: [
 		testCase('if ([].length) {}',
-			undefined,
 			undefined,
 			[errorMessages.compareToValue]
 		),
 		testCase('if ("".length) {}',
 			undefined,
-			undefined,
 			[errorMessages.compareToValue]
 		),
 		testCase('if (array.length) {}',
-			undefined,
 			undefined,
 			[errorMessages.compareToValue]
 		),
 		testCase('if (!array.length) {}',
 			undefined,
-			undefined,
 			[errorMessages.compareToValue]
 		),
 		testCase('if (array.foo.length) {}',
-			undefined,
 			undefined,
 			[errorMessages.compareToValue]
 		),
 		testCase('if (!!array.length) {}',
 			undefined,
-			undefined,
 			[errorMessages.compareToValue]
 		),
 		testCase('if (array.length && array[0] === 1) {}',
-			undefined,
 			undefined,
 			[errorMessages.compareToValue]
 		),
 		testCase('if (array[0] === 1 || array.length) {}',
 			undefined,
-			undefined,
 			[errorMessages.compareToValue]
-		),
-		testCase('if (1 === array.length) {}',
-			undefined,
-			undefined,
-			[errorMessages.lengthFirst]
-		),
-		testCase('if ([].length === 0 || 0 < array.length) {}',
-			undefined,
-			undefined,
-			[errorMessages.lengthFirst]
 		),
 		testCase('if (array.length < 1) {}',
 			'eq',
-			undefined,
-			[errorMessages.emptyEqual]
+			[errorMessages.emptyEqual],
+			'if (array.length === 0) {}'
 		),
-		testCase('if (array.length === 0) {}',
-			'lt',
-			undefined,
-			[errorMessages.emptyLess]
-		),
-		testCase('if (array.length == 0) {}',
-			'lt',
-			undefined,
-			[errorMessages.emptyLess]
+		testCase('if (array.length<1) {}',
+			'eq',
+			[errorMessages.emptyEqual],
+			'if (array.length === 0) {}'
 		),
 		testCase('if (array.length > 0) {}',
-			undefined,
 			'ne',
-			[errorMessages.notEmptyEqual]
+			[errorMessages.notEmptyEqual],
+			'if (array.length !== 0) {}'
 		),
 		testCase('if (array.length >= 1) {}',
-			undefined,
 			'ne',
-			[errorMessages.notEmptyEqual]
+			[errorMessages.notEmptyEqual],
+			'if (array.length !== 0) {}'
 		),
 		testCase('if (array.length != 0) {}',
-			undefined,
 			'gt',
-			[errorMessages.notEmptyGreater]
+			[errorMessages.notEmptyGreater],
+			'if (array.length > 0) {}'
 		),
 		testCase('if (array.length !== 0) {}',
-			undefined,
 			'gt',
-			[errorMessages.notEmptyGreater]
+			[errorMessages.notEmptyGreater],
+			'if (array.length > 0) {}'
 		),
 		testCase('if (array.length >= 1) {}',
-			undefined,
 			'gt',
-			[errorMessages.notEmptyGreater]
+			[errorMessages.notEmptyGreater],
+			'if (array.length > 0) {}'
 		),
 		testCase('if (array.length != 0) {}',
-			undefined,
 			'gte',
-			[errorMessages.notEmptyGreaterEqual]
+			[errorMessages.notEmptyGreaterEqual],
+			'if (array.length >= 1) {}'
 		),
 		testCase('if (array.length !== 0) {}',
-			undefined,
 			'gte',
-			[errorMessages.notEmptyGreaterEqual]
+			[errorMessages.notEmptyGreaterEqual],
+			'if (array.length >= 1) {}'
 		),
 		testCase('if (array.length > 0) {}',
-			undefined,
 			'gte',
-			[errorMessages.notEmptyGreaterEqual]
+			[errorMessages.notEmptyGreaterEqual],
+			'if (array.length >= 1) {}'
 		),
 		testCase('if (array.length < 1 || array.length >= 1) {}',
-			'eq',
 			'ne',
-			[errorMessages.emptyEqual, errorMessages.notEmptyEqual]
-		),
-		testCase('if (array1.length === 0 && array2.length > 0) {}',
-			'lt',
-			'gte',
-			[errorMessages.emptyLess, errorMessages.notEmptyGreaterEqual]
-		),
-		testCase('if (array1.length == 0 && array2.length != 0 && 1 > [].length) {}',
-			'lt',
-			'gt',
-			[errorMessages.emptyLess, errorMessages.notEmptyGreater, errorMessages.lengthFirst]
+			[errorMessages.emptyEqual, errorMessages.notEmptyEqual],
+			'if (array.length === 0 || array.length !== 0) {}'
 		)
 	]
 });

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -16,13 +16,13 @@ const error = message => {
 };
 
 const errorMessages = {
-	lengthFirst: error('`length` property should be first argument of comparision'),
+	lengthFirst: error('`length` property should be first argument of comparision.'),
 	compareToValue: error('`length` property should be compared to a value.'),
-	emptyEqual: error('empty `length` should be compared with `=== 0`'),
-	emptyLess: error('empty `length` should be compared with `< 1`'),
-	notEmptyEqual: error('not empty `length` should be compared with `!== 1`'),
-	notEmptyGreater: error('not empty `length` should be compared with `> 0`'),
-	notEmptyGreaterEqual: error('not empty `length` should be compared with `>= 1`')
+	emptyEqual: error('empty `length` should be compared with `=== 0`.'),
+	emptyLess: error('empty `length` should be compared with `< 1`.'),
+	notEmptyEqual: error('not empty `length` should be compared with `!== 1`.'),
+	notEmptyGreater: error('not empty `length` should be compared with `> 0`.'),
+	notEmptyGreaterEqual: error('not empty `length` should be compared with `>= 1`.')
 };
 
 function testCase(code, emptyType, notEmptyType, errors = []) {


### PR DESCRIPTION
Fixes #56

In short it aims to add functionality to the rule `explicit-length-check` by providing some options to determine the preferred way of checking for length properties.

The `explicit-length-check` rule now enforces length comparison with `!== 0` when checking for an empty array. It auto-fixes when the check is made with '< 1'. 

#### Fail
```js
if (string.length < 1) {}
```
#### Pass
```js
if (array.length !== 0) {}
```

For non zero length comparisons we can define our preferred way of checking it by providing an option:
```js
{
  'unicorn/explicit-length-check': ['error', {
    'non-zero': 'not-equal'
  }]
}
```
where `non-zero` can be one of the following:
- `not-equal`
	- this option makes sure that non-zero is checked with: `array.length !== 0`
- `greater-than`
	- this option makes sure that non-zero is checked with: `array.length > 0`
- `greater-than-or-equal`
	- this option makes sure that non-zero is checked with: `array.length >= 1`

*If no options are provided it will work as before, allowing any of this possibilities.* 


What I did was to check for `BinaryExpressions` and look for the `empty` case and, if defined in the options, the `not-empty` case.

It will check if any of the cases, `empty` or `not-empty`, are contemplated in the `BinaryExpression`  by comparing the operator and the literal value. 
If any of the cases have a match and the operator+value are of other option types, than it is rejected and a fix is provided with the preferred way.
