### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -105,6 +105,9 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/catch-error-name.md'
+		},
 		schema
 	}
 };

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -107,7 +107,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('catch-error-name')
+			url: getDocsUrl()
 		},
 		schema
 	}

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -1,5 +1,6 @@
 'use strict';
 const astUtils = require('eslint-ast-utils');
+const getDocsUrl = require('./utils/get-docs-url');
 
 // Matches someObj.then([FunctionExpression | ArrowFunctionExpression])
 function isLintablePromiseCatch(node) {
@@ -106,7 +107,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/catch-error-name.md'
+			url: getDocsUrl('catch-error-name')
 		},
 		schema
 	}

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -130,6 +130,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/custom-error-definition.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -1,5 +1,6 @@
 'use strict';
 const upperfirst = require('lodash.upperfirst');
+const getDocsUrl = require('./utils/get-docs-url');
 
 const nameRegexp = /^(?:[A-Z][a-z0-9]*)*Error$/;
 
@@ -131,7 +132,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/custom-error-definition.md'
+			url: getDocsUrl('custom-error-definition')
 		},
 		fixable: 'code'
 	}

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -132,7 +132,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('custom-error-definition')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -53,6 +53,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/escape-case.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -1,4 +1,6 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
 const escapeWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u\{(?:[a-f\d]{1,})\}|c[a-z])/;
 const hasLowercaseCharacter = /[a-z]+/;
 const message = 'Use uppercase characters for the value of the escape sequence.';
@@ -54,7 +56,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/escape-case.md'
+			url: getDocsUrl('escape-case')
 		},
 		fixable: 'code'
 	}

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -56,7 +56,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('escape-case')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -147,6 +147,9 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/explicit-length-check.md'
+		},
 		fixable: 'code',
 		schema
 	}

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -149,7 +149,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('explicit-length-check')
+			url: getDocsUrl()
 		},
 		fixable: 'code',
 		schema

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -1,4 +1,5 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 const operatorTypes = {
 	gt: ['>'],
@@ -148,7 +149,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/explicit-length-check.md'
+			url: getDocsUrl('explicit-length-check')
 		},
 		fixable: 'code',
 		schema

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -116,7 +116,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('filename-case')
+			url: getDocsUrl()
 		},
 		schema
 	}

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -4,6 +4,7 @@ const camelCase = require('lodash.camelcase');
 const kebabCase = require('lodash.kebabcase');
 const snakeCase = require('lodash.snakecase');
 const upperfirst = require('lodash.upperfirst');
+const getDocsUrl = require('./utils/get-docs-url');
 
 const pascalCase = str => upperfirst(camelCase(str));
 const numberRegex = /(\d+)/;
@@ -115,7 +116,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/filename-case.md'
+			url: getDocsUrl('filename-case')
 		},
 		schema
 	}

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -114,6 +114,9 @@ const schema = [{
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/filename-case.md'
+		},
 		schema
 	}
 };

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -26,7 +26,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('import-index')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -23,6 +23,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/import-index.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -1,4 +1,6 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
 const regexp = /^(@.*?\/.*?|[./]+?.*?)(?:\/(?:index(?:\.js)?)?)$/;
 const isImportingIndex = m => regexp.test(m);
 const normalize = m => m.replace(regexp, '$1');
@@ -24,7 +26,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/import-index.md'
+			url: getDocsUrl('import-index')
 		},
 		fixable: 'code'
 	}

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -67,7 +67,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('new-for-builtins')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -64,6 +64,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/new-for-builtins.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -1,4 +1,6 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
 const enforceNew = new Set([
 	'Object',
 	'Array',
@@ -65,7 +67,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/new-for-builtins.md'
+			url: getDocsUrl('new-for-builtins')
 		},
 		fixable: 'code'
 	}

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -29,5 +29,9 @@ const create = context => ({
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-abusive-eslint-disable.md'
+		}
+	}
 };

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -1,4 +1,5 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 const disableRegex = /^eslint-disable(-next-line|-line)?($|(\s+([\w-]+))?)/;
 
@@ -31,7 +32,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-abusive-eslint-disable.md'
+			url: getDocsUrl('no-abusive-eslint-disable')
 		}
 	}
 };

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -32,7 +32,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('no-abusive-eslint-disable')
+			url: getDocsUrl()
 		}
 	}
 };

