### PR TITLE
Do not auto-fix prefer-spread in certain cases - fixes #164

### DIFF
--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -12,6 +12,8 @@ const isArrayFrom = node => {
 	);
 };
 
+const isArrayLike = arg => arg && arg.type !== 'ObjectExpression';
+
 const parseArgument = (context, arg) => {
 	if (arg.type === 'Identifier') {
 		return arg.name;
@@ -23,7 +25,7 @@ const parseArgument = (context, arg) => {
 const create = context => {
 	return {
 		CallExpression(node) {
-			if (isArrayFrom(node)) {
+			if (isArrayFrom(node) && isArrayLike(node.arguments[0])) {
 				context.report({
 					node,
 					message: 'Prefer the spread operator over `Array.from()`.',

--- a/test/prefer-spread.js
+++ b/test/prefer-spread.js
@@ -19,7 +19,10 @@ ruleTester.run('prefer-spread', rule, {
 		'Int32Array.from(set);',
 		'Uint32Array.from(set);',
 		'Float32Array.from(set);',
-		'Float64Array.from(set);'
+		'Float64Array.from(set);',
+		'Array.from()',
+		'Array.from({length: 10})',
+		'Array.from({length: 10}, mapFn)'
 	],
 	invalid: [
 		{


### PR DESCRIPTION
This PR fixes #164. Currently, I only check in the `isArrayLike` function if the argument is not of type `ObjectExpression`. I believe that's the best we can do for now because auto-fixing `Array.from(foo);` might be wrong as well if `foo` is an object for instance. As long as we don't have types in JS, we can't do this 100% for sure.