### PR TITLE
Allow number postfix in `catch-error-name` to prevent shadowed variables - fixes #93

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -55,6 +55,16 @@ try {
 }
 ```
 
+```js
+const handleError = err => {
+	const err2 = new Error('foo bar');
+
+	obj.catch(err3 => {
+		// `err3` is allowed because of shadowed variables
+	});
+}
+```
+
 
 ## Options
 

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -70,6 +70,21 @@ ruleTester.run('catch-error-name', rule, {
 				obj.catch(err3 => { });
 			}
 		`),
+		testCase(`
+			const handleError = err => {
+				const err2 = new Error('foo bar');
+				const err3 = new Error('foo bar');
+				const err4 = new Error('foo bar');
+				const err5 = new Error('foo bar');
+				const err6 = new Error('foo bar');
+				const err7 = new Error('foo bar');
+				const err8 = new Error('foo bar');
+				const err9 = new Error('foo bar');
+				const err10 = new Error('foo bar');
+
+				obj.catch(err11 => { });
+			}
+		`),
 		testCase('obj.catch(() => {})'),
 		testCase('obj.catch(error => {})', 'error'),
 		testCase('obj.catch(outerError => { return obj2.catch(innerError => {}) })'),
@@ -112,6 +127,25 @@ ruleTester.run('catch-error-name', rule, {
 		{
 			code: `
 				const handleError = err => {
+					const err9 = new Error('foo bar');
+
+					try {
+						doSomething();
+					} catch (foo) {
+						console.log(foo);
+					}
+				}
+			`,
+			errors: [
+				{
+					ruleId: 'catch-error-name',
+					message: 'The catch parameter should be named `err2`.'
+				}
+			]
+		},
+		{
+			code: `
+				const handleError = err => {
 					const err2 = new Error('foo bar');
 
 					obj.catch(foo => { });
@@ -121,6 +155,26 @@ ruleTester.run('catch-error-name', rule, {
 				{
 					ruleId: 'catch-error-name',
 					message: 'The catch parameter should be named `err3`.'
+				}
+			]
+		},
+		{
+			code: `
+				const handleError = error => {
+					const error2 = new Error('foo bar');
+
+					obj.catch(foo => { });
+				}
+			`,
+			errors: [
+				{
+					ruleId: 'catch-error-name',
+					message: 'The catch parameter should be named `error3`.'
+				}
+			],
+			options: [
+				{
+					name: 'error'
 				}
 			]
 		},

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -23,7 +23,53 @@ ruleTester.run('catch-error-name', rule, {
 		testCase('try {} catch (_) { console.log(foo); }'),
 		testCase('try {} catch (error) {}', 'error'),
 		testCase('try {} catch (outerError) { try {} catch (innerError) {} }'),
+		testCase(`
+			const handleError = err => {
+				try {
+					doSomething();
+				} catch (err2) {
+					console.log(err2);
+				}
+			}
+		`),
+		testCase(`
+			const handleError = error => {
+				try {
+					doSomething();
+				} catch (error2) {
+					console.log(error2);
+				}
+			}
+		`, 'error'),
+		testCase(`
+			const handleError = err => {
+				const err2 = new Error('foo bar');
+
+				try {
+					doSomething();
+				} catch (err3) {
+					console.log(err3);
+				}
+			}
+		`),
 		testCase('obj.catch(err => {})'),
+		testCase(`
+			const handleError = err => {
+				obj.catch(err2 => { });
+			}
+		`),
+		testCase(`
+			const handleError = error => {
+				obj.catch(error2 => { });
+			}
+		`, 'error'),
+		testCase(`
+			const handleError = err => {
+				const err2 = new Error('foo bar');
+
+				obj.catch(err3 => { });
+			}
+		`),
 		testCase('obj.catch(() => {})'),
 		testCase('obj.catch(error => {})', 'error'),
 		testCase('obj.catch(outerError => { return obj2.catch(innerError => {}) })'),
@@ -46,6 +92,38 @@ ruleTester.run('catch-error-name', rule, {
 		testCase('obj.catch(err => {})', 'error', true),
 		testCase('obj.catch(function (error) {})', null, true),
 		testCase('obj.catch(function (err) {})', 'error', true),
+		{
+			code: `
+				const handleError = err => {
+					try {
+						doSomething();
+					} catch (foo) {
+						console.log(foo);
+					}
+				}
+			`,
+			errors: [
+				{
+					ruleId: 'catch-error-name',
+					message: 'The catch parameter should be named `err2`.'
+				}
+			]
+		},
+		{
+			code: `
+				const handleError = err => {
+					const err2 = new Error('foo bar');
+
+					obj.catch(foo => { });
+				}
+			`,
+			errors: [
+				{
+					ruleId: 'catch-error-name',
+					message: 'The catch parameter should be named `err3`.'
+				}
+			]
+		},
 		{
 			code: `
 				obj.catch(error => {});


### PR DESCRIPTION
Not sure if I made it too complex. Could've just allowed any number postfix any time. So if you rather want that, let me know and I'll change it :).