### PR TITLE
Fix: allow process.exit() to be called in process.once

### DIFF
--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -14,7 +14,7 @@ const create = context => {
 			const callee = node.callee;
 
 			if (callee.type === 'MemberExpression' && callee.object.name === 'process') {
-				if (callee.property.name === 'on') {
+				if (callee.property.name === 'on' || callee.property.name === 'once') {
 					processEventHandler = node;
 					return;
 				}


### PR DESCRIPTION
no-process-exit rule: Just like process.exit is allowed within process.on callbacks, allow it in process.once.

Resovles #133 