### PR TITLE
Add `no-unreadable-array-destructuring` rule

### DIFF
--- a/docs/rules/no-unreadable-array-destructuring.md
+++ b/docs/rules/no-unreadable-array-destructuring.md
@@ -1,6 +1,7 @@
 # Disallow unreadable array destructuring
 
-Destructuring is very useful, but it can also make some code harder to read. This limits the abusive ignoring consecutive values when destructuring from array.
+Destructuring is very useful, but it can also make some code harder to read. This rule prevents ignoring consecutive values when destructuring from an array.
+
 
 ## Fail
 
@@ -11,6 +12,7 @@ const [,,,, foo] = parts;
 const [,,...rest] = parts;
 ```
 
+
 ## Pass
 
 ```js
@@ -20,14 +22,21 @@ const foo = parts[3];
 const [,...rest] = parts;
 ```
 
-## Worth to know
 
-You might have to modify the built-in [prefer-destructuring](https://eslint.org/docs/rules/prefer-destructuring) rule to be compatible with this one. In that case you can do it like this:
+## Note
 
-```js
+You might have to modify the built-in [`prefer-destructuring`](https://eslint.org/docs/rules/prefer-destructuring) rule to be compatible with this one:
+
+```json
 {
-  "rules": {
-    "prefer-destructuring": ["error", {"object": true, "array": false}]
-  }
+	"rules": {
+		"prefer-destructuring": [
+			"error",
+			{
+				"object": true,
+				"array": false
+			}
+		]
+	}
 }
 ```

--- a/docs/rules/no-unreadable-array-destructuring.md
+++ b/docs/rules/no-unreadable-array-destructuring.md
@@ -1,6 +1,6 @@
 # Disallow unreadable array destructuring
 
-Destructuring is very useful, but it can also make some code harder to read.
+Destructuring is very useful, but it can also make some code harder to read. This limits the abusive ignoring consecutive values when destructuring from array.
 
 ## Fail
 
@@ -8,8 +8,8 @@ Destructuring is very useful, but it can also make some code harder to read.
 const [,, foo] = parts;
 const [,,, foo] = parts;
 const [,,,, foo] = parts;
+const [,,...rest] = parts;
 ```
-
 
 ## Pass
 
@@ -17,4 +17,17 @@ const [,,,, foo] = parts;
 const [, foo] = parts;
 const [foo] = parts;
 const foo = parts[3];
+const [,...rest] = parts;
+```
+
+## Worth to know
+
+You might have to modify the built-in [prefer-destructuring](https://eslint.org/docs/rules/prefer-destructuring) rule to be compatible with this one. In that case you can do it like this:
+
+```js
+{
+  "rules": {
+    "prefer-destructuring": ["error", {"object": true, "array": false}]
+  }
+}
 ```

--- a/docs/rules/no-unreadable-array-destructuring.md
+++ b/docs/rules/no-unreadable-array-destructuring.md
@@ -1,0 +1,20 @@
+# Disallow unreadable array destructuring
+
+Destructuring is very useful, but it can also make some code harder to read.
+
+## Fail
+
+```js
+const [,, foo] = parts;
+const [,,, foo] = parts;
+const [,,,, foo] = parts;
+```
+
+
+## Pass
+
+```js
+const [, foo] = parts;
+const [foo] = parts;
+const foo = parts[3];
+```

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
 				'unicorn/filename-case': ['error', {case: 'kebabCase'}],
 				'unicorn/no-abusive-eslint-disable': 'error',
 				'unicorn/no-process-exit': 'error',
+				'unicorn/no-unreadable-array-destructuring': 'error',
 				'unicorn/throw-new-error': 'error',
 				'unicorn/number-literal-case': 'error',
 				'unicorn/escape-case': 'error',

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ module.exports = {
 				'unicorn/filename-case': ['error', {case: 'kebabCase'}],
 				'unicorn/no-abusive-eslint-disable': 'error',
 				'unicorn/no-process-exit': 'error',
-				'unicorn/no-unreadable-array-destructuring': 'error',
 				'unicorn/throw-new-error': 'error',
 				'unicorn/number-literal-case': 'error',
 				'unicorn/escape-case': 'error',
@@ -41,7 +40,8 @@ module.exports = {
 				'unicorn/no-unsafe-regex': 'off',
 				'unicorn/prefer-add-event-listener': 'error',
 				'unicorn/prefer-exponentiation-operator': 'error',
-				'unicorn/no-console-spaces': 'error'
+				'unicorn/no-console-spaces': 'error',
+				'unicorn/no-unreadable-array-destructuring': 'error'
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,6 @@ Configure it in `package.json`.
 			"unicorn/filename-case": ["error", {"case": "kebabCase"}],
 			"unicorn/no-abusive-eslint-disable": "error",
 			"unicorn/no-process-exit": "error",
-			"no-unreadable-array-destructuring": "error",
 			"unicorn/throw-new-error": "error",
 			"unicorn/number-literal-case": "error",
 			"unicorn/escape-case": "error",
@@ -56,7 +55,8 @@ Configure it in `package.json`.
 			"unicorn/error-message": "error",
 			"unicorn/no-unsafe-regex": "off",
 			"unicorn/prefer-add-event-listener": "error",
-			"unicorn/no-console-spaces": "error"
+			"unicorn/no-console-spaces": "error",
+			"no-unreadable-array-destructuring": "error"
 		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ Configure it in `package.json`.
 			"unicorn/filename-case": ["error", {"case": "kebabCase"}],
 			"unicorn/no-abusive-eslint-disable": "error",
 			"unicorn/no-process-exit": "error",
+			"no-unreadable-array-destructuring": "error",
 			"unicorn/throw-new-error": "error",
 			"unicorn/number-literal-case": "error",
 			"unicorn/escape-case": "error",
@@ -85,7 +86,8 @@ Configure it in `package.json`.
 - [error-message](docs/rules/error-message.md) - Enforce passing a `message` value when throwing a built-in error.
 - [no-unsafe-regex](docs/rules/no-unsafe-regex.md) - Disallow unsafe regular expressions.
 - [prefer-add-event-listener](docs/rules/prefer-add-event-listener.md) - Prefer `addEventListener` over `on`-functions. *(fixable)*
- - [prefer-exponentiation-operator](docs/rules/prefer-exponentiation-operator.md) - Prefer the exponentiation operator over `Math.pow()` *(fixable)*
+- [prefer-exponentiation-operator](docs/rules/prefer-exponentiation-operator.md) - Prefer the exponentiation operator over `Math.pow()` *(fixable)*
+- [no-unreadable-array-destructuring](docs/rules/no-unreadable-array-destructuring.md) - Disallow unreadable array destructuring.
 
 
 ## Recommended config

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -1,10 +1,8 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const isCommaFollwedWithComma = (el, index, array) => {
-	if (el === null) {
-		return array[index + 1] === el;
-	}
+const isCommaFollowedWithComma = (el, index, array) => {
+	return el === null && array[index + 1] === null;
 };
 
 const create = context => {
@@ -15,10 +13,10 @@ const create = context => {
 				return;
 			}
 
-			if (elements.some(isCommaFollwedWithComma)) {
+			if (elements.some(isCommaFollowedWithComma)) {
 				context.report({
 					node,
-					message: 'Only one ignored value in series allowed in array destructuring.'
+					message: 'Array destructuring may not contain consecutive ignored values.'
 				});
 			}
 		}

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -1,8 +1,8 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const isCommaFollowedWithComma = (el, index, array) => {
-	return el === null && array[index + 1] === null;
+const isCommaFollowedWithComma = (element, index, array) => {
+	return element === null && array[index + 1] === null;
 };
 
 const create = context => {

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -1,0 +1,35 @@
+'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
+const isCommaFollwedWithComma = (el, index, array) => {
+	if (el === null) {
+		return array[index + 1] === el;
+	}
+};
+
+const create = context => {
+	return {
+		ArrayPattern(node) {
+			const {elements} = node;
+			if (!elements || elements.length === 0) {
+				return;
+			}
+
+			if (elements.some(isCommaFollwedWithComma)) {
+				context.report({
+					node,
+					message: 'Only one ignored value in series allowed in array destructuring.'
+				});
+			}
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {
+			url: getDocsUrl(__filename)
+		}
+	}
+};

--- a/test/no-unreadable-array-destructuring.js
+++ b/test/no-unreadable-array-destructuring.js
@@ -16,24 +16,47 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 		'const [foo,   ,     bar] = parts;',
 		'const [foo,] = parts;',
 		'const [foo,,] = parts;',
-		'const [foo,, bar,, baz] = parts;'
+		'const [foo,, bar,, baz] = parts;',
+		'function foo([, bar]) {}',
+		'function foo([bar]) {}',
+		'function foo([bar,,baz]) {}',
+		'function foo([bar,   ,     baz]) {}',
+		'function foo([bar,]) {}',
+		'function foo([bar,,]) {}',
+		'function foo([bar,, baz,, qux]) {}'
 	],
 	invalid: [
 		{
 			code: 'const [,, foo] = parts;',
-			errors: [{message: 'Only one ignored value in series allowed in array destructuring.'}]
+			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
 		},
 		{
 			code: 'const [foo,,, bar] = parts;',
-			errors: [{message: 'Only one ignored value in series allowed in array destructuring.'}]
+			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
 		},
 		{
 			code: 'const [foo,,,] = parts;',
-			errors: [{message: 'Only one ignored value in series allowed in array destructuring.'}]
+			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
 		},
 		{
 			code: 'const [foo, bar,, baz ,,, qux] = parts;',
-			errors: [{message: 'Only one ignored value in series allowed in array destructuring.'}]
+			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+		},
+		{
+			code: 'function foo([,, bar]) {}',
+			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+		},
+		{
+			code: 'function foo([bar,,, baz]) {}',
+			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+		},
+		{
+			code: 'function foo([bar,,,]) {}',
+			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+		},
+		{
+			code: 'function foo([bar, baz,, qux ,,, quux]) {}',
+			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
 		}
 	]
 });

--- a/test/no-unreadable-array-destructuring.js
+++ b/test/no-unreadable-array-destructuring.js
@@ -8,6 +8,8 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
+const errors = [{message: 'Array destructuring may not contain consecutive ignored values.'}];
+
 ruleTester.run('no-unreadable-array-destructuring', rule, {
 	valid: [
 		'const [, foo] = parts;',
@@ -23,40 +25,45 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 		'function foo([bar,   ,     baz]) {}',
 		'function foo([bar,]) {}',
 		'function foo([bar,,]) {}',
-		'function foo([bar,, baz,, qux]) {}'
+		'function foo([bar,, baz,, qux]) {}',
+		'const [, ...rest] = parts;'
 	],
 	invalid: [
 		{
 			code: 'const [,, foo] = parts;',
-			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+			errors
 		},
 		{
 			code: 'const [foo,,, bar] = parts;',
-			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+			errors
 		},
 		{
 			code: 'const [foo,,,] = parts;',
-			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+			errors
 		},
 		{
 			code: 'const [foo, bar,, baz ,,, qux] = parts;',
-			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+			errors
 		},
 		{
 			code: 'function foo([,, bar]) {}',
-			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+			errors
 		},
 		{
 			code: 'function foo([bar,,, baz]) {}',
-			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+			errors
 		},
 		{
 			code: 'function foo([bar,,,]) {}',
-			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+			errors
 		},
 		{
 			code: 'function foo([bar, baz,, qux ,,, quux]) {}',
-			errors: [{message: 'Array destructuring may not contain consecutive ignored values.'}]
+			errors
+		},
+		{
+			code: 'const [,,...rest] = parts;',
+			errors
 		}
 	]
 });

--- a/test/no-unreadable-array-destructuring.js
+++ b/test/no-unreadable-array-destructuring.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-unreadable-array-destructuring';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+ruleTester.run('no-unreadable-array-destructuring', rule, {
+	valid: [
+		'const [, foo] = parts;',
+		'const [foo] = parts;',
+		'const [foo,,bar] = parts;',
+		'const [foo,   ,     bar] = parts;',
+		'const [foo,] = parts;',
+		'const [foo,,] = parts;',
+		'const [foo,, bar,, baz] = parts;'
+	],
+	invalid: [
+		{
+			code: 'const [,, foo] = parts;',
+			errors: [{message: 'Only one ignored value in series allowed in array destructuring.'}]
+		},
+		{
+			code: 'const [foo,,, bar] = parts;',
+			errors: [{message: 'Only one ignored value in series allowed in array destructuring.'}]
+		},
+		{
+			code: 'const [foo,,,] = parts;',
+			errors: [{message: 'Only one ignored value in series allowed in array destructuring.'}]
+		},
+		{
+			code: 'const [foo, bar,, baz ,,, qux] = parts;',
+			errors: [{message: 'Only one ignored value in series allowed in array destructuring.'}]
+		}
+	]
+});


### PR DESCRIPTION
At the moment the rule disallows more than one ignored value in series. However I can tune this, I can allow to ignore at most one value at the beginning if you find current behaviour too mild. 
Fixes #197 