### PR TITLE
Fix process.exit within process.once throwing no-process-exit - fixes #133

### DIFF
--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -14,7 +14,7 @@ const create = context => {
 			const callee = node.callee;
 
 			if (callee.type === 'MemberExpression' && callee.object.name === 'process') {
-				if (callee.property.name === 'on') {
+				if (callee.property.name === 'on' || callee.property.name === 'once') {
 					processEventHandler = node;
 					return;
 				}

--- a/test/no-process-exit.js
+++ b/test/no-process-exit.js
@@ -24,6 +24,11 @@ ruleTester.run('no-process-exit', rule, {
 		'process.on("SIGINT", () => { process.exit(1); })',
 		'process.on("SIGINT", () => process.exit(1))',
 		'process.on("SIGINT", () => { if (true) { process.exit(1); } })',
+		'process.once("SIGINT", function() { process.exit(1); })',
+		'process.once("SIGKILL", function() { process.exit(1); })',
+		'process.once("SIGINT", () => { process.exit(1); })',
+		'process.once("SIGINT", () => process.exit(1))',
+		'process.once("SIGINT", () => { if (true) { process.exit(1); } })',
 		''
 	],
 	invalid: [


### PR DESCRIPTION
Support process.exit process.once callback, just like with process.on.