### PR TITLE
Add support for `_` as error name in promises

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -65,6 +65,13 @@ const handleError = err => {
 }
 ```
 
+```js
+somePromise.catch(_ => {
+	// `_` is allowed when the error is not used
+	console.log(foo);
+});
+```
+
 
 ## Options
 

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -63,6 +63,12 @@ const create = context => {
 		CallExpression: node => {
 			if (isLintablePromiseCatch(node)) {
 				const params = node.arguments[0].params;
+
+				if (params.length > 0 && params[0].name === '_') {
+					push(!astUtils.containsIdentifier('_', node.arguments[0].body));
+					return;
+				}
+
 				const errName = indexifyName(name, context.getScope());
 				push(params.length === 0 || params[0].name === errName || errName);
 			}

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -102,13 +102,16 @@ ruleTester.run('catch-error-name', rule, {
 	invalid: [
 		testCase('try {} catch (error) {}', null, true),
 		testCase('try {} catch (err) {}', 'error', true),
+		testCase('try {} catch ({message}) {}', null, true),
 		testCase('try {} catch (_) { console.log(_); }', null, true),
 		testCase('try {} catch (outerError) {}', null, true),
 		testCase('try {} catch (innerError) {}', null, true),
 		testCase('obj.catch(error => {})', null, true),
 		testCase('obj.catch(err => {})', 'error', true),
+		testCase('obj.catch(({message}) => {})', null, true),
 		testCase('obj.catch(_ => { console.log(_); })', null, true),
 		testCase('obj.catch(function (error) {})', null, true),
+		testCase('obj.catch(function ({message}) {})', null, true),
 		testCase('obj.catch(function (err) {})', 'error', true),
 		testCase('obj.catch(function (_) { console.log(_); })', null, true),
 		{

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -86,6 +86,8 @@ ruleTester.run('catch-error-name', rule, {
 			}
 		`),
 		testCase('obj.catch(() => {})'),
+		testCase('obj.catch((_) => {})'),
+		testCase('obj.catch((_) => { console.log(foo); })'),
 		testCase('obj.catch(error => {})', 'error'),
 		testCase('obj.catch(outerError => { return obj2.catch(innerError => {}) })'),
 		testCase('obj.catch(function (err) {})'),
@@ -105,8 +107,10 @@ ruleTester.run('catch-error-name', rule, {
 		testCase('try {} catch (innerError) {}', null, true),
 		testCase('obj.catch(error => {})', null, true),
 		testCase('obj.catch(err => {})', 'error', true),
+		testCase('obj.catch(_ => { console.log(_); })', null, true),
 		testCase('obj.catch(function (error) {})', null, true),
 		testCase('obj.catch(function (err) {})', 'error', true),
+		testCase('obj.catch(function (_) { console.log(_); })', null, true),
 		{
 			code: `
 				const handleError = err => {


### PR DESCRIPTION
In #99 I allowed the use of `_` for `try-catch` blocks, but I forgot to do this for promises as well. This PR adds the possibility to use `_` as a name in promises when the error name is not used.