### PR TITLE
Add `regex-shorthand` rule - fixes #112

### DIFF
--- a/docs/rules/regex-shorthand.md
+++ b/docs/rules/regex-shorthand.md
@@ -1,0 +1,27 @@
+# Enforce the use of regex shorthands to improve readability
+
+
+## Fail
+
+```js
+const regex = /[0-9]/;
+const regex = /[^0-9]/;
+const regex = /[a-zA-Z0-9_]/;
+const regex = /[a-z0-9_]/i;
+const regex = /[^a-zA-Z0-9_]/;
+const regex = /[^a-z0-9_]/i;
+const regex = /[0-9]\.[a-zA-Z0-9_]\-[^0-9]/i;
+```
+
+
+## Pass
+
+```js
+const regex = /\d/;
+const regex = /\D/;
+const regex = /\w/;
+const regex = /\w/i;
+const regex = /\W/;
+const regex = /\W/i;
+const regex = /\d\.\w\-\D/i;
+```

--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ module.exports = {
 				'unicorn/prefer-type-error': 'error',
 				'unicorn/no-fn-reference-in-iterator': 'error',
 				'unicorn/import-index': 'error',
-				'unicorn/new-for-builtins': 'error'
+				'unicorn/new-for-builtins': 'error',
+				'unicorn/regex-shorthand': 'error'
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"xo"
 	],
 	"dependencies": {
+		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.0.0",
 		"import-modules": "^1.1.0",
 		"lodash.camelcase": "^4.1.1",

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,8 @@ Configure it in `package.json`.
 			"unicorn/prefer-type-error": "error",
 			"unicorn/no-fn-reference-in-iterator": "error",
 			"unicorn/import-index": "error",
-			"unicorn/new-for-builtins": "error"
+			"unicorn/new-for-builtins": "error",
+			"unicorn/regex-shorthand": "error"
 		}
 	}
 }
@@ -75,6 +76,7 @@ Configure it in `package.json`.
 - [no-fn-reference-in-iterator](docs/rules/no-fn-reference-in-iterator.md) - Prevents passing a function reference directly to iterator methods. *(fixable)*
 - [import-index](docs/rules/import-index.md) - Enforce importing index files with `.`. *(fixable)*
 - [new-for-builtins](docs/rules/new-for-builtins.md) - Enforce the use of `new` for all builtins, except `String`, `Number` and `Boolean`. *(fixable)*
