### PR TITLE
no-abusive-eslint-disable: Allow specifying rules from a scoped plugin

### DIFF
--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -1,7 +1,7 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const disableRegex = /^eslint-disable(-next-line|-line)?($|(\s+([\w-]+))?)/;
+const disableRegex = /^eslint-disable(-next-line|-line)?($|(\s+(@[\w-]+\/[\w-]+\/)?[\w-]+)?)/;
 
 const create = context => ({
 	Program: node => {

--- a/test/no-abusive-eslint-disable.js
+++ b/test/no-abusive-eslint-disable.js
@@ -22,7 +22,9 @@ ruleTester.run('no-abusive-eslint-disable', rule, {
 		`eval(); //     eslint-disable-line no-eval`,
 		`eval(); //\teslint-disable-line no-eval`,
 		`eval(); /* eslint-disable-line no-eval */`,
-		`eval(); /* eslint-disable-line no-eval */`,
+		`eval(); // eslint-disable-line plugin/rule`,
+		`eval(); // eslint-disable-line @scope/plugin/rule-name`,
+		`eval(); // eslint-disable-line no-eval, @scope/plugin/rule-name`,
 		`eval(); // eslint-line-disable`,
 		`eval(); // some comment`,
 		`foo();
@@ -59,6 +61,14 @@ ruleTester.run('no-abusive-eslint-disable', rule, {
 		},
 		{
 			code: '// eslint-disable-next-line\neval();',
+			errors: [error('Specify the rules you want to disable at line 1:0')]
+		},
+		{
+			code: '// eslint-disable-next-line @scopewithoutplugin\neval();',
+			errors: [error('Specify the rules you want to disable at line 1:0')]
+		},
+		{
+			code: '// eslint-disable-next-line @scope/pluginwithoutrule\neval();',
 			errors: [error('Specify the rules you want to disable at line 1:0')]
 		}
 	]


### PR DESCRIPTION
I noticed that no `no-abusive-eslint-disable` rule mistakenly reported an error when we specify a rule from a scoped plugin.

Example of error:
```js
eval(); // eslint-disable-line @scope/plugin/name
```