### PR TITLE
catch-error-name - Support optional catch binding

### DIFF
--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -85,6 +85,11 @@ const create = context => {
 			}
 		},
 		CatchClause: node => {
+			if (!node || !node.param) {
+				push(true);
+				return;
+			}
+
 			if (node.param.name === '_') {
 				push(!astUtils.someContainIdentifier('_', node.body.body));
 				return;

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -85,6 +85,7 @@ const create = context => {
 			}
 		},
 		CatchClause: node => {
+			// Optional catch binding
 			if (!node || !node.param) {
 				push(true);
 				return;

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -120,7 +120,15 @@ ruleTester.run('catch-error-name', rule, {
 					caughtErrorsIgnorePattern: '^skip'
 				}
 			]
-		}
+		},
+		// TODO: Uncomment once test runner supports optional-catch-binding https://github.com/tc39/proposal-optional-catch-binding
+		// testCase(`
+		// 	try {
+		// 		throw new Error('message');
+		// 	} catch {
+		// 		console.log('failed');
+		// 	}
+		// `),
 	],
 	invalid: [
 		testCase('try {} catch (err) {}', null, true),


### PR DESCRIPTION
Fixes #186. The test runner choked on the new syntax and I couldn't figure out exactly what the problem was. My hunch is that either ava or the eslint test runner doesn't support optional catch bindings.

To test the fix, I used `npm link` and ran the scenario from the bug. Pushing `true` was the cleanest way to leave the rest of the code alone.
