### PR TITLE
Exclude index.js from the filename-case rule

### DIFF
--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -1,6 +1,8 @@
 # Enforce a case style for filenames
 
-Enforces all linted files to have their names in a certain case style with the exception of `index.js`. Default is `kebabCase`.
+Enforces all linted files to have their names in a certain case style. Default is `kebabCase`.
+
+Files named `index.js` are ignored as they can't change case (Only a problem with `pascalCase`).
 
 
 ### `kebabCase`
@@ -27,7 +29,6 @@ Enforces all linted files to have their names in a certain case style with the e
 - `FooBar.Test.js`
 - `FooBar.TestUtils.js`
 
-Therefore, the `pascalCase` rule will not be applied to `index.js`
 
 ## Options
 

--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -1,6 +1,6 @@
 # Enforce a case style for filenames
 
-Enforces all linted files to have their names in a certain case style. Default is `kebabCase`.
+Enforces all linted files to have their names in a certain case style with the exception of `index.js`. Default is `kebabCase`.
 
 
 ### `kebabCase`
@@ -27,6 +27,7 @@ Enforces all linted files to have their names in a certain case style. Default i
 - `FooBar.Test.js`
 - `FooBar.TestUtils.js`
 
+Therefore, the `pascalCase` rule will not be applied to `index.js`
 
 ## Options
 

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -66,6 +66,10 @@ function splitFilename(filename) {
 	};
 }
 
+function isIndexFile(filenameWithExt) {
+	return path.basename(filenameWithExt) === 'index.js';
+}
+
 const create = context => {
 	const chosenCase = cases[context.options[0].case || 'camelCase'];
 	const filenameWithExt = context.getFilename();
@@ -78,6 +82,11 @@ const create = context => {
 		Program: node => {
 			const extension = path.extname(filenameWithExt);
 			const filename = path.basename(filenameWithExt, extension);
+
+			if (isIndexFile(filenameWithExt)) {
+				return;
+			}
+
 			const splitName = splitFilename(filename);
 			const fixedFilename = fixFilename(chosenCase, splitName.trailing);
 			const renameFilename = splitName.leading + fixedFilename + extension;

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -66,10 +66,6 @@ function splitFilename(filename) {
 	};
 }
 
-function isIndexFile(filenameWithExt) {
-	return path.basename(filenameWithExt) === 'index.js';
-}
-
 const create = context => {
 	const chosenCase = cases[context.options[0].case || 'camelCase'];
 	const filenameWithExt = context.getFilename();
@@ -83,7 +79,7 @@ const create = context => {
 			const extension = path.extname(filenameWithExt);
 			const filename = path.basename(filenameWithExt, extension);
 
-			if (isIndexFile(filenameWithExt)) {
+			if (filename + extension === 'index.js') {
 				return;
 			}
 

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -56,6 +56,7 @@ ruleTester.run('filename-case', rule, {
 		testCase('spec/Iss47Spec.js', 'pascalCase'),
 		testCase('spec/Iss47.100Spec.js', 'pascalCase'),
 		testCase('spec/I18n.js', 'pascalCase'),
+		testCase('spec/index.js', 'pascalCase'),
 		testCase('<text>', 'camelCase'),
 		testCase('<text>', 'snakeCase'),
 		testCase('<text>', 'kebabCase'),


### PR DESCRIPTION
Exclude `index.js` from the `filename-case` rule

Fixes #131