### PR TITLE
Use link to tagged version for rule docs

### DIFF
--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -1,9 +1,10 @@
 'use strict';
 const path = require('path');
+const pkg = require('../../package');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
 
 module.exports = ruleName => {
 	ruleName = ruleName || path.basename(module.parent.filename, '.js');
-	return `${repoUrl}/blob/master/docs/rules/${ruleName}.md`;
+	return `${repoUrl}/blob/v${pkg.version}/docs/rules/${ruleName}.md`;
 };

--- a/test/get-docs-url.js
+++ b/test/get-docs-url.js
@@ -1,12 +1,13 @@
 import test from 'ava';
+import pkg from '../package';
 import getDocsUrl from '../rules/utils/get-docs-url';
 
 test('returns the URL of the a named rule\'s documentation', t => {
-	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/foo.md';
+	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${pkg.version}/docs/rules/foo.md`;
 	t.is(getDocsUrl('foo'), url);
 });
 
 test('determines the rule name from the file', t => {
-	const url = 'https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/get-docs-url.md';
+	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${pkg.version}/docs/rules/get-docs-url.md`;
 	t.is(getDocsUrl(), url);
 });


### PR DESCRIPTION
This uses the version present in package.json for generating the URL to rule documentation. I think this is good because the documentation will match the version the user has installed. This way, even if a rule is changed or removed in the future, the user can find the documentation with ease.