--- a/rules/no-array-instanceof.js
+++ b/rules/no-array-instanceof.js
@@ -20,7 +20,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('no-array-instanceof')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/no-array-instanceof.js
+++ b/rules/no-array-instanceof.js
@@ -18,6 +18,9 @@ const create = context => ({
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-array-instanceof.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-array-instanceof.js
+++ b/rules/no-array-instanceof.js
@@ -1,4 +1,5 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 const create = context => ({
 	BinaryExpression: node => {
@@ -19,7 +20,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-array-instanceof.md'
+			url: getDocsUrl('no-array-instanceof')
 		},
 		fixable: 'code'
 	}

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -49,7 +49,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('no-fn-reference-in-iterator')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -46,6 +46,9 @@ const create = context => ({
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-fn-reference-in-iterator.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -1,4 +1,6 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
 const iteratorMethods = new Map([
 	['map', 1],
 	['forEach', 1],
@@ -47,7 +49,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-fn-reference-in-iterator.md'
+			url: getDocsUrl('no-fn-reference-in-iterator')
 		},
 		fixable: 'code'
 	}

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -1,5 +1,6 @@
 /* eslint-disable unicorn/no-hex-escape */
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 function checkEscape(context, node, value) {
 	const fixedValue = typeof value === 'string' ? value.replace(/((?:^|[^\\])(?:\\\\)*)\\x/g, '$1\\u00') : value;
@@ -28,7 +29,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-hex-escape.md'
+			url: getDocsUrl('no-hex-escape')
 		},
 		fixable: 'code'
 	}

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -29,7 +29,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('no-hex-escape')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -27,6 +27,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-hex-escape.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -22,6 +22,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-new-buffer.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -25,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('no-new-buffer')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -1,4 +1,6 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
 const inferMethod = args => (args.length > 0 && typeof args[0].value === 'number') ? 'alloc' : 'from';
 
 const create = context => {
@@ -23,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-new-buffer.md'
+			url: getDocsUrl('no-new-buffer')
 		},
 		fixable: 'code'
 	}

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -1,4 +1,5 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 const create = context => {
 	const startsWithHashBang = context.getSourceCode().lines[0].indexOf('#!') === 0;
@@ -39,7 +40,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-process-exit.md'
+			url: getDocsUrl('no-process-exit')
 		}
 	}
 };

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -37,5 +37,9 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-process-exit.md'
+		}
+	}
 };

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -40,7 +40,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('no-process-exit')
+			url: getDocsUrl()
 		}
 	}
 };

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -33,7 +33,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('number-literal-case')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -30,6 +30,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/number-literal-case.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -1,4 +1,6 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
 const fix = value => {
 	if (!/^0[a-zA-Z]/.test(value)) {
 		return value;
@@ -31,7 +33,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/number-literal-case.md'
+			url: getDocsUrl('number-literal-case')
 		},
 		fixable: 'code'
 	}

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -1,4 +1,5 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 const isArrayFrom = node => {
 	const callee = node.callee;
@@ -50,7 +51,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-spread.md'
+			url: getDocsUrl('prefer-spread')
 		},
 		fixable: 'code'
 	}

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -51,7 +51,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('prefer-spread')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -49,6 +49,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-spread.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -1,4 +1,6 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
 const doesNotContain = (string, chars) => chars.every(char => !string.includes(char));
 
 const isSimpleString = string => doesNotContain(
@@ -51,8 +53,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-starts-ends-with.md'
+			url: getDocsUrl('prefer-starts-ends-with')
 		}
 	}
 };
-

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -49,6 +49,10 @@ const create = context => {
 
 module.exports = {
 	create,
-	meta: {}
+	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-starts-ends-with.md'
+		}
+	}
 };
 

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -53,7 +53,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('prefer-starts-ends-with')
+			url: getDocsUrl()
 		}
 	}
 };

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -1,4 +1,5 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 const tcIdentifiers = new Set([
 	'isArguments',
@@ -119,7 +120,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-type-error.md'
+			url: getDocsUrl('prefer-type-error')
 		},
 		fixable: 'code'
 	}

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -120,7 +120,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('prefer-type-error')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -118,6 +118,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-type-error.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -47,7 +47,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('regex-shorthand')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -1,5 +1,6 @@
 'use strict';
 const cleanRegexp = require('clean-regexp');
+const getDocsUrl = require('./utils/get-docs-url');
 
 const message = 'Use regex shorthands to improve readability.';
 
@@ -46,7 +47,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/regex-shorthand.md'
+			url: getDocsUrl('regex-shorthand')
 		},
 		fixable: 'code'
 	}

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -45,6 +45,9 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/regex-shorthand.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -22,7 +22,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl('throw-new-error')
+			url: getDocsUrl()
 		},
 		fixable: 'code'
 	}

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -20,6 +20,9 @@ const create = context => ({
 module.exports = {
 	create,
 	meta: {
+		docs: {
+			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/throw-new-error.md'
+		},
 		fixable: 'code'
 	}
 };

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -1,4 +1,5 @@
 'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
 
 const customError = /^(?:[A-Z][a-z0-9]*)*Error$/;
 
@@ -21,7 +22,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/throw-new-error.md'
+			url: getDocsUrl('throw-new-error')
 		},
 		fixable: 'code'
 	}

