### PR TITLE
Make the `catch-error-name` rule fixable in most cases

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -4,6 +4,8 @@ Applies to both `try/catch` clauses and `promise.catch(...)` handlers.
 
 The desired name is configurable, but defaults to `error`.
 
+This rule is fixable unless reported code was destructuring an error.
+
 
 ## Fail
 

--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -4,7 +4,7 @@ Applies to both `try/catch` clauses and `promise.catch(...)` handlers.
 
 The desired name is configurable, but defaults to `error`.
 
-This rule is fixable unless reported code was destructuring an error.
+This rule is fixable unless the reported code was destructuring an error.
 
 
 ## Fail

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -71,9 +71,9 @@ const create = context => {
 					const scope = context.getScope();
 					const variable = scope.set.get(node.name);
 					if (variable) {
-						variable.references.forEach(reference => {
+						for (const reference of variable.references) {
 							fixings.push(fixer.replaceText(reference.identifier, expectedName));
-						});
+						}
 					}
 
 					return fixings;

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -58,10 +58,29 @@ const create = context => {
 		const value = stack.pop();
 
 		if (value !== true && !caughtErrorsIgnorePattern.test(node.name)) {
-			context.report({
+			const expectedName = value || name;
+			const problem = {
 				node,
-				message: `The catch parameter should be named \`${value || name}\`.`
-			});
+				message: `The catch parameter should be named \`${expectedName}\`.`
+			};
+
+			if (node.type === 'Identifier') {
+				problem.fix = fixer => {
+					const fixings = [fixer.replaceText(node, expectedName)];
+
+					const scope = context.getScope();
+					const variable = scope.set.get(node.name);
+					if (variable) {
+						variable.references.forEach(reference => {
+							fixings.push(fixer.replaceText(reference.identifier, expectedName));
+						});
+					}
+
+					return fixings;
+				};
+			}
+
+			context.report(problem);
 		}
 	}
 
@@ -123,6 +142,7 @@ module.exports = {
 		docs: {
 			url: getDocsUrl(__filename)
 		},
+		fixable: 'code',
 		schema
 	}
 };


### PR DESCRIPTION
Fixes #189 (with exception of not fixing a destructuring of an error)