### PR TITLE
Add blacklist to `no-fn-reference-in-iterator` rule to prevent false-positives

### DIFF
--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -46,7 +46,7 @@ const toSelector = name => {
 };
 
 // Select all the call expressions except the ones present in the blacklist
-const selector = `CallExpression${calleeBlacklist.map(toSelector).join('')}`
+const selector = `CallExpression${calleeBlacklist.map(toSelector).join('')}`;
 
 const create = context => ({
 	[selector]: node => {

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -41,7 +41,6 @@ const fix = (context, node) => {
 
 const toSelector = name => {
 	const splitted = name.split('.');
-
 	return `[callee.${'object.'.repeat(splitted.length)}name!="${splitted.shift()}"]`;
 };
 

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -13,12 +13,20 @@ const iteratorMethods = new Map([
 	['reduceRight', 2]
 ]);
 
-const whitelist = new Set([
+const functionWhitelist = new Set([
 	'Boolean'
 ]);
 
+const calleeBlacklist = [
+	'Promise',
+	'React.children',
+	'_',
+	'Async',
+	'async'
+];
+
 const isIteratorMethod = node => node.callee.property && iteratorMethods.has(node.callee.property.name);
-const hasFunctionArgument = node => node.arguments.length > 0 && (node.arguments[0].type === 'Identifier' || node.arguments[0].type === 'CallExpression') && !whitelist.has(node.arguments[0].name);
+const hasFunctionArgument = node => node.arguments.length > 0 && (node.arguments[0].type === 'Identifier' || node.arguments[0].type === 'CallExpression') && !functionWhitelist.has(node.arguments[0].name);
 
 const getNumberOfArguments = node => node.callee.property && iteratorMethods.get(node.callee.property.name);
 const parseArgument = (context, arg) => arg.type === 'Identifier' ? arg.name : context.getSourceCode().getText(arg);
@@ -31,8 +39,17 @@ const fix = (context, node) => {
 	return fixer => fixer.replaceText(arg, `${numberOfArgs === 1 ? argString : `(${argString})`} => ${parseArgument(context, arg)}(${argString})`);
 };
 
+const toSelector = name => {
+	const splitted = name.split('.');
+
+	return `[callee.${'object.'.repeat(splitted.length)}name!="${splitted.shift()}"]`;
+};
+
+// Select all the call expressions except the ones present in the blacklist
+const selector = `CallExpression${calleeBlacklist.map(toSelector).join('')}`
+
 const create = context => ({
-	'CallExpression[callee.object.name!="Promise"]': node => {
+	[selector]: node => {
 		if (isIteratorMethod(node) && hasFunctionArgument(node)) {
 			const arg = node.arguments[0];
 

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -31,7 +31,11 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 		'foo.reduce((a, b) => a + b, 0)',
 		'foo.reduceRight((a, b) => a.concat(b), [])',
 		'Promise.map(fn)',
-		'Promise.forEach(fn)'
+		'Promise.forEach(fn)',
+		'_.map(fn)',
+		'Async.map(list, fn)',
+		'async.map(list, fn)',
+		'React.children.forEach(children, fn)'
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Trying to fix #121. Currently only implemented a blacklist for `Async`, `async`, `_`, `React.children` and `Promise`. It wasn't entirely clear what was meant by 

> We should always ignore methods with more than 1 argument.

Does this mean that if we pass in more than 1 argument to `map`, it shouldn't do anything? Because this might be an issue for `reduce` and `reduceRight`.