+- [regex-shorthand](docs/rules/regex-shorthand.md) - Enforce the use of regex shorthands to improve readability. *(fixable)*
 
 
 ## Recommended config

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -1,0 +1,50 @@
+'use strict';
+const cleanRegexp = require('clean-regexp');
+
+const message = 'Use regex shorthands to improve readability.';
+
+const create = context => {
+	return {
+		'Literal[regex]': node => {
+			const oldPattern = node.regex.pattern;
+			const flags = node.regex.flags;
+
+			const newPattern = cleanRegexp(oldPattern, flags);
+
+			if (oldPattern !== newPattern) {
+				context.report({
+					node,
+					message,
+					fix: fixer => fixer.replaceTextRange(node.range, `/${newPattern}/${flags}`)
+				});
+			}
+		},
+		'NewExpression[callee.name="RegExp"]': node => {
+			const args = node.arguments;
+
+			if (args.length === 0 || args[0].type !== 'Literal') {
+				return;
+			}
+
+			const oldPattern = args[0].value;
+			const flags = args[1] && args[1].type === 'Literal' ? args[1].value : '';
+
+			const newPattern = cleanRegexp(oldPattern, flags);
+
+			if (oldPattern !== newPattern) {
+				context.report({
+					node,
+					message,
+					fix: fixer => fixer.replaceTextRange(args[0].range, `'${newPattern}'`)
+				});
+			}
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		fixable: 'code'
+	}
+};

--- a/test/regex-shorthand.js
+++ b/test/regex-shorthand.js
@@ -1,0 +1,124 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/regex-shorthand';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	},
+	parserOptions: {
+		sourceType: 'module'
+	}
+});
+
+const error = {
+	ruleId: 'regex-shorthand',
+	message: 'Use regex shorthands to improve readability.'
+};
+
+ruleTester.run('regex-shorthand', rule, {
+	valid: [
+		'const foo = /\\d/',
+		'const foo = /\\W/i',
+		'const foo = /\\w/ig',
+		'const foo = /[a-z]/ig',
+		'const foo = /\\d*?/ig',
+		'const foo = /[a-z0-9_]/',
+		`const foo = new RegExp('\\d')`,
+		`const foo = new RegExp('\\d', 'ig')`,
+		`const foo = new RegExp('\\d*?')`,
+		`const foo = new RegExp('[a-z]', 'i')`
+	],
+	invalid: [
+		{
+			code: 'const foo = /[0-9]/',
+			errors: [error],
+			output: 'const foo = /\\d/'
+		},
+		{
+			code: `const foo = new RegExp('[0-9]')`,
+			errors: [error],
+			output: `const foo = new RegExp('\\d')`
+		},
+		{
+			code: 'const foo = /[0-9]/ig',
+			errors: [error],
+			output: 'const foo = /\\d/ig'
+		},
+		{
+			code: `const foo = new RegExp('[0-9]', 'ig')`,
+			errors: [error],
+			output: `const foo = new RegExp('\\d', 'ig')`
+		},
+		{
+			code: 'const foo = /[^0-9]/',
+			errors: [error],
+			output: 'const foo = /\\D/'
+		},
+		{
+			code: 'const foo = /[A-Za-z0-9_]/',
+			errors: [error],
+			output: 'const foo = /\\w/'
+		},
+		{
+			code: 'const foo = /[A-Za-z\\d_]/',
+			errors: [error],
+			output: 'const foo = /\\w/'
+		},
+		{
+			code: 'const foo = /[a-zA-Z0-9_]/',
+			errors: [error],
+			output: 'const foo = /\\w/'
+		},
+		{
+			code: 'const foo = /[a-zA-Z\\d_]/',
+			errors: [error],
+			output: 'const foo = /\\w/'
+		},
+		{
+			code: 'const foo = /[A-Za-z0-9_]+[0-9]?\\.[A-Za-z0-9_]*/',
+			errors: [error],
+			output: 'const foo = /\\w+\\d?\\.\\w*/'
+		},
+		{
+			code: 'const foo = /[a-z0-9_]/i',
+			errors: [error],
+			output: 'const foo = /\\w/i'
+		},
+		{
+			code: 'const foo = /[a-z\\d_]/i',
+			errors: [error],
+			output: 'const foo = /\\w/i'
+		},
+		{
+			code: 'const foo = /[^A-Za-z0-9_]/',
+			errors: [error],
+			output: 'const foo = /\\W/'
+		},
+		{
+			code: 'const foo = /[^A-Za-z\\d_]/',
+			errors: [error],
+			output: 'const foo = /\\W/'
+		},
+		{
+			code: 'const foo = /[^a-z0-9_]/i',
+			errors: [error],
+			output: 'const foo = /\\W/i'
+		},
+		{
+			code: 'const foo = /[^a-z\\d_]/i',
+			errors: [error],
+			output: 'const foo = /\\W/i'
+		},
+		{
+			code: 'const foo = /[^a-z\\d_]/ig',
+			errors: [error],
+			output: 'const foo = /\\W/ig'
+		},
+		{
+			code: 'const foo = /[^\\d_a-z]/ig',
+			errors: [error],
+			output: 'const foo = /\\W/ig'
+		}
+	]
+});


### PR DESCRIPTION
This PR adds a new `regex-shorthand` rule proposed in #112. I created a new package for this, [`clean-regexp`](https://github.com/samverschueren/clean-regexp) because I realised that every regular expression should be matched in any order as explained here https://github.com/sindresorhus/eslint-plugin-unicorn/issues/112#issuecomment-321161108.