### PR TITLE
Add `caughtErrorsIgnorePattern` option to `catch-error-name` rule

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -75,8 +75,40 @@ somePromise.catch(_ => {
 
 ## Options
 
+### Name
+
 You can set the `name` option like this:
 
 ```js
 "unicorn/catch-error-name": ["error", {"name": "err"}]
 ```
+
+### caughtErrorsIgnorePattern
+
+```js
+"unicorn/catch-error-name": ["error", {"caughtErrorsIgnorePattern": "^ignore"}]
+```
+
+The `caughtErrorsIgnorePattern` option specifies exceptions not to check for usage: catch arguments whose names match a regexp pattern. 
+For example, variables whose names begin with a string ‘ignore’.
+
+## Fail
+
+```js
+try {
+	doSomething();
+} catch (skipErr) {
+	// ...
+}
+```
+
+## Pass
+
+```js
+try {
+	doSomething();
+} catch (ignoreErr) {
+	// ...
+}
+```
+

--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -86,11 +86,11 @@ You can set the `name` option like this:
 ### caughtErrorsIgnorePattern
 
 ```js
-"unicorn/catch-error-name": ["error", {"caughtErrorsIgnorePattern": "^ignore"}]
+"unicorn/catch-error-name": ["error", {"caughtErrorsIgnorePattern": "^_"}]
 ```
 
 The `caughtErrorsIgnorePattern` option specifies exceptions not to check for usage: catch arguments whose names match a regexp pattern.
-For example, variables whose names begin with a string `ignore`. Default is `^ignore`.
+For example, variables whose names begin with a string `_`. Default is `^_`.
 
 ## Fail
 
@@ -107,7 +107,7 @@ try {
 ```js
 try {
 	doSomething();
-} catch (ignoreErr) {
+} catch (_err) {
 	// …
 }
 ```

--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -86,11 +86,11 @@ You can set the `name` option like this:
 ### caughtErrorsIgnorePattern
 
 ```js
-"unicorn/catch-error-name": ["error", {"caughtErrorsIgnorePattern": "^_"}]
+"unicorn/catch-error-name": ["error", {"caughtErrorsIgnorePattern": "^_$"}]
 ```
 
 The `caughtErrorsIgnorePattern` option specifies exceptions not to check for usage: catch arguments whose names match a regexp pattern.
-For example, variables whose names begin with a string `_`. Default is `^_`.
+For example, variables whose names is a string `_`. Default is `^_$`.
 
 ## Fail
 
@@ -107,7 +107,7 @@ try {
 ```js
 try {
 	doSomething();
-} catch (_err) {
+} catch (_) {
 	// …
 }
 ```

--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -75,7 +75,7 @@ somePromise.catch(_ => {
 
 ## Options
 
-### Name
+### name
 
 You can set the `name` option like this:
 
@@ -89,8 +89,8 @@ You can set the `name` option like this:
 "unicorn/catch-error-name": ["error", {"caughtErrorsIgnorePattern": "^ignore"}]
 ```
 
-The `caughtErrorsIgnorePattern` option specifies exceptions not to check for usage: catch arguments whose names match a regexp pattern. 
-For example, variables whose names begin with a string ‘ignore’.
+The `caughtErrorsIgnorePattern` option specifies exceptions not to check for usage: catch arguments whose names match a regexp pattern.
+For example, variables whose names begin with a string `ignore`. Default is `^ignore`.
 
 ## Fail
 
@@ -98,7 +98,7 @@ For example, variables whose names begin with a string ‘ignore’.
 try {
 	doSomething();
 } catch (skipErr) {
-	// ...
+	// …
 }
 ```
 
@@ -108,7 +108,6 @@ try {
 try {
 	doSomething();
 } catch (ignoreErr) {
-	// ...
+	// …
 }
 ```
-

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -39,9 +39,7 @@ function indexifyName(name, scope) {
 const create = context => {
 	const opts = Object.assign({}, {name: 'err'}, context.options[0]);
 	const name = opts.name;
-	const caughtErrorsIgnorePattern = opts.caughtErrorsIgnorePattern ?
-		new RegExp(opts.caughtErrorsIgnorePattern) :
-		null;
+	const caughtErrorsIgnorePattern = new RegExp(opts.caughtErrorsIgnorePattern || '^_');
 	const stack = [];
 
 	function push(value) {
@@ -55,7 +53,7 @@ const create = context => {
 	function popAndReport(node) {
 		const value = stack.pop();
 
-		if (caughtErrorsIgnorePattern && caughtErrorsIgnorePattern.test(node.name)) {
+		if (node && caughtErrorsIgnorePattern.test(node.name)) {
 			return;
 		}
 

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -39,7 +39,7 @@ function indexifyName(name, scope) {
 const create = context => {
 	const opts = Object.assign({}, {name: 'err'}, context.options[0]);
 	const name = opts.name;
-	const caughtErrorsIgnorePattern = new RegExp(opts.caughtErrorsIgnorePattern || '^_');
+	const caughtErrorsIgnorePattern = new RegExp(opts.caughtErrorsIgnorePattern || '^_$');
 	const stack = [];
 
 	function push(value) {

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -39,6 +39,9 @@ function indexifyName(name, scope) {
 const create = context => {
 	const opts = context.options[0];
 	const name = (opts && opts.name) || 'err';
+	const caughtErrorsIgnorePattern = opts && opts.caughtErrorsIgnorePattern ?
+		new RegExp(opts.caughtErrorsIgnorePattern) :
+		null;
 	const stack = [];
 
 	function push(value) {
@@ -51,6 +54,10 @@ const create = context => {
 
 	function popAndReport(node) {
 		const value = stack.pop();
+
+		if (caughtErrorsIgnorePattern && caughtErrorsIgnorePattern.test(node.name)) {
+			return;
+		}
 
 		if (value !== true) {
 			context.report({
@@ -98,6 +105,9 @@ const schema = [{
 	type: 'object',
 	properties: {
 		name: {
+			type: 'string'
+		},
+		caughtErrorsIgnorePattern: {
 			type: 'string'
 		}
 	}

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -37,9 +37,9 @@ function indexifyName(name, scope) {
 }
 
 const create = context => {
-	const opts = context.options[0];
-	const name = (opts && opts.name) || 'err';
-	const caughtErrorsIgnorePattern = opts && opts.caughtErrorsIgnorePattern ?
+	const opts = Object.assign({}, {name: 'err'}, context.options[0]);
+	const name = opts.name;
+	const caughtErrorsIgnorePattern = opts.caughtErrorsIgnorePattern ?
 		new RegExp(opts.caughtErrorsIgnorePattern) :
 		null;
 	const stack = [];

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -95,50 +95,29 @@ ruleTester.run('catch-error-name', rule, {
 		testCase('obj.catch(function (error) {})', 'error'),
 		testCase('obj.catch(function (outerError) { return obj2.catch(function (innerError) {}) })'),
 		testCase('obj.catch()'),
+		testCase('obj.catch(_ => { console.log(_); })'),
+		testCase('obj.catch(function (_) { console.log(_); })'),
 		testCase('foo(function (err) {})'),
 		testCase('foo().then(function (err) {})'),
 		testCase('foo().catch(function (err) {})'),
-		{
-			code: 'try {} catch (ignoreErr) {}',
-			options: [
-				{
-					name: 'error',
-					caughtErrorsIgnorePattern: '^ignore'
-				}
-			]
-		},
-		{
-			code: 'try {} catch (ignoreErr) { try {} catch (ignoreErr) {} }',
-			options: [
-				{
-					name: 'error',
-					caughtErrorsIgnorePattern: '^ignore'
-				}
-			]
-		},
-		{
-			code: `
+		testCase('try {} catch (_err) {}'),
+		testCase('try {} catch (_err) { try {} catch (_err) {} }'),
+		testCase('try {} catch (_) { console.log(_); }'),
+		testCase(`
 				const handleError = error => {
 					try {
 						doSomething();
-					} catch (ignoreErr) {
-						console.log(ignoreErr);
+					} catch (_err) {
+						console.log(_err);
 					}
 				}
-			`,
-			options: [
-				{
-					name: 'error',
-					caughtErrorsIgnorePattern: '^ignore'
-				}
-			]
-		},
+		`),
+		testCase('obj.catch(_err => {})'),
 		{
-			code: 'obj.catch(ignoreErr => {})',
+			code: 'try {} catch (skipErr) {}',
 			options: [
 				{
-					name: 'error',
-					caughtErrorsIgnorePattern: '^ignore'
+					caughtErrorsIgnorePattern: '^skip'
 				}
 			]
 		}
@@ -147,17 +126,14 @@ ruleTester.run('catch-error-name', rule, {
 		testCase('try {} catch (error) {}', null, true),
 		testCase('try {} catch (err) {}', 'error', true),
 		testCase('try {} catch ({message}) {}', null, true),
-		testCase('try {} catch (_) { console.log(_); }', null, true),
 		testCase('try {} catch (outerError) {}', null, true),
 		testCase('try {} catch (innerError) {}', null, true),
 		testCase('obj.catch(error => {})', null, true),
 		testCase('obj.catch(err => {})', 'error', true),
 		testCase('obj.catch(({message}) => {})', null, true),
-		testCase('obj.catch(_ => { console.log(_); })', null, true),
 		testCase('obj.catch(function (error) {})', null, true),
 		testCase('obj.catch(function ({message}) {})', null, true),
 		testCase('obj.catch(function (err) {})', 'error', true),
-		testCase('obj.catch(function (_) { console.log(_); })', null, true),
 		// Failing tests for #107
 		// testCase(`
 		// 	foo.then(() => {
@@ -251,16 +227,15 @@ ruleTester.run('catch-error-name', rule, {
 			]
 		},
 		{
-			code: 'try {} catch (ignoreErr) {}',
+			code: 'try {} catch (_err) {}',
 			errors: [
 				{
 					ruleId: 'catch-error-name',
-					message: 'The catch parameter should be named `error`.'
+					message: 'The catch parameter should be named `err`.'
 				}
 			],
 			options: [
 				{
-					name: 'error',
 					caughtErrorsIgnorePattern: '^skip'
 				}
 			]

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -97,7 +97,51 @@ ruleTester.run('catch-error-name', rule, {
 		testCase('obj.catch()'),
 		testCase('foo(function (err) {})'),
 		testCase('foo().then(function (err) {})'),
-		testCase('foo().catch(function (err) {})')
+		testCase('foo().catch(function (err) {})'),
+		{
+			code: 'try {} catch (ignoreErr) {}',
+			options: [
+				{
+					name: 'error',
+					caughtErrorsIgnorePattern: '^ignore'
+				}
+			]
+		},
+		{
+			code: 'try {} catch (ignoreErr) { try {} catch (ignoreErr) {} }',
+			options: [
+				{
+					name: 'error',
+					caughtErrorsIgnorePattern: '^ignore'
+				}
+			]
+		},
+		{
+			code: `
+				const handleError = error => {
+					try {
+						doSomething();
+					} catch (ignoreErr) {
+						console.log(ignoreErr);
+					}
+				}
+			`,
+			options: [
+				{
+					name: 'error',
+					caughtErrorsIgnorePattern: '^ignore'
+				}
+			]
+		},
+		{
+			code: 'obj.catch(ignoreErr => {})',
+			options: [
+				{
+					name: 'error',
+					caughtErrorsIgnorePattern: '^ignore'
+				}
+			]
+		}
 	],
 	invalid: [
 		testCase('try {} catch (error) {}', null, true),
@@ -204,6 +248,21 @@ ruleTester.run('catch-error-name', rule, {
 			errors: [
 				{ruleId: 'catch-error-name'},
 				{ruleId: 'catch-error-name'}
+			]
+		},
+		{
+			code: 'try {} catch (ignoreErr) {}',
+			errors: [
+				{
+					ruleId: 'catch-error-name',
+					message: 'The catch parameter should be named `error`.'
+				}
+			],
+			options: [
+				{
+					name: 'error',
+					caughtErrorsIgnorePattern: '^skip'
+				}
 			]
 		}
 	]

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -100,19 +100,19 @@ ruleTester.run('catch-error-name', rule, {
 		testCase('foo(function (err) {})'),
 		testCase('foo().then(function (err) {})'),
 		testCase('foo().catch(function (err) {})'),
-		testCase('try {} catch (_err) {}'),
-		testCase('try {} catch (_err) { try {} catch (_err) {} }'),
+		testCase('try {} catch (_) {}'),
+		testCase('try {} catch (_) { try {} catch (_) {} }'),
 		testCase('try {} catch (_) { console.log(_); }'),
 		testCase(`
 				const handleError = error => {
 					try {
 						doSomething();
-					} catch (_err) {
-						console.log(_err);
+					} catch (_) {
+						console.log(_);
 					}
 				}
 		`),
-		testCase('obj.catch(_err => {})'),
+		testCase('obj.catch(_ => {})'),
 		{
 			code: 'try {} catch (skipErr) {}',
 			options: [


### PR DESCRIPTION
Fixes #48
I think better add option which error name we should ignore (as do eslint) instead allow multiple errors names