### PR TITLE
Add conditional expressions in explicit-length-check rule

### DIFF
--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -136,6 +136,9 @@ const create = context => {
 	return {
 		IfStatement: node => {
 			checkExpression(context, node.test);
+		},
+		ConditionalExpression: node => {
+			checkExpression(context, node.test);
 		}
 	};
 };

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -53,6 +53,7 @@ ruleTester.run('explicit-length-check', rule, {
 		testCase('if (array.length <= 1) {}'),
 		testCase('if (array.length > 1) {}'),
 		testCase('if (array.length < 2) {}'),
+		testCase('const foo = [].length === 0 ? null : undefined'),
 		testCase('array.length', 'not-equal'),
 		testCase('array.length > 0', 'not-equal'),
 		testCase('array.length >= 1', 'not-equal'),
@@ -182,6 +183,11 @@ ruleTester.run('explicit-length-check', rule, {
 			'not-equal',
 			[errorMessages.zeroEqual, errorMessages.nonZeroEqual],
 			'if (array.length === 0 || array.length !== 0) {}'
-		)
+		),
+		testCase(
+			'const foo = [].length ? null : undefined',
+			undefined,
+			[errorMessages.compareToValue]
+		),
 	]
 });


### PR DESCRIPTION
Add ConditionalExpression in the rule `explicit-length-check`, allowing to check this kind of code : 

```js
const foo = [].length === 0 ? null : undefined;
```

Before, only IfStatements where checked.

It does create a breaking change, do you want to add an option for it ?