### PR TITLE
Add `no-unnecessary-polyfills` rule

### DIFF
--- a/docs/rules/no-unnecessary-polyfills.md
+++ b/docs/rules/no-unnecessary-polyfills.md
@@ -1,9 +1,6 @@
 # Enforce the use of built-in methods instead of unnecessary polyfills
 
-Takes node version from `package.json` and warns to use supported built in methods
-instead of using unnecessary polyfills.
-
-The desired name is configurable, but defaults to `error`.
+This rules helps to use existing methods instead of using extra polyfills. 
 
 ## Fail
 
@@ -23,7 +20,7 @@ const objectAssign = require('object-assign');
 ## Pass
 
 package.json
-```json5
+```json
 {
 	"engines": {
 		"node": "<4.0.0"

--- a/docs/rules/no-unnecessary-polyfills.md
+++ b/docs/rules/no-unnecessary-polyfills.md
@@ -11,7 +11,7 @@ package.json
 ```json
 {
 	"engines": {
-		"node": ">8.0.0"
+		"node": ">=8"
 	}
 }
 

--- a/docs/rules/no-unnecessary-polyfills.md
+++ b/docs/rules/no-unnecessary-polyfills.md
@@ -34,3 +34,12 @@ package.json
 ```js
 const assign = require("object-assign"); // passes as Object.assign is not supported
 ```
+
+## Options
+
+By default it takes node version from `package.json`. However you can override
+target node version:
+
+```js
+"unicorn/no-unnecessary-polyfills": ["error", {"targetVersion": "6"}]
+```

--- a/docs/rules/no-unnecessary-polyfills.md
+++ b/docs/rules/no-unnecessary-polyfills.md
@@ -8,7 +8,7 @@ The desired name is configurable, but defaults to `error`.
 ## Fail
 
 package.json
-```json5
+```json
 {
 	"engines": {
 		"node": ">8.0.0"

--- a/docs/rules/no-unnecessary-polyfills.md
+++ b/docs/rules/no-unnecessary-polyfills.md
@@ -1,4 +1,4 @@
-# Enforce to use built in method instead of unnecessary polyfills
+# Enforce the use of built-in methods instead of unnecessary polyfills
 
 Takes node version from `package.json` and warns to use supported built in methods
 instead of using unnecessary polyfills.

--- a/docs/rules/no-unnecessary-polyfills.md
+++ b/docs/rules/no-unnecessary-polyfills.md
@@ -1,0 +1,36 @@
+# Enforce to use built in method instead of unnecessary polyfills
+
+Takes node version from `package.json` and warns to use supported built in methods
+instead of using unnecessary polyfills.
+
+The desired name is configurable, but defaults to `error`.
+
+## Fail
+
+package.json
+```json5
+{
+	"engines": {
+		"node": ">8.0.0"
+	}
+}
+
+```
+```js
+const assign = require("object-assign"); // warns to use built in Object.assign
+```
+
+## Pass
+
+package.json
+```json5
+{
+	"engines": {
+		"node": "<4.0.0"
+	}
+}
+
+```
+```js
+const assign = require("object-assign"); // passes as Object.assign is not supported
+```

--- a/docs/rules/no-unnecessary-polyfills.md
+++ b/docs/rules/no-unnecessary-polyfills.md
@@ -17,7 +17,7 @@ package.json
 
 ```
 ```js
-const assign = require("object-assign"); // warns to use built in Object.assign
+const objectAssign = require('object-assign');
 ```
 
 ## Pass

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = {
 				'unicorn/no-keyword-prefix': 'off',
 				'unicorn/no-new-buffer': 'error',
 				'unicorn/no-process-exit': 'error',
+				'unicorn/no-unnecessary-polyfills': 'error',
 				'unicorn/no-unreadable-array-destructuring': 'error',
 				'unicorn/no-unsafe-regex': 'off',
 				'unicorn/no-unused-properties': 'off',
@@ -53,8 +54,7 @@ module.exports = {
 				'unicorn/prefer-type-error': 'error',
 				'unicorn/prevent-abbreviations': 'error',
 				'unicorn/regex-shorthand': 'error',
-				'unicorn/throw-new-error': 'error',
-				'unicorn/no-unnecessary-polyfills': 'error'
+				'unicorn/throw-new-error': 'error'
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ module.exports = {
 				'unicorn/no-unreadable-array-destructuring': 'error',
 				'unicorn/no-unused-properties': 'off',
 				'unicorn/prefer-node-append': 'error',
-				'unicorn/prefer-query-selector': 'error'
+				'unicorn/prefer-query-selector': 'error',
+				'unicorn/no-unnecessary-polyfills': 'error'
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && nyc ava",
+		"test": "nyc ava",
 		"integration": "./test/integration/test.js"
 	},
 	"files": [
@@ -31,7 +31,7 @@
 		"xo"
 	],
 	"dependencies": {
-		"@babel/preset-env": "^7.3.1",
+		"@babel/preset-env": "^7.5.5",
 		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.0.0",
 		"import-modules": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"xo"
 	],
 	"dependencies": {
+		"@babel/preset-env": "^7.3.1",
 		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.0.0",
 		"import-modules": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
 		"lodash.kebabcase": "^4.0.1",
 		"lodash.snakecase": "^4.0.1",
 		"lodash.upperfirst": "^4.2.0",
-		"node-compat-table": "williamkapke/node-compat-table",
-		"read-pkg": "^4.0.1",
 		"read-pkg-up": "^4.0.0",
 		"safe-regex": "^2.0.1",
 		"semver": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"reserved-words": "^0.1.2",
 		"read-pkg-up": "^4.0.0",
 		"safe-regex": "^2.0.2",
-		"semver": "^5.6.0"
+		"semver": "^6.3.0"
 	},
 	"devDependencies": {
 		"ava": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
 		"lodash.kebabcase": "^4.0.1",
 		"lodash.snakecase": "^4.0.1",
 		"lodash.upperfirst": "^4.2.0",
-		"safe-regex": "^2.0.1"
+		"node-compat-table": "williamkapke/node-compat-table",
+		"read-pkg": "^4.0.1",
+		"read-pkg-up": "^4.0.0",
+		"safe-regex": "^2.0.1",
+		"semver": "^5.6.0"
 	},
 	"devDependencies": {
 		"ava": "^1.1.0",

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ Configure it in `package.json`.
 			"unicorn/no-keyword-prefix": "off",
 			"unicorn/no-new-buffer": "error",
 			"unicorn/no-process-exit": "error",
+			"unicorn/no-unnecessary-polyfills": "error",
 			"unicorn/no-unreadable-array-destructuring": "error",
 			"unicorn/no-unsafe-regex": "off",
 			"unicorn/no-unused-properties": "off",
@@ -97,6 +98,7 @@ Configure it in `package.json`.
 - [no-keyword-prefix](docs/rules/no-keyword-prefix.md) - Disallow identifiers starting with `new` or `class`.
 - [no-new-buffer](docs/rules/no-new-buffer.md) - Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`. *(fixable)*
 - [no-process-exit](docs/rules/no-process-exit.md) - Disallow `process.exit()`.
+- [no-unnecessary-polyfills](docs/rules/no-unnecessary-polyfills.md) - Enforce the use of built-in methods instead of unnecessary polyfills.
 - [no-unreadable-array-destructuring](docs/rules/no-unreadable-array-destructuring.md) - Disallow unreadable array destructuring.
 - [no-unsafe-regex](docs/rules/no-unsafe-regex.md) - Disallow unsafe regular expressions.
 - [no-unused-properties](docs/rules/no-unused-properties.md) - Disallow unused object properties.

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -1,122 +1,115 @@
-'use strict';
-const semver = require('semver');
-const readPkgUp = require('read-pkg-up');
-const builtIns = require('@babel/preset-env/data/built-ins');
-const getDocsUrl = require('./utils/get-docs-url');
+'use strict'
+const semver = require('semver')
+const readPkgUp = require('read-pkg-up')
+const compatTable = require('@babel/preset-env/data/built-ins.json')
+const getDocsUrl = require('./utils/get-docs-url')
+const upperfirst = require('lodash.upperfirst')
+const camelcase = require('lodash.camelcase')
 
 function isRequireCall(node) {
-	return node.callee.name === 'require';
+  return node.callee.name === 'require'
 }
 
 function getVersionFromPkg(cwd) {
-	const pkg = readPkgUp.sync({cwd});
-	return pkg && pkg.pkg.engines && pkg.pkg.engines.node;
+  const pkg = readPkgUp.sync({ cwd })
+  return pkg && pkg.pkg.engines && pkg.pkg.engines.node
 }
 
-const compatTable = Object.keys(builtIns).reduce((current, feature) =>
-	Object.assign(current, {[feature.split('.').slice(1).join('.')]: builtIns[feature]})
-, {});
-
 function isValidVersion(version) {
-	return /^[\d.]+$/.test(version.trim());
+  return /^[\d.]+$/.test(version.trim())
+}
+
+const polyfills = {
+  'es6.promise': [ 'promise-polyfill' ],
+  'es7.promise.finally': [ 'p-finally' ],
 }
 
 const polyfillMap = Object.keys(compatTable).reduce((current, name) => {
-	const polyfills = [];
-	const parts = name.split('.');
-	const allParts = name.split(/[.-]/);
+  let [ ecmaVersion, constructorName, methodName = '' ] = name.split('.')
 
-	function dotted(parts) {
-		return parts.join('.');
-	}
+  constructorName = `(${constructorName}|${camelcase(constructorName)})`
+  methodName = `(${methodName}|${camelcase(methodName)})`
 
-	function dashed(parts) {
-		return parts.join('-');
-	}
+  const prefixes = '(mdn-polyfills|polyfill-|core-js(-pure)?/features/|)'
+  const suffixes = '(-polyfill|)'
+  const delimiter = '(\\.|-|\.prototype\.|/|)'
 
-	function joined(parts) {
-		return parts.join('');
-	}
+  const polyfill = polyfills[ name ]
 
-	function addPrototype(parts) {
-		const clone = parts.slice();
-		clone.splice(1, 0, 'prototype');
-		return clone;
-	}
+  current.push({
+    feature: name,
+    polyfillRegex: new RegExp(`^${prefixes}(` + `${ecmaVersion}${delimiter}${constructorName}${delimiter}${methodName}` + '|' + `${constructorName}${delimiter}${methodName}` + '|' + `${ecmaVersion}${delimiter}${constructorName}` + '|' + methodName +  '|' + (polyfill ? `(${polyfill.join('|')})` : '') + `)${suffixes}$`, 'i'),
+  })
 
-	function allVariants(parts) {
-		return [
-			dotted(parts),
-			joined(parts),
-			dashed(parts),
-			dotted(addPrototype(parts)),
-			dashed(addPrototype(parts)),
-			joined(addPrototype(parts))
-		];
-	}
+  return current
+}, [])
 
-	polyfills.push(name);
+function formatErrorMessage(featureName) {
+  const [ _ecmaVersion, namespace, method ] = featureName.split('.')
 
-	polyfills.push(...allVariants(parts));
-	polyfills.push(...allVariants(allParts));
-
-	polyfills.push(`mdn-polyfills/${dotted(addPrototype(parts))}`);
-	polyfills.push(`${dashed(parts)}-polyfill`);
-	polyfills.push(`polyfill-${dashed(parts)}`);
-
-	current.push({
-		feature: name,
-		polyfills
-	});
-
-	return current;
-}, []);
+  return `Use the built-in \`${method ? `${upperfirst(namespace)}#${camelcase(method)}` : `${upperfirst(namespace)}`}\`.`
+}
 
 function processRule(context, node, moduleName, targetVersion) {
-	const polyfill = polyfillMap.find(({polyfills}) => polyfills.includes(moduleName));
+  const polyfill = polyfillMap.find(({ polyfillRegex }) => polyfillRegex.test(moduleName))
 
-	if (polyfill) {
-		const feature = compatTable[polyfill.feature];
-		const supportedNodeVersion = semver.valid(semver.coerce(feature.node));
-		const validRangeTargetVersion = semver.validRange(targetVersion).replace('=', '');
-		const validTargetVersion = isValidVersion(targetVersion) && semver.valid(semver.coerce(targetVersion));
+  if (polyfill) {
+    const feature = compatTable[ polyfill.feature ]
+    const supportedNodeVersion = semver.valid(semver.coerce(feature.node))
+    const validRangeTargetVersion = semver.validRange(targetVersion).replace('=', '')
+    const validTargetVersion = isValidVersion(targetVersion) && semver.valid(semver.coerce(targetVersion))
 
-		if (validTargetVersion) {
-			if (semver.lte(supportedNodeVersion, validTargetVersion)) {
-				context.report({
-					node,
-					message: `Use built in ${polyfill.feature}`
-				});
-			}
-		} else if (semver.ltr(supportedNodeVersion, validRangeTargetVersion)) {
-			context.report({
-				node,
-				message: `Use built in ${polyfill.feature}`
-			});
-		}
-	}
+    if (validTargetVersion) {
+      if (semver.lte(supportedNodeVersion, validTargetVersion)) {
+        context.report({
+          node,
+          message: formatErrorMessage(polyfill.feature),
+        })
+      }
+    } else if (semver.ltr(supportedNodeVersion, validRangeTargetVersion)) {
+      context.report({
+        node,
+        message: formatErrorMessage(polyfill.feature),
+      })
+    }
+  }
 }
 
 const create = context => {
-	const options = context.options[0];
-	const targetVersion = (options && options.targetVersion) || getVersionFromPkg(context.getFilename());
-	return {
-		CallExpression: node => {
-			if (targetVersion && isRequireCall(node)) {
-				const arg0 = node.arguments[0];
-				const moduleName = arg0.value;
-				processRule(context, node, moduleName, targetVersion);
-			}
-		},
-		ImportDeclaration: node => targetVersion && processRule(context, node, node.source.value, targetVersion)
-	};
-};
+  const options = context.options[ 0 ]
+  const targetVersion = (options && options.targetVersion) || getVersionFromPkg(context.getFilename())
+
+  if (!targetVersion) {
+    return {}
+  }
+
+  return {
+    CallExpression: node => {
+      if (isRequireCall(node)) {
+        const moduleName = node.arguments[ 0 ].value
+        processRule(context, node, moduleName, targetVersion)
+      }
+    },
+    ImportDeclaration: node => processRule(context, node, node.source.value, targetVersion),
+  }
+}
+
+const schema = [ {
+  type: 'object',
+  properties: {
+    targetVersion: {
+      type: 'string',
+    },
+  },
+} ]
 
 module.exports = {
-	create,
-	meta: {
-		docs: {
-			url: getDocsUrl(__filename)
-		}
-	}
-};
+  create,
+  meta: {
+    schema,
+    type: 'suggestion',
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+}

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -42,8 +42,6 @@ const polyfillMap = Object.keys(compatTable).reduce((current, name) => {
 		return clone;
 	}
 
-	polyfills.push(name);
-
 	function allVariants(parts) {
 		return [
 			dotted(parts),
@@ -54,6 +52,8 @@ const polyfillMap = Object.keys(compatTable).reduce((current, name) => {
 			joined(addPrototype(parts))
 		];
 	}
+
+	polyfills.push(name);
 
 	polyfills.push(...allVariants(parts));
 	polyfills.push(...allVariants(allParts));

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -1,0 +1,85 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver');
+const readPkgUp = require('read-pkg-up');
+const getDocsUrl = require('./utils/get-docs-url');
+
+const polyfillMap = [
+	{
+		name: 'built-in extensions›Object static methods›Object.assign',
+		original: 'Object.assign',
+		polyfills: ['object-assign']
+	}
+];
+
+function getCompatValues(nodeVersion) {
+	const compats = require(`node-compat-table/results/v8/${nodeVersion}`);
+	return Object
+		.values(compats)
+		.reduce((current, val) => {
+			if (typeof val !== 'object') {
+				return current;
+			}
+
+			return Object.assign(current, val);
+		}, {});
+}
+
+function isRequireCall(node) {
+	return node.callee.name === 'require';
+}
+
+function getTargetVersion() {
+	const pkg = readPkgUp.sync();
+	return pkg && pkg.pkg.engines && pkg.pkg.engines.node;
+}
+
+function getCompatVersions() {
+	const nodeCompatTablePath = path.dirname(require.resolve('node-compat-table/build'));
+	return fs
+		.readdirSync(
+			path.join(nodeCompatTablePath, 'results/v8')
+		)
+		.map(dir => dir.replace('.json', ''))
+		.filter(dir => semver.valid(dir) && !dir.includes('--'))
+		.sort(semver.compare);
+}
+
+const engineVersion = getTargetVersion();
+
+let version;
+let compatValues;
+
+if (engineVersion) {
+	version = getCompatVersions().find(item => semver.satisfies(item, engineVersion));
+	compatValues = version && getCompatValues(version);
+}
+
+const create = context => {
+	return {
+		CallExpression: node => {
+			if (compatValues && isRequireCall(node)) {
+				const arg0 = node.arguments[0];
+				const moduleName = arg0.value;
+				const polyfill = polyfillMap.find(({polyfills}) => polyfills.includes(moduleName));
+
+				if (polyfill && compatValues[polyfill.name] === true) {
+					context.report({
+						node,
+						message: `Use built in ${polyfill.original}`
+					});
+				}
+			}
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {
+			url: getDocsUrl(__filename)
+		}
+	}
+};

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -15,10 +15,6 @@ function getVersionFromPkg(cwd) {
 	return pkg && pkg.pkg.engines && pkg.pkg.engines.node;
 }
 
-function isValidVersion(version) {
-	return /^[\d.]+$/.test(version.trim());
-}
-
 const polyfills = {
 	'es6.promise': ['promise-polyfill'],
 	'es7.promise.finally': ['p-finally']
@@ -57,7 +53,7 @@ function processRule(context, node, moduleName, targetVersion) {
 		const feature = compatTable[polyfill.feature];
 		const supportedNodeVersion = semver.valid(semver.coerce(feature.node));
 		const validRangeTargetVersion = semver.validRange(targetVersion).replace('=', '');
-		const validTargetVersion = isValidVersion(targetVersion) && semver.valid(semver.coerce(targetVersion));
+		const validTargetVersion = semver.minVersion(targetVersion);
 
 		if (validTargetVersion) {
 			if (semver.lte(supportedNodeVersion, validTargetVersion)) {

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -23,15 +23,15 @@ const polyfillMap = Object.keys(compatTable).reduce((current, name) => {
 	const parts = name.split('.');
 	const allParts = name.split(/[.-]/);
 
-	function dotted() {
+	function dotted(parts) {
 		return parts.join('.');
 	}
 
-	function dashed() {
+	function dashed(parts) {
 		return parts.join('-');
 	}
 
-	function joined() {
+	function joined(parts) {
 		return parts.join('');
 	}
 
@@ -74,9 +74,13 @@ function processRule(context, node, moduleName, targetVersion) {
 
 	if (polyfill) {
 		const feature = compatTable[polyfill.feature];
-		const supportedNodeVersion = feature.node;
+		const supportedNodeVersion = semver.valid(semver.coerce(feature.node));
+		const semverTargetVersion = semver.valid(semver.coerce(targetVersion));
 
-		if (semver.satisfies(semver.coerce(supportedNodeVersion), targetVersion)) {
+		if (
+			semver.satisfies(supportedNodeVersion, targetVersion) ||
+			semver.lt(supportedNodeVersion, semverTargetVersion)
+		) {
 			context.report({
 				node,
 				message: `Use built in ${polyfill.feature}`

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -22,15 +22,45 @@ const compatTable = Object.keys(builtIns).reduce((current, feature) => ({
 const polyfillMap = Object.keys(compatTable).reduce((current, name) => {
 	const polyfills = [];
 	const parts = name.split('.');
-	const dashedName = parts.join('-');
-	const nameWithPrototype = parts.slice().splice(1, 0, 'prototype');
+	const allParts = name.split(/[.-]/);
+
+	function dotted() {
+		return parts.join('.');
+	}
+
+	function dashed() {
+		return parts.join('-');
+	}
+
+	function joined() {
+		return parts.join('');
+	}
+
+	function addPrototype(parts) {
+		const clone = parts.slice();
+		clone.splice(1, 0, 'prototype');
+		return clone;
+	}
 
 	polyfills.push(name);
-	polyfills.push(dashedName);
-	polyfills.push(nameWithPrototype);
-	polyfills.push(`mdn-polyfills/${nameWithPrototype}`);
-	polyfills.push(`${dashedName}-polyfill`);
-	polyfills.push(`polyfill-${dashedName}`);
+
+	function allVariants(parts) {
+		return [
+			dotted(parts),
+			joined(parts),
+			dashed(parts),
+			dotted(addPrototype(parts)),
+			dashed(addPrototype(parts)),
+			joined(addPrototype(parts))
+		];
+	}
+
+	polyfills.push(...allVariants(parts));
+	polyfills.push(...allVariants(allParts));
+
+	polyfills.push(`mdn-polyfills/${dotted(addPrototype(parts))}`);
+	polyfills.push(`${dashed(parts)}-polyfill`);
+	polyfills.push(`polyfill-${dashed(parts)}`);
 
 	current.push({
 		feature: name,

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -90,14 +90,16 @@ const create = context => {
 	};
 };
 
-const schema = [{
-	type: 'object',
-	properties: {
-		targetVersion: {
-			type: 'string'
+const schema = [
+	{
+		type: 'object',
+		properties: {
+			targetVersion: {
+				type: 'string'
+			}
 		}
 	}
-}];
+];
 
 module.exports = {
 	create,

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -9,7 +9,7 @@ function isRequireCall(node) {
 }
 
 function getVersionFromPkg(cwd) {
-	const pkg = readPkgUp.sync({ cwd });
+	const pkg = readPkgUp.sync({cwd});
 	return pkg && pkg.pkg.engines && pkg.pkg.engines.node;
 }
 

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -1,115 +1,115 @@
-'use strict'
-const semver = require('semver')
-const readPkgUp = require('read-pkg-up')
-const compatTable = require('@babel/preset-env/data/built-ins.json')
-const getDocsUrl = require('./utils/get-docs-url')
-const upperfirst = require('lodash.upperfirst')
-const camelcase = require('lodash.camelcase')
+'use strict';
+const semver = require('semver');
+const readPkgUp = require('read-pkg-up');
+const compatTable = require('@babel/preset-env/data/built-ins.json');
+const upperfirst = require('lodash.upperfirst');
+const camelcase = require('lodash.camelcase');
+const getDocsUrl = require('./utils/get-docs-url');
 
 function isRequireCall(node) {
-  return node.callee.name === 'require'
+	return node.callee.name === 'require';
 }
 
 function getVersionFromPkg(cwd) {
-  const pkg = readPkgUp.sync({ cwd })
-  return pkg && pkg.pkg.engines && pkg.pkg.engines.node
+	const pkg = readPkgUp.sync({cwd});
+	return pkg && pkg.pkg.engines && pkg.pkg.engines.node;
 }
 
 function isValidVersion(version) {
-  return /^[\d.]+$/.test(version.trim())
+	return /^[\d.]+$/.test(version.trim());
 }
 
 const polyfills = {
-  'es6.promise': [ 'promise-polyfill' ],
-  'es7.promise.finally': [ 'p-finally' ],
-}
+	'es6.promise': ['promise-polyfill'],
+	'es7.promise.finally': ['p-finally']
+};
 
 const polyfillMap = Object.keys(compatTable).reduce((current, name) => {
-  let [ ecmaVersion, constructorName, methodName = '' ] = name.split('.')
+	let [ecmaVersion, constructorName, methodName = ''] = name.split('.');
 
-  constructorName = `(${constructorName}|${camelcase(constructorName)})`
-  methodName = `(${methodName}|${camelcase(methodName)})`
+	constructorName = `(${constructorName}|${camelcase(constructorName)})`;
+	methodName = `(${methodName}|${camelcase(methodName)})`;
 
-  const prefixes = '(mdn-polyfills|polyfill-|core-js(-pure)?/features/|)'
-  const suffixes = '(-polyfill|)'
-  const delimiter = '(\\.|-|\.prototype\.|/|)'
+	const prefixes = '(mdn-polyfills|polyfill-|core-js(-pure)?/features/|)';
+	const suffixes = '(-polyfill|)';
+	const delimiter = '(\\.|-|\\.prototype\\.|/|)';
 
-  const polyfill = polyfills[ name ]
+	const polyfill = polyfills[name];
 
-  current.push({
-    feature: name,
-    polyfillRegex: new RegExp(`^${prefixes}(` + `${ecmaVersion}${delimiter}${constructorName}${delimiter}${methodName}` + '|' + `${constructorName}${delimiter}${methodName}` + '|' + `${ecmaVersion}${delimiter}${constructorName}` + '|' + methodName +  '|' + (polyfill ? `(${polyfill.join('|')})` : '') + `)${suffixes}$`, 'i'),
-  })
+	current.push({
+		feature: name,
+		polyfillRegex: new RegExp(`^${prefixes}(${ecmaVersion}${delimiter}${constructorName}${delimiter}${methodName}|${constructorName}${delimiter}${methodName}|${ecmaVersion}${delimiter}${constructorName}|${methodName}|${(polyfill ? `(${polyfill.join('|')})` : '')})${suffixes}$`, 'i')
+	});
 
-  return current
-}, [])
+	return current;
+}, []);
 
 function formatErrorMessage(featureName) {
-  const [ _ecmaVersion, namespace, method ] = featureName.split('.')
+	const [, namespace, method] = featureName.split('.');
 
-  return `Use the built-in \`${method ? `${upperfirst(namespace)}#${camelcase(method)}` : `${upperfirst(namespace)}`}\`.`
+	return `Use the built-in \`${method ? `${upperfirst(namespace)}#${camelcase(method)}` : `${upperfirst(namespace)}`}\`.`;
 }
 
 function processRule(context, node, moduleName, targetVersion) {
-  const polyfill = polyfillMap.find(({ polyfillRegex }) => polyfillRegex.test(moduleName))
+	const polyfill = polyfillMap.find(({polyfillRegex}) => polyfillRegex.test(moduleName));
 
-  if (polyfill) {
-    const feature = compatTable[ polyfill.feature ]
-    const supportedNodeVersion = semver.valid(semver.coerce(feature.node))
-    const validRangeTargetVersion = semver.validRange(targetVersion).replace('=', '')
-    const validTargetVersion = isValidVersion(targetVersion) && semver.valid(semver.coerce(targetVersion))
+	if (polyfill) {
+		const feature = compatTable[polyfill.feature];
+		const supportedNodeVersion = semver.valid(semver.coerce(feature.node));
+		const validRangeTargetVersion = semver.validRange(targetVersion).replace('=', '');
+		const validTargetVersion = isValidVersion(targetVersion) && semver.valid(semver.coerce(targetVersion));
 
-    if (validTargetVersion) {
-      if (semver.lte(supportedNodeVersion, validTargetVersion)) {
-        context.report({
-          node,
-          message: formatErrorMessage(polyfill.feature),
-        })
-      }
-    } else if (semver.ltr(supportedNodeVersion, validRangeTargetVersion)) {
-      context.report({
-        node,
-        message: formatErrorMessage(polyfill.feature),
-      })
-    }
-  }
+		if (validTargetVersion) {
+			if (semver.lte(supportedNodeVersion, validTargetVersion)) {
+				context.report({
+					node,
+					message: formatErrorMessage(polyfill.feature)
+				});
+			}
+		} else if (semver.ltr(supportedNodeVersion, validRangeTargetVersion)) {
+			context.report({
+				node,
+				message: formatErrorMessage(polyfill.feature)
+			});
+		}
+	}
 }
 
 const create = context => {
-  const options = context.options[ 0 ]
-  const targetVersion = (options && options.targetVersion) || getVersionFromPkg(context.getFilename())
+	const options = context.options[0];
+	const targetVersion = (options && options.targetVersion) || getVersionFromPkg(context.getFilename());
 
-  if (!targetVersion) {
-    return {}
-  }
+	if (!targetVersion) {
+		return {};
+	}
 
-  return {
-    CallExpression: node => {
-      if (isRequireCall(node)) {
-        const moduleName = node.arguments[ 0 ].value
-        processRule(context, node, moduleName, targetVersion)
-      }
-    },
-    ImportDeclaration: node => processRule(context, node, node.source.value, targetVersion),
-  }
-}
+	return {
+		CallExpression: node => {
+			if (isRequireCall(node)) {
+				const moduleName = node.arguments[0].value;
+				processRule(context, node, moduleName, targetVersion);
+			}
+		},
+		ImportDeclaration: node => processRule(context, node, node.source.value, targetVersion)
+	};
+};
 
-const schema = [ {
-  type: 'object',
-  properties: {
-    targetVersion: {
-      type: 'string',
-    },
-  },
-} ]
+const schema = [{
+	type: 'object',
+	properties: {
+		targetVersion: {
+			type: 'string'
+		}
+	}
+}];
 
 module.exports = {
-  create,
-  meta: {
-    schema,
-    type: 'suggestion',
-    docs: {
-      url: getDocsUrl(__filename),
-    },
-  },
-}
+	create,
+	meta: {
+		schema,
+		type: 'suggestion',
+		docs: {
+			url: getDocsUrl(__filename)
+		}
+	}
+};

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -6,13 +6,11 @@ const getDocsUrl = require('./utils/get-docs-url');
 
 const polyfillMap = [
 	{
-		feature: 'es6.object.assign',
-		original: 'Object.assign',
+		feature: 'object.assign',
 		polyfills: ['object-assign']
 	},
 	{
-		feature: 'es6.array.from',
-		original: 'Array.from',
+		feature: 'array.from',
 		polyfills: ['array-from-polyfill']
 	}
 ];
@@ -27,18 +25,22 @@ function getTargetVersion() {
 }
 
 const targetVersion = getTargetVersion();
+const compatTable = Object.keys(builtIns).reduce((current, feature) => ({
+	...current,
+	[feature.split('.').slice(1).join('.')]: builtIns[feature],
+}), {});
 
 function processRule(context, node, moduleName) {
 	const polyfill = polyfillMap.find(({polyfills}) => polyfills.includes(moduleName));
 
 	if (polyfill) {
-		const feature = builtIns[polyfill.feature];
+		const feature = compatTable[polyfill.feature];
 		const supportedNodeVersion = feature.node;
 
 		if (semver.satisfies(semver.coerce(supportedNodeVersion), targetVersion)) {
 			context.report({
 				node,
-				message: `Use built in ${polyfill.original}`
+				message: `Use built in ${polyfill.feature}`
 			});
 		}
 	}

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -13,10 +13,9 @@ function getVersionFromPkg(cwd) {
 	return pkg && pkg.pkg.engines && pkg.pkg.engines.node;
 }
 
-const compatTable = Object.keys(builtIns).reduce((current, feature) => ({
-	...current,
-	[feature.split('.').slice(1).join('.')]: builtIns[feature]
-}), {});
+const compatTable = Object.keys(builtIns).reduce((current, feature) =>
+	Object.assign(current, {[feature.split('.').slice(1).join('.')]: builtIns[feature]})
+, {});
 
 const polyfillMap = Object.keys(compatTable).reduce((current, name) => {
 	const polyfills = [];

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -32,54 +32,114 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 	],
 	invalid: [
 		{
+			code: 'require("setprototypeof")',
+			options: [{targetVersion: '>4'}],
+			errors: [{message: 'Use the built-in `Object#setPrototypeOf`.'}]
+		},{
+			code: 'require("core-js-pure/features/array/from")',
+			options: [{targetVersion: '>7 <8'}],
+			errors: [{message: 'Use the built-in `Array#from`.'}]
+		},
+		{
+			code: 'require("core-js/features/array/from")',
+			options: [{targetVersion: '>7 <8'}],
+			errors: [{message: 'Use the built-in `Array#from`.'}]
+		},
+		{
+			code: 'require("es6-symbol")',
+			options: [{targetVersion: '>7'}],
+			errors: [{message: 'Use the built-in `Symbol`.'}]
+		},
+		{
+			code: 'require("code-point-at")',
+			options: [{targetVersion: '>4'}],
+			errors: [{message: 'Use the built-in `String#codePointAt`.'}]
+		},
+	/*	{
+			code: 'require("util.promisify")',
+			options: [{targetVersion: '>5'}]
+		},*/
+		{
+			code: 'require("object.getownpropertydescriptors")',
+			options: [{targetVersion: '>8'}],
+			errors: [{message: 'Use the built-in `Object#getOwnPropertyDescriptors`.'}]
+		},
+		/*{
+			code: 'require("object.fromentries")',
+			options: [{targetVersion: '>=12'}],
+			errors: [{message: 'Use the built-in `Object#fromEntries`.'}]
+		},*/
+		{
+			code: 'require("string.prototype.padstart")',
+			options: [{targetVersion: '>8'}],
+			errors: [{message: 'Use the built-in `String#padStart`.'}]
+
+		},
+		{
+			code: 'require("p-finally")',
+			options: [{targetVersion: '>10'}],
+			errors: [{message: 'Use the built-in `Promise#finally`.'}]
+
+		},
+		{
+			code: 'require("promise-polyfill")',
+			options: [{targetVersion: '>7'}],
+			errors: [{message: 'Use the built-in `Promise`.'}]
+		},
+		{
+			code: 'require("es6-promise")',
+			options: [{targetVersion: '>7'}],
+			errors: [{message: 'Use the built-in `Promise`.'}]
+		},
+		{
 			code: 'require("object-assign")',
 			options: [{targetVersion: '6'}],
-			errors: [{message: 'Use built in object.assign'}]
+			errors: [{message: 'Use the built-in `Object#assign`.'}]
 		},
 		{
 			code: 'import assign from "object-assign"',
 			options: [{targetVersion: '6'}],
-			errors: [{message: 'Use built in object.assign'}]
+			errors: [{message: 'Use the built-in `Object#assign`.'}]
 		},
 		{
 			code: 'require("object-assign")',
 			options: [{targetVersion: '>6'}],
-			errors: [{message: 'Use built in object.assign'}]
+			errors: [{message: 'Use the built-in `Object#assign`.'}]
 		},
 		{
 			code: 'require("object-assign")',
 			options: [{targetVersion: '8'}],
-			errors: [{message: 'Use built in object.assign'}]
+			errors: [{message: 'Use the built-in `Object#assign`.'}]
 		},
 		{
 			code: 'require("array-from")',
 			options: [{targetVersion: '>7 <8'}],
-			errors: [{message: 'Use built in array.from'}]
+			errors: [{message: 'Use the built-in `Array#from`.'}]
 		},
 		{
 			code: 'require("array.prototype.every")',
 			options: [{targetVersion: '~4.0.0'}],
-			errors: [{message: 'Use built in array.every'}]
+			errors: [{message: 'Use the built-in `Array#every`.'}]
 		},
 		{
 			code: 'require("array-find-index")',
 			options: [{targetVersion: '>4.0.0'}],
-			errors: [{message: 'Use built in array.find-index'}]
+			errors: [{message: 'Use the built-in `Array#findIndex`.'}]
 		},
 		{
 			code: 'require("array-find-index")',
 			options: [{targetVersion: '>4'}],
-			errors: [{message: 'Use built in array.find-index'}]
+			errors: [{message: 'Use the built-in `Array#findIndex`.'}]
 		},
 		{
 			code: 'require("array-find-index")',
 			options: [{targetVersion: '>=4 <5.2 || >6.0.0'}],
-			errors: [{message: 'Use built in array.find-index'}]
+			errors: [{message: 'Use the built-in `Array#findIndex`.'}]
 		},
 		{
 			code: 'require("array-find-index")',
 			options: [{targetVersion: '4'}],
-			errors: [{message: 'Use built in array.find-index'}]
+			errors: [{message: 'Use the built-in `Array#findIndex`.'}]
 		}
 	]
 });

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -11,7 +11,7 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-ruleTester.run('no-unreadable-array-destructuring', rule, {
+ruleTester.run('no-unnecessary-polyfills', rule, {
 	valid: [
 
 	],

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -35,7 +35,8 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 			code: 'require("setprototypeof")',
 			options: [{targetVersion: '>4'}],
 			errors: [{message: 'Use the built-in `Object#setPrototypeOf`.'}]
-		},{
+		},
+		{
 			code: 'require("core-js-pure/features/array/from")',
 			options: [{targetVersion: '>7 <8'}],
 			errors: [{message: 'Use the built-in `Array#from`.'}]
@@ -55,20 +56,20 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 			options: [{targetVersion: '>4'}],
 			errors: [{message: 'Use the built-in `String#codePointAt`.'}]
 		},
-	/*	{
+		/*	{
 			code: 'require("util.promisify")',
 			options: [{targetVersion: '>5'}]
-		},*/
+		}, */
 		{
 			code: 'require("object.getownpropertydescriptors")',
 			options: [{targetVersion: '>8'}],
 			errors: [{message: 'Use the built-in `Object#getOwnPropertyDescriptors`.'}]
 		},
-		/*{
+		/* {
 			code: 'require("object.fromentries")',
 			options: [{targetVersion: '>=12'}],
 			errors: [{message: 'Use the built-in `Object#fromEntries`.'}]
-		},*/
+		}, */
 		{
 			code: 'require("string.prototype.padstart")',
 			options: [{targetVersion: '>8'}],

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -28,7 +28,7 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 		{
 			code: 'require("object-assign")',
 			options: [{targetVersion: '>3'}]
-		},
+		}
 	],
 	invalid: [
 		{

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -23,6 +23,10 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 		{
 			code: 'import assign from "object-assign"',
 			errors: [{message: 'Use built in object.assign'}]
+		},
+		{
+			code: 'require("array-from")',
+			errors: [{message: 'Use built in array.from'}]
 		}
 	]
 });

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -16,7 +16,7 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 		{
 			code: 'require("object-assign")',
 			options: [{targetVersion: '0.10'}]
-		},
+		}
 	],
 	invalid: [
 		{

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -13,19 +13,25 @@ const ruleTester = avaRuleTester(test, {
 
 ruleTester.run('no-unnecessary-polyfills', rule, {
 	valid: [
-
+		{
+			code: 'require("object-assign")',
+			options: [{targetVersion: '0.10'}]
+		},
 	],
 	invalid: [
 		{
 			code: 'require("object-assign")',
+			options: [{targetVersion: '6'}],
 			errors: [{message: 'Use built in object.assign'}]
 		},
 		{
 			code: 'import assign from "object-assign"',
+			options: [{targetVersion: '6'}],
 			errors: [{message: 'Use built in object.assign'}]
 		},
 		{
 			code: 'require("array-from")',
+			options: [{targetVersion: '6'}],
 			errors: [{message: 'Use built in array.from'}]
 		}
 	]

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -16,7 +16,19 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 		{
 			code: 'require("object-assign")',
 			options: [{targetVersion: '0.1.0'}]
-		}
+		},
+		{
+			code: 'import assign from "object-assign"',
+			options: [{targetVersion: '0.1.0'}]
+		},
+		{
+			code: 'require("object-assign")',
+			options: [{targetVersion: '<4'}]
+		},
+		{
+			code: 'require("object-assign")',
+			options: [{targetVersion: '>3'}]
+		},
 	],
 	invalid: [
 		{
@@ -30,14 +42,44 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 			errors: [{message: 'Use built in object.assign'}]
 		},
 		{
+			code: 'require("object-assign")',
+			options: [{targetVersion: '>6'}],
+			errors: [{message: 'Use built in object.assign'}]
+		},
+		{
+			code: 'require("object-assign")',
+			options: [{targetVersion: '8'}],
+			errors: [{message: 'Use built in object.assign'}]
+		},
+		{
 			code: 'require("array-from")',
 			options: [{targetVersion: '>7 <8'}],
 			errors: [{message: 'Use built in array.from'}]
 		},
 		{
 			code: 'require("array.prototype.every")',
-			options: [{targetVersion: '4.0.0'}],
+			options: [{targetVersion: '~4.0.0'}],
 			errors: [{message: 'Use built in array.every'}]
+		},
+		{
+			code: 'require("array-find-index")',
+			options: [{targetVersion: '>4.0.0'}],
+			errors: [{message: 'Use built in array.find-index'}]
+		},
+		{
+			code: 'require("array-find-index")',
+			options: [{targetVersion: '>4'}],
+			errors: [{message: 'Use built in array.find-index'}]
+		},
+		{
+			code: 'require("array-find-index")',
+			options: [{targetVersion: '>=4 <5.2 || >6.0.0'}],
+			errors: [{message: 'Use built in array.find-index'}]
+		},
+		{
+			code: 'require("array-find-index")',
+			options: [{targetVersion: '4'}],
+			errors: [{message: 'Use built in array.find-index'}]
 		}
 	]
 });

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -1,0 +1,21 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-unnecessary-polyfills';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+ruleTester.run('no-unreadable-array-destructuring', rule, {
+	valid: [
+
+	],
+	invalid: [
+		{
+			code: 'require("object-assign")',
+			errors: [{message: 'Use built in Object.assign'}]
+		}
+	]
+});

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -15,7 +15,7 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 	valid: [
 		{
 			code: 'require("object-assign")',
-			options: [{targetVersion: '0.10'}]
+			options: [{targetVersion: '0.1.0'}]
 		}
 	],
 	invalid: [
@@ -31,8 +31,13 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 		},
 		{
 			code: 'require("array-from")',
-			options: [{targetVersion: '6'}],
+			options: [{targetVersion: '>7 <8'}],
 			errors: [{message: 'Use built in array.from'}]
+		},
+		{
+			code: 'require("array.prototype.every")',
+			options: [{targetVersion: '4.0.0'}],
+			errors: [{message: 'Use built in array.every'}]
 		}
 	]
 });

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -38,12 +38,12 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 		},
 		{
 			code: 'require("core-js-pure/features/array/from")',
-			options: [{targetVersion: '>7 <8'}],
+			options: [{targetVersion: '>7'}],
 			errors: [{message: 'Use the built-in `Array#from`.'}]
 		},
 		{
 			code: 'require("core-js/features/array/from")',
-			options: [{targetVersion: '>7 <8'}],
+			options: [{targetVersion: '>7'}],
 			errors: [{message: 'Use the built-in `Array#from`.'}]
 		},
 		{
@@ -114,7 +114,7 @@ ruleTester.run('no-unnecessary-polyfills', rule, {
 		},
 		{
 			code: 'require("array-from")',
-			options: [{targetVersion: '>7 <8'}],
+			options: [{targetVersion: '>7'}],
 			errors: [{message: 'Use the built-in `Array#from`.'}]
 		},
 		{

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -5,6 +5,9 @@ import rule from '../rules/no-unnecessary-polyfills';
 const ruleTester = avaRuleTester(test, {
 	env: {
 		es6: true
+	},
+	parserOptions: {
+		sourceType: 'module'
 	}
 });
 
@@ -15,6 +18,10 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 	invalid: [
 		{
 			code: 'require("object-assign")',
+			errors: [{message: 'Use built in Object.assign'}]
+		},
+		{
+			code: 'import assign from "object-assign"',
 			errors: [{message: 'Use built in Object.assign'}]
 		}
 	]

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -18,11 +18,11 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 	invalid: [
 		{
 			code: 'require("object-assign")',
-			errors: [{message: 'Use built in Object.assign'}]
+			errors: [{message: 'Use built in object.assign'}]
 		},
 		{
 			code: 'import assign from "object-assign"',
-			errors: [{message: 'Use built in Object.assign'}]
+			errors: [{message: 'Use built in object.assign'}]
 		}
 	]
 });


### PR DESCRIPTION
This is initial version of `no-unnecessary-polyfills`.

Resolves #36.

Here some todos to complicate:

 - [x] Read `package.json` from installed project
 - [x] Add more polyfills
 - [x] Add optional engine version via options
 - [x] Support for `imports`