### PR TITLE
Add `prefer-includes` rule

### DIFF
--- a/docs/rules/prefer-includes.md
+++ b/docs/rules/prefer-includes.md
@@ -1,0 +1,46 @@
+# Prefer `.includes()` over `.indexOf()` when checking for existence
+
+The rule assume all properties named .indexOf() have a .includes() counterpart, as ESLint doesn't do type analysis. This is luckily true for all built-ins: String#includes, Array#includes, TypedArray#includes, Buffer#includes.
+
+
+## Fail
+
+```js
+const str = 'foobar';
+
+str.indexOf('foo') !== -1;
+str.indexOf('foo') != -1;
+str.indexOf('foo') > -1;
+str.indexOf('foo') >= 0;
+```
+
+```js
+const str = 'foobar';
+
+!str.includes === -1;
+!str.includes == -1;
+!str.includes < 0;
+```
+
+
+## Pass
+
+```js
+const str = 'foobar';
+
+str.includes('foo');
+```
+
+TODO:
+
+Would also be useful to catch cases where .includes() would be better than a regex:
+
+```js
+/\r\n/.test(foo);
+```
+
+Could be:
+
+```js
+foo.includes('\r\n');
+```

--- a/docs/rules/prefer-includes.md
+++ b/docs/rules/prefer-includes.md
@@ -1,46 +1,32 @@
 # Prefer `.includes()` over `.indexOf()` when checking for existence
 
