### PR TITLE
regex-shorthand - Escape backslash and apostrophe

### DIFF
--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -48,10 +48,20 @@ const create = context => {
 			const newPattern = cleanRegexp(oldPattern, flags);
 
 			if (oldPattern !== newPattern) {
+				let fixed;
+				if (hasRegExp) {
+					fixed = `/${newPattern}/`;
+				} else {
+					// Escape backslash and apostrophe because we wrap the result in single quotes.
+					fixed = (newPattern || '').replace(/\\/, '\\\\');
+					fixed = fixed.replace(/'/, '\'');
+					fixed = `'${fixed}'`;
+				}
+
 				context.report({
 					node,
 					message,
-					fix: fixer => fixer.replaceTextRange(args[0].range, hasRegExp ? `/${newPattern}/` : `'${newPattern}'`)
+					fix: fixer => fixer.replaceTextRange(args[0].range, fixed),
 				});
 			}
 		}

--- a/test/regex-shorthand.js
+++ b/test/regex-shorthand.js
@@ -44,7 +44,17 @@ ruleTester.run('regex-shorthand', rule, {
 		{
 			code: `const foo = new RegExp('[0-9]')`,
 			errors: [error],
-			output: `const foo = new RegExp('\\d')`
+			output: `const foo = new RegExp('\\\\d')`
+		},
+		{
+			code: `const foo = new RegExp("[0-9]")`,
+			errors: [error],
+			output: `const foo = new RegExp('\\\\d')`
+		},
+		{
+			code: `const foo = new RegExp("'[0-9]'")`,
+			errors: [error],
+			output: `const foo = new RegExp('\'\\\\d\'')`
 		},
 		{
 			code: 'const foo = /[0-9]/ig',
@@ -54,7 +64,7 @@ ruleTester.run('regex-shorthand', rule, {
 		{
 			code: `const foo = new RegExp('[0-9]', 'ig')`,
 			errors: [error],
-			output: `const foo = new RegExp('\\d', 'ig')`
+			output: `const foo = new RegExp('\\\\d', 'ig')`
 		},
 		{
 			code: 'const foo = /[^0-9]/',


### PR DESCRIPTION
Fixes #178. While I was in there I realized that there was an implicit conversion between `"` and `'` which has another potential escaping issue.
