### PR TITLE
custom-error-definition - Fix null reference

### DIFF
--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -48,6 +48,10 @@ const customErrorDefinition = (context, node) => {
 		return;
 	}
 
+	if (node.id == null) {
+		return;
+	}
+
 	const {name} = node.id;
 	const className = getClassName(name);
 

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -102,7 +102,15 @@ ruleTester.run('custom-error-definition', rule, {
 					super(error);
 				}
 			};
+		`,
 		`
+			exports.fooError = class extends Error {
+				constructor(error) {
+					super(error);
+					this.name = 'fooError';
+				}
+			};
+		`,
 	],
 	invalid: [
 		{
@@ -348,6 +356,20 @@ ruleTester.run('custom-error-definition', rule, {
 				invalidNameError('FooError')
 			]
 		},
+		// TODO: Uncomment test as part of #190
+		// {
+		// 	code: `
+		// 		exports.fooError = class FooError extends Error {
+		// 			constructor(error) {
+		// 				super(error);
+		// 				this.name = 'FooError';
+		// 			}
+		// 		};
+		// 	`,
+		// 	errors: [
+		// 		invalidNameError('fooError')
+		// 	]
+		// },
 		{
 			code: `
 				exports.FooError = class FooError extends TypeError {

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -95,14 +95,14 @@ ruleTester.run('custom-error-definition', rule, {
 					this.name = 'FooError';
 				}
 			};
+		`,
 		`
-		// `
-		// 	exports.FooError = class extends Error {
-		// 		constructor(error) {
-		// 			super(error);
-		// 		}
-		// 	};
-		// `
+			exports.FooError = class extends Error {
+				constructor(error) {
+					super(error);
+				}
+			};
+		`
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Fixes #150.

I did NOT try to verify that the name used was correct (e.g. `export.FooError` versus `export.foo`). I just fixed the null ref.

As of this PR, these cases will all pass:

```js
exports.fooError = class extends Error {
    constructor(error) {
        super(error);
    }
};

exports.fooError = class extends Error {
    constructor(error) {
        super(error);
        this.name = 'fooError';
    }
};

exports.fooError = class FooError extends Error {
    constructor(error) {
        super(error);
        this.name = 'FooError';
    }
};
```
