### PR TITLE
Allow `_` as error name if not used inside catch block - fixes #87

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -46,6 +46,15 @@ try {
 }
 ```
 
+```js
+try {
+	doSomething();
+} catch (_) {
+	// `_` is allowed when the error is not used
+	console.log(foo);
+}
+```
+
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"xo"
 	],
 	"dependencies": {
+		"eslint-ast-utils": "^1.0.0",
 		"import-modules": "^1.1.0",
 		"lodash.camelcase": "^4.1.1",
 		"lodash.kebabcase": "^4.0.1",

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -1,4 +1,5 @@
 'use strict';
+const astUtils = require('eslint-ast-utils');
 
 // Matches someObj.then([FunctionExpression | ArrowFunctionExpression])
 function isLintablePromiseCatch(node) {
@@ -58,6 +59,11 @@ const create = context => {
 			}
 		},
 		CatchClause: node => {
+			if (node.param.name === '_') {
+				push(!astUtils.someContainIdentifier('_', node.body.body));
+				return;
+			}
+
 			push(node.param.name === name);
 		},
 		'CatchClause:exit': node => {

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -19,6 +19,8 @@ function testCase(code, name, error) {
 ruleTester.run('catch-error-name', rule, {
 	valid: [
 		testCase('try {} catch (err) {}'),
+		testCase('try {} catch (_) {}'),
+		testCase('try {} catch (_) { console.log(foo); }'),
 		testCase('try {} catch (error) {}', 'error'),
 		testCase('try {} catch (outerError) { try {} catch (innerError) {} }'),
 		testCase('obj.catch(err => {})'),
@@ -37,6 +39,7 @@ ruleTester.run('catch-error-name', rule, {
 	invalid: [
 		testCase('try {} catch (error) {}', null, true),
 		testCase('try {} catch (err) {}', 'error', true),
+		testCase('try {} catch (_) { console.log(_); }', null, true),
 		testCase('try {} catch (outerError) {}', null, true),
 		testCase('try {} catch (innerError) {}', null, true),
 		testCase('obj.catch(error => {})', null, true),


### PR DESCRIPTION
This PR fixes #87 by allowing `_` if it's not used in the catch block.