### PR TITLE
Make the `no-abusive-eslint-disable` rule support shorthand syntax

### DIFF
--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -1,7 +1,7 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const disableRegex = /^eslint-disable(-next-line|-line)?($|(\s+(@[\w-]+\/[\w-]+\/)?[\w-]+)?)/;
+const disableRegex = /^eslint-disable(-next-line|-line)?($|(\s+(@[\w-]+\/(?:[\w-]+\/)?)?[\w-]+)?)/;
 
 const create = context => ({
 	Program: node => {

--- a/test/no-abusive-eslint-disable.js
+++ b/test/no-abusive-eslint-disable.js
@@ -25,6 +25,8 @@ ruleTester.run('no-abusive-eslint-disable', rule, {
 		'eval(); // eslint-disable-line plugin/rule',
 		'eval(); // eslint-disable-line @scope/plugin/rule-name',
 		'eval(); // eslint-disable-line no-eval, @scope/plugin/rule-name',
+		'eval(); // eslint-disable-line @scope/rule-name',
+		'eval(); // eslint-disable-line no-eval, @scope/rule-name',
 		'eval(); // eslint-line-disable',
 		'eval(); // some comment',
 		`foo();
@@ -65,10 +67,6 @@ ruleTester.run('no-abusive-eslint-disable', rule, {
 		},
 		{
 			code: '// eslint-disable-next-line @scopewithoutplugin\neval();',
-			errors: [error('Specify the rules you want to disable at line 1:0')]
-		},
-		{
-			code: '// eslint-disable-next-line @scope/pluginwithoutrule\neval();',
 			errors: [error('Specify the rules you want to disable at line 1:0')]
 		}
 	]


### PR DESCRIPTION
This change allows users to use the shorthand notation for rules, like:

```js
// eslint-disable-next-line @typescript-eslint/no-var-requires
```

If a package in a scope uses the name `eslint-plugin`, like [`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin), users can omit the `eslint-plugin` part.
