### PR TITLE
Add prefer-exponentiation-operator rule

### DIFF
--- a/docs/rules/prefer-exponentiation-operator.md
+++ b/docs/rules/prefer-exponentiation-operator.md
@@ -1,6 +1,6 @@
 # Prefer the exponentiation operator over `Math.pow()`
 
-Enforces the use of the exponentiation operator over `Math.pow()`.
+Enforces the use of the [exponentiation operator](http://2ality.com/2016/02/exponentiation-operator.html) over [`Math.pow()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow).
 
 
 ## Fail

--- a/docs/rules/prefer-exponentiation-operator.md
+++ b/docs/rules/prefer-exponentiation-operator.md
@@ -1,0 +1,17 @@
+# Prefer the exponentiation operator over `Math.pow()`
+
+Enforces the use of the exponentiation operator over `Math.pow()`.
+
+
+## Fail
+
+```js
+Math.pow(2, 4);
+```
+
+
+## Pass
+
+```js
+2 ** 4
+```

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ module.exports = {
 				'unicorn/prefer-spread': 'error',
 				'unicorn/error-message': 'error',
 				'unicorn/no-unsafe-regex': 'off',
-				'unicorn/prefer-add-event-listener': 'error'
+				'unicorn/prefer-add-event-listener': 'error',
+				'unicorn/prefer-exponentiation-operator': 'off'
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = {
 				'unicorn/error-message': 'error',
 				'unicorn/no-unsafe-regex': 'off',
 				'unicorn/prefer-add-event-listener': 'error',
-				'unicorn/prefer-exponentiation-operator': 'off'
+				'unicorn/prefer-exponentiation-operator': 'error'
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Configure it in `package.json`.
 - [prefer-add-event-listener](docs/rules/prefer-add-event-listener.md) - Prefer `addEventListener` over `on`-functions. *(fixable)*
  - [prefer-exponentiation-operator](docs/rules/prefer-exponentiation-operator.md) - Prefer the exponentiation operator over `Math.pow()` *(fixable)*
 
+
 ## Recommended config
 
 This plugin exports a [`recommended` config](index.js) that enforces good practices.

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ Configure it in `package.json`.
 - [error-message](docs/rules/error-message.md) - Enforce passing a `message` value when throwing a built-in error.
 - [no-unsafe-regex](docs/rules/no-unsafe-regex.md) - Disallow unsafe regular expressions.
 - [prefer-add-event-listener](docs/rules/prefer-add-event-listener.md) - Prefer `addEventListener` over `on`-functions. *(fixable)*
-
+ - [prefer-exponentiation-operator](docs/rules/prefer-exponentiation-operator.md) - Prefer the exponentiation operator over `Math.pow()` *(fixable)*
 
 ## Recommended config
 

--- a/rules/prefer-exponentiation-operator.js
+++ b/rules/prefer-exponentiation-operator.js
@@ -1,0 +1,52 @@
+'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
+const isMathPow = node => {
+	const {callee} = node;
+	return (
+		callee.type === 'MemberExpression' &&
+		callee.object.type === 'Identifier' &&
+		callee.object.name === 'Math' &&
+		callee.property.type === 'Identifier' &&
+		callee.property.name === 'pow'
+	);
+};
+
+const parseArgument = (context, arg) => {
+	if (arg.type === 'Identifier') {
+		return arg.name;
+	}
+
+	return context.getSourceCode().getText(arg);
+};
+
+const create = context => {
+	return {
+		CallExpression(node) {
+			if (isMathPow(node)) {
+				context.report({
+					node,
+					message: 'Prefer the exponentiation operator over `Math.pow()`.',
+					fix: fixer => {
+						const base = parseArgument(context, node.arguments[0]);
+						const exponent = parseArgument(context, node.arguments[1]);
+
+						const replacement = `${base} ** ${exponent}`;
+
+						return fixer.replaceText(node, replacement);
+					}
+				});
+			}
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {
+			url: getDocsUrl(__filename)
+		},
+		fixable: 'code'
+	}
+};

--- a/rules/prefer-exponentiation-operator.js
+++ b/rules/prefer-exponentiation-operator.js
@@ -20,6 +20,15 @@ const parseArgument = (context, arg) => {
 	return context.getSourceCode().getText(arg);
 };
 
+const fix = (context, node, fixer) => {
+	const base = parseArgument(context, node.arguments[0]);
+	const exponent = parseArgument(context, node.arguments[1]);
+
+	const replacement = `${base} ** ${exponent}`;
+
+	return fixer.replaceText(node, replacement);
+}
+
 const create = context => {
 	return {
 		CallExpression(node) {
@@ -27,14 +36,7 @@ const create = context => {
 				context.report({
 					node,
 					message: 'Prefer the exponentiation operator over `Math.pow()`.',
-					fix: fixer => {
-						const base = parseArgument(context, node.arguments[0]);
-						const exponent = parseArgument(context, node.arguments[1]);
-
-						const replacement = `${base} ** ${exponent}`;
-
-						return fixer.replaceText(node, replacement);
-					}
+					fix: fixer => fix(context, node, fixer),
 				});
 			}
 		}

--- a/test/prefer-exponentiation-operator.js
+++ b/test/prefer-exponentiation-operator.js
@@ -8,6 +8,8 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
+const message = 'Prefer the exponentiation operator over `Math.pow()`.';
+
 ruleTester.run('prefer-exponentiation-operator', rule, {
 	valid: [
 		'a ** b;',
@@ -16,35 +18,35 @@ ruleTester.run('prefer-exponentiation-operator', rule, {
 	invalid: [
 		{
 			code: 'const x = Math.pow(2, 4);',
-			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			errors: [{message}],
 			output: 'const x = 2 ** 4;'
 		},
 		{
 			code: 'const x = Math.pow(-2, (2 - 4) +0 -0.2);',
-			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			errors: [{message}],
 			output: 'const x = -2 ** (2 - 4) +0 -0.2;'
 		},
 		{
 			code: 'const x = Math.pow(Math.pow(2, 4), 8);',
 			errors: [
-				{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1},
-				{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 20, line: 1},
+				{message, column: 11, line: 1},
+				{message, column: 20, line: 1},
 			],
 			output: 'const x = Math.pow(2, 4) ** 8;'
 		},
 		{
 			code: 'const x = Math.pow(2, b);',
-			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			errors: [{message}],
 			output: 'const x = 2 ** b;'
 		},
 		{
 			code: 'const x = Math.pow(c, 4);',
-			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			errors: [{message}],
 			output: 'const x = c ** 4;'
 		},
 		{
 			code: 'const x = Math.pow(foo(), bar());',
-			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			errors: [{message}],
 			output: 'const x = foo() ** bar();'
 		}
 	]

--- a/test/prefer-exponentiation-operator.js
+++ b/test/prefer-exponentiation-operator.js
@@ -1,0 +1,51 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-exponentiation-operator';
+
+const ruleTester = avaRuleTester(test, {
+	parserOptions: {
+		ecmaVersion: 2016
+	}
+});
+
+ruleTester.run('prefer-exponentiation-operator', rule, {
+	valid: [
+		'a ** b;',
+		'2 ** 4;',
+	],
+	invalid: [
+		{
+			code: 'const x = Math.pow(2, 4);',
+			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			output: 'const x = 2 ** 4;'
+		},
+		{
+			code: 'const x = Math.pow(-2, (2 - 4) +0 -0.2);',
+			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			output: 'const x = -2 ** (2 - 4) +0 -0.2;'
+		},
+		{
+			code: 'const x = Math.pow(Math.pow(2, 4), 8);',
+			errors: [
+				{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1},
+				{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 20, line: 1},
+			],
+			output: 'const x = Math.pow(2, 4) ** 8;'
+		},
+		{
+			code: 'const x = Math.pow(2, b);',
+			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			output: 'const x = 2 ** b;'
+		},
+		{
+			code: 'const x = Math.pow(c, 4);',
+			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			output: 'const x = c ** 4;'
+		},
+		{
+			code: 'const x = Math.pow(foo(), bar());',
+			errors: [{message: 'Prefer the exponentiation operator over `Math.pow()`.', column: 11, line: 1}],
+			output: 'const x = foo() ** bar();'
+		}
+	]
+});


### PR DESCRIPTION
Had two questions:

* Should the rule be added to the recommended configuration as `off`?
* Should new rules always be added to the bottom of the rule list in `readme.md`?

Fixes #173.