-The rule assume all properties named .indexOf() have a .includes() counterpart, as ESLint doesn't do type analysis. This is luckily true for all built-ins: String#includes, Array#includes, TypedArray#includes, Buffer#includes.
+The rule assume all properties named `.indexOf()` have a `.includes()` counterpart, as ESLint doesn't do type analysis. This is luckily true for all built-ins: `String#includes`, `Array#includes`, `TypedArray#includes`, `Buffer#includes`.
 
 
 ## Fail
 
 ```js
-const str = 'foobar';
+const x = 'foobar';
 
-str.indexOf('foo') !== -1;
-str.indexOf('foo') != -1;
-str.indexOf('foo') > -1;
-str.indexOf('foo') >= 0;
+x.indexOf('foo') !== -1;
+x.indexOf('foo') != -1;
+x.indexOf('foo') > -1;
+x.indexOf('foo') >= 0;
 ```
 
 ```js
-const str = 'foobar';
+const x = 'foobar';
 
-!str.includes === -1;
-!str.includes == -1;
-!str.includes < 0;
+!x.includes === -1;
+!x.includes == -1;
+!x.includes < 0;
 ```
 
 
 ## Pass
 
 ```js
-const str = 'foobar';
+const x = 'foobar';
 
-str.includes('foo');
-```
-
-TODO:
-
-Would also be useful to catch cases where .includes() would be better than a regex:
-
-```js
-/\r\n/.test(foo);
-```
-
-Could be:
-
-```js
-foo.includes('\r\n');
+x.includes('foo');
 ```

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ module.exports = {
 				'unicorn/no-fn-reference-in-iterator': 'error',
 				'unicorn/import-index': 'error',
 				'unicorn/new-for-builtins': 'error',
-				'unicorn/regex-shorthand': 'error'
+				'unicorn/regex-shorthand': 'error',
+				'unicorn/prefer-includes': 'error'
 			}
 		}
 	}

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -1,4 +1,5 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 const isIndexOfCallExpression = node => {
 	if (node.type !== 'CallExpression') {
@@ -105,6 +106,9 @@ const create = context => ({
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: getDocsUrl()
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const isIndexOfCallExpression = node => {
+	if (node.type !== 'CallExpression') {
+		return false;
+	}
+
+	const property = node.callee.property;
+
+	return property.name === 'indexOf';
+};
+
+const isUnaryNotExpression = node => (
+	node.type === 'UnaryExpression' && node.operator === '!'
+);
+
+const isNegativeOne = (operator, value) => operator === '-' && value === 1;
+
+const getSourceCode = (context, node) => (
+	// Context.getSourceCode().text.slice(node.range[0], node.range[1])
+	context.getSourceCode().getText(node)
+);
+
+const report = (context, node, target, pattern) => {
+	const targetSource = getSourceCode(context, target);
+	const patternSource = getSourceCode(context, pattern);
+	context.report({
+		node,
+		message: 'Use .includes(), rather than .indexOf(), when checking for existence.',
+		fix: fixer => fixer.replaceText(node, `${targetSource}.includes(${patternSource})`)
+	});
+};
+
+const create = context => ({
+	BinaryExpression: node => {
+		const left = node.left;
+		const right = node.right;
+
+		if (isIndexOfCallExpression(left)) {
+			const target = left.callee.object;
+			const pattern = left.arguments[0];
+
+			if (right.type === 'UnaryExpression') {
+				const argument = right.argument;
+
+				if (argument.type !== 'Literal') {
+					return false;
+				}
+
+				const value = argument.value;
+
+				if (['!==', '!=', '>'].indexOf(node.operator) !== -1 && isNegativeOne(right.operator, value)) {
+					report(context, node, target, pattern);
+				}
+			}
+
+			if (right.type !== 'Literal') {
+				return false;
+			}
+
+			if (right.type === 'Literal' && node.operator === '>=' && right.value === 0) {
+				report(context, node, target, pattern);
+			}
+			return;
+		}
+
+		if (isUnaryNotExpression(left)) {
+			const argument = left.argument;
+
+			if (isIndexOfCallExpression(argument)) {
+				const target = argument.callee.object;
+				const pattern = argument.arguments[0];
+
+				if (right.type === 'UnaryExpression') {
+					const argument = right.argument;
+
+					if (argument.type !== 'Literal') {
+						return false;
+					}
+
+					const value = argument.value;
+
+					if (node.operator === '===' && isNegativeOne(right.operator, value)) {
+						report(context, node, target, pattern);
+					}
+					if (node.operator === '==' && isNegativeOne(right.operator, value)) {
+						report(context, node, target, pattern);
+					}
+				}
+
+				if (right.type !== 'Literal') {
+					return false;
+				}
+
+				if (node.operator === '<' && right.value === 0) {
+					report(context, node, target, pattern);
+				}
+
+				return false;
+			}
+		}
+	}
+});
+
+module.exports = {
+	create,
+	meta: {
+		fixable: 'code'
+	}
+};

--- a/test/prefer-includes.js
+++ b/test/prefer-includes.js
@@ -1,0 +1,68 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-includes';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const errors = [{
+	ruleId: 'prefer-includes',
+	message: 'Use .includes(), rather than .indexOf(), when checking for existence.'
+}];
+
+ruleTester.run('prefer-includes', rule, {
+	valid: [
+		`str.indexOf('foo') !== -n`,
+		`str.indexOf('foo') !== 1`,
+		`!str.indexOf('foo') === 1`,
+		`!str.indexOf('foo') === -n`,
+		`str.includes('foo')`,
+		`'foobar'.includes('foo')`,
+		'[1,2,3].includes(4)'
+	],
+	invalid: [
+		{
+			code: `'foobar'.indexOf('foo') !== -1`,
+			output: `'foobar'.includes('foo')`,
+			errors
+		},
+		{
+			code: `str.indexOf('foo') != -1`,
+			output: `str.includes('foo')`,
+			errors
+		},
+		{
+			code: `str.indexOf('foo') > -1`,
+			output: `str.includes('foo')`,
+			errors
+		},
+		{
+			code: `'foobar'.indexOf('foo') >= 0`,
+			output: `'foobar'.includes('foo')`,
+			errors
+		},
+		{
+			code: `!str.indexOf('foo') === -1`,
+			output: `str.includes('foo')`,
+			errors
+		},
+		{
+			code: `!str.indexOf('foo') == -1`,
+			output: `str.includes('foo')`,
+			errors
+		},
+		{
+			code: `!'foobar'.indexOf('foo') < 0`,
+			output: `'foobar'.includes('foo')`,
+			errors
+		},
+		{
+			code: '[1,2,3].indexOf(4) !== -1',
+			output: '[1,2,3].includes(4)',
+			errors
+		}
+	]
+});


### PR DESCRIPTION
Implements #8 with the regex part still missing for now.
Used @jeremyjs's base code with the improvements suggested by @sindresorhus and @jfmengels 
 here: #70 due to inactivity from @jeremyjs.
Glad to work on it with more improvements that you find worthy.