--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -1,13 +1,11 @@
 'use strict';
+const {basename} = require('path');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
 
-function getDocsUrl(ruleName, givenCommitHash) {
-	let commitHash = givenCommitHash;
-	if (!commitHash) {
-		commitHash = 'master';
-	}
-	return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`;
-}
+module.exports = function (ruleName, commitHash) {
+	ruleName = ruleName || basename(module.parent.filename).replace('.js', '');
+	commitHash = commitHash || 'master';
 
-module.exports = getDocsUrl;
+	return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`;
+};

--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
 
-module.exports = (ruleName) => {
+module.exports = ruleName => {
 	ruleName = ruleName || path.basename(module.parent.filename, '.js');
 	return `${repoUrl}/blob/master/docs/rules/${ruleName}.md`;
 };

--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -3,9 +3,7 @@ const path = require('path');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
 
-module.exports = (ruleName, commitHash) => {
+module.exports = (ruleName) => {
 	ruleName = ruleName || path.basename(module.parent.filename, '.js');
-	commitHash = commitHash || 'master';
-
-	return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`;
+	return `${repoUrl}/blob/master/docs/rules/${ruleName}.md`;
 };

--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -1,10 +1,10 @@
 'use strict';
-const {basename} = require('path');
+const path = require('path');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
 
-module.exports = function (ruleName, commitHash) {
-	ruleName = ruleName || basename(module.parent.filename).replace('.js', '');
+module.exports = (ruleName, commitHash) => {
+	ruleName = ruleName || path.basename(module.parent.filename, '.js');
 	commitHash = commitHash || 'master';
 
 	return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`;

--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
+
+function getDocsUrl(ruleName, givenCommitHash) {
+	let commitHash = givenCommitHash;
+	if (!commitHash) {
+		commitHash = 'master';
+	}
+	return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`;
+}
+
+module.exports = getDocsUrl;

--- a/test/get-docs-url.js
+++ b/test/get-docs-url.js
@@ -12,3 +12,9 @@ test('returns the URL of the a named rule\'s documentation at a commit hash', t 
 	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/bar/docs/rules/foo.md';
 	t.is(getDocsUrl('foo', 'bar'), url);
 });
+
+test('determines the rule name from the file', t => {
+	t.plan(1);
+	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/get-docs-url.md';
+	t.is(getDocsUrl(), url);
+});

--- a/test/get-docs-url.js
+++ b/test/get-docs-url.js
@@ -1,0 +1,14 @@
+import test from 'ava';
+import getDocsUrl from '../rules/utils/get-docs-url';
+
+test('returns the URL of the a named rule\'s documentation', t => {
+	t.plan(1);
+	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/foo.md';
+	t.is(getDocsUrl('foo'), url);
+});
+
+test('returns the URL of the a named rule\'s documentation at a commit hash', t => {
+	t.plan(1);
+	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/bar/docs/rules/foo.md';
+	t.is(getDocsUrl('foo', 'bar'), url);
+});

--- a/test/get-docs-url.js
+++ b/test/get-docs-url.js
@@ -2,19 +2,16 @@ import test from 'ava';
 import getDocsUrl from '../rules/utils/get-docs-url';
 
 test('returns the URL of the a named rule\'s documentation', t => {
-	t.plan(1);
 	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/foo.md';
 	t.is(getDocsUrl('foo'), url);
 });
 
 test('returns the URL of the a named rule\'s documentation at a commit hash', t => {
-	t.plan(1);
 	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/bar/docs/rules/foo.md';
 	t.is(getDocsUrl('foo', 'bar'), url);
 });
 
 test('determines the rule name from the file', t => {
-	t.plan(1);
 	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/get-docs-url.md';
 	t.is(getDocsUrl(), url);
 });

--- a/test/get-docs-url.js
+++ b/test/get-docs-url.js
@@ -6,11 +6,6 @@ test('returns the URL of the a named rule\'s documentation', t => {
 	t.is(getDocsUrl('foo'), url);
 });
 
-test('returns the URL of the a named rule\'s documentation at a commit hash', t => {
-	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/bar/docs/rules/foo.md';
-	t.is(getDocsUrl('foo', 'bar'), url);
-});
-
 test('determines the rule name from the file', t => {
 	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/get-docs-url.md';
 	t.is(getDocsUrl(), url);


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can know where their documentation is without having to resort to external packages to guess.