### PR TITLE
Do not use module.parent for resolving rule name

### DIFF
--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -115,7 +115,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		schema
 	}

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -132,7 +132,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -91,7 +91,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -56,7 +56,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -154,7 +154,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code',
 		schema

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -116,7 +116,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		schema
 	}

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -26,7 +26,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -67,7 +67,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -32,7 +32,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-array-instanceof.js
+++ b/rules/no-array-instanceof.js
@@ -20,7 +20,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -49,7 +49,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -29,7 +29,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -25,7 +25,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -40,7 +40,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/no-unsafe-regex.js
+++ b/rules/no-unsafe-regex.js
@@ -53,7 +53,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -33,7 +33,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -45,7 +45,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -51,7 +51,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -53,7 +53,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		}
 	}
 };

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -120,7 +120,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -62,7 +62,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -22,7 +22,7 @@ module.exports = {
 	create,
 	meta: {
 		docs: {
-			url: getDocsUrl()
+			url: getDocsUrl(__filename)
 		},
 		fixable: 'code'
 	}

--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -4,7 +4,7 @@ const pkg = require('../../package');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
 
-module.exports = ruleName => {
-	ruleName = ruleName || path.basename(module.parent.filename, '.js');
+module.exports = filename => {
+	const ruleName = path.basename(filename, '.js');
 	return `${repoUrl}/blob/v${pkg.version}/docs/rules/${ruleName}.md`;
 };

--- a/test/get-docs-url.js
+++ b/test/get-docs-url.js
@@ -4,10 +4,10 @@ import getDocsUrl from '../rules/utils/get-docs-url';
 
 test('returns the URL of the a named rule\'s documentation', t => {
 	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${pkg.version}/docs/rules/foo.md`;
-	t.is(getDocsUrl('foo'), url);
+	t.is(getDocsUrl('foo.js'), url);
 });
 
 test('determines the rule name from the file', t => {
 	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${pkg.version}/docs/rules/get-docs-url.md`;
-	t.is(getDocsUrl(), url);
+	t.is(getDocsUrl(__filename), url);
 });


### PR DESCRIPTION
_Note: This is very similar to the PR avajs/eslint-plugin-ava#188, but including the same description just to be through._

`module.parent` is cached after the first `require` and this results in nearly all rules having the URL to `assertion-arguments`. Here's a simple repro:

```js
'use strict';

const { rules } = require('eslint-plugin-unicorn');

const wrongLinks = [];

for (const ruleName of Object.keys(rules)) {
    const rule = rules[ruleName];
    const { url } = rule.meta.docs;
    if (!url.includes(ruleName)) wrongLinks.push(ruleName);
}

console.log(wrongLinks);
```

```
λ node rule-docs-url.js
[ 'custom-error-definition',
  'error-message',
  'escape-case',
  'explicit-length-check',
  'filename-case',
  'import-index',
  'new-for-builtins',
  'no-abusive-eslint-disable',
  'no-array-instanceof',
  'no-fn-reference-in-iterator',
  'no-hex-escape',
  'no-new-buffer',
  'no-process-exit',
  'no-unsafe-regex',
  'number-literal-case',
  'prefer-add-event-listener',
  'prefer-spread',
  'prefer-starts-ends-with',
  'prefer-type-error',
  'regex-shorthand',
  'throw-new-error' ]
```