### PR TITLE
Add `prefer-better-name` Solves #169

### DIFF
--- a/docs/rules/prefer-better-name.md
+++ b/docs/rules/prefer-better-name.md
@@ -9,7 +9,7 @@ Configuration is done by 2 options `baseRuleset` and `rules`:
 ```js
 {
   "unicorn/prefer-better-name": ["error", {
-    "baseRuleset": "default", // optional, possible values are `default` and `extended`
+    "baseRuleset": "default", // optional, possible values are `default`, `extended` and null(to disable base ruleset)
     "rules": {
       "badName|anotherBadName": "goodName", // sets the rule to change `badName` and `anotherBadName` to `goodName`
       "oneMoreBadName": "anotherGoodName", // sets the rule to change `oneMoreBadName` to `anotherGoodName`

--- a/docs/rules/prefer-better-name.md
+++ b/docs/rules/prefer-better-name.md
@@ -1,19 +1,38 @@
-# Prefer one variables names over the others(configurable). Prefer not to have ambigue names.
+# Prefer one variables names over the others and to not have ambigue names.
 
-Will output errors on all encounters of bad names from ruleset. If the rule is non-ambiguous, it is a fixable error.
+Using abbreviations in code is considered a bad style by some people as abbreviation knowledge is context dependant and not shared by all code writers even in current timeframe, not even speaking about the future. Also, some projects might require to prevent usage of certain words or abbreviations as they might be confusing in project context.
 
-Configuration is done by 2 options, a name of base ruleset and an object containing rules in format:
+This rule is fixable for words and abbreviations deemed non-ambiguous.
+
+## Options
+Configuration is done by 2 options `baseRuleset` and `rules`:
 ```js
 {
-  "badName|anotherBadName": "goodName", // sets the rule to change badName and anotherBadName to goodName
-  "oneMoreBadName": "anotherGoodName", // sets the rule to change oneMoreBadName to anotherGoodName
-  "ambiguousName": "possibleMeaning|anotherPossibleMeaning", // ambiguous name, with hint to what it could mean
-  "mostlyGoodName|aBitGoodName": "", // disables the rules for mostlyGoodName and aBitGoodName
+  "unicorn/prefer-better-name": ["error", {
+    "baseRuleset": "default", // optional, possible values are `default` and `extended`
+    "rules": {
+      "badName|anotherBadName": "goodName", // sets the rule to change `badName` and `anotherBadName` to `goodName`
+      "oneMoreBadName": "anotherGoodName", // sets the rule to change `oneMoreBadName` to `anotherGoodName`
+      "ambiguousName": "possibleMeaning|anotherPossibleMeaning", // `ambiguousName`, hinting it could mean either `possibleMeaning` or `anotherPossibleMeaning`
+      "mostlyGoodName|aBitGoodName": "", // disables the rules for `mostlyGoodName` and `aBitGoodName`
+    }
+  }]
 }
 ```
 
+## Fail (with `default` ruleset)
+```js
+const e = new Error();
+```
+
+## Pass (with `default` ruleset)
+```js
+const error = new Error();
+```
+
 ## Ruleset `default`
-This ruleset consists of following rules:
+
+Consists of following rules:
 ```json
 {
   "err": "error",

--- a/docs/rules/prefer-better-name.md
+++ b/docs/rules/prefer-better-name.md
@@ -1,0 +1,69 @@
+# Prefer one variables names over the others(configurable). Prefer not to have ambigue names.
+
+Will output errors on all encounters of bad names from ruleset. If the rule is non-ambiguous, it is a fixable error.
+
+Configuration is done by 2 options, a name of base ruleset and an object containing rules in format:
+```js
+{
+  "badName|anotherBadName": "goodName", // sets the rule to change badName and anotherBadName to goodName
+  "oneMoreBadName": "anotherGoodName", // sets the rule to change oneMoreBadName to anotherGoodName
+  "ambiguousName": "possibleMeaning|anotherPossibleMeaning", // ambiguous name, with hint to what it could mean
+  "mostlyGoodName|aBitGoodName": "", // disables the rules for mostlyGoodName and aBitGoodName
+}
+```
+
+## Ruleset `default`
+This ruleset consists of following rules:
+```json
+{
+  "err": "error",
+  "cb": "callback",
+  "opts": "options",
+  "str": "string",
+  "obj": "object",
+  "num": "number",
+  "val": "value",
+  "e": "event|error",
+  "el": "element",
+  "req": "request",
+  "res": "response|result",
+  "btn": "button",
+  "msg": "message",
+  "len": "length",
+  "env": "environment",
+  "dev": "development",
+  "prod": "production",
+  "tmp": "temporary",
+  "arg": "argument",
+  "tbl": "table",
+  "db": "database",
+  "ctx": "context",
+  "mod": "module"
+}
+```
+
+## Ruleset `extended`
+
+Consistsof all rules from ruleset `default` plus
+
+```json
+{
+  "elem": "element",
+  "arr": "array",
+  "btn": "button",
+  "msg": "message",
+  "len": "length",
+  "tmp": "temporary",
+  "ans": "answer",
+  "arg": "argument",
+  "rec": "record",
+  "attrs": "attributes",
+  "ns": "namespace",
+  "prop": "property",
+  "ref": "reference",
+  "cmd": "command",
+  "k": "key",
+  "v": "value",
+  "idx": "index"
+}
+```

--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ module.exports = {
 				'unicorn/no-unused-properties': 'off',
 				'unicorn/prefer-node-append': 'error',
 				'unicorn/prefer-query-selector': 'error',
-				'unicorn/prefer-node-remove': 'error'
+				'unicorn/prefer-node-remove': 'error',
+				'unicorn/prefer-better-name': 'off'
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,8 @@ Configure it in `package.json`.
 			"unicorn/no-unused-properties": "off",
 			"unicorn/prefer-node-append": "error",
 			"unicorn/prefer-query-selector": "error",
-			"unicorn/prefer-node-remove": "error"
+			"unicorn/prefer-node-remove": "error",
+			"unicorn/prefer-better-name": "off"
 		}
 	}
 }
@@ -110,6 +111,7 @@ Configure it in `package.json`.
 - [prefer-node-append](docs/rules/prefer-node-append.md) - Prefer `append` over `appendChild`. *(fixable)*
 - [prefer-query-selector](docs/rules/prefer-query-selector.md) - Prefer `querySelector` over `getElementById`, `querySelectorAll` over `getElementsByClassName` and `getElementsByTagName`. *(partly fixable)*
 - [prefer-node-remove](docs/rules/prefer-node-remove.md) - Prefer `remove` over `parentNode.removeChild` and `parentElement.removeChild`. *(fixable)*
+- [prefer-better-name](docs/rules/prefer-better-name.md) - Prefer one variables names over the others(configurable). Prefer not tohave ambigue names. *(partially fixable)*
 
 
 ## Recommended config

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ Configure it in `package.json`.
 - [prefer-node-append](docs/rules/prefer-node-append.md) - Prefer `append` over `appendChild`. *(fixable)*
 - [prefer-query-selector](docs/rules/prefer-query-selector.md) - Prefer `querySelector` over `getElementById`, `querySelectorAll` over `getElementsByClassName` and `getElementsByTagName`. *(partly fixable)*
 - [prefer-node-remove](docs/rules/prefer-node-remove.md) - Prefer `remove` over `parentNode.removeChild` and `parentElement.removeChild`. *(fixable)*
-- [prefer-better-name](docs/rules/prefer-better-name.md) - Prefer one variables names over the others(configurable). Prefer not to have ambigue names. *(partially fixable)*
+- [prefer-better-name](docs/rules/prefer-better-name.md) - Prefer one variables names over the others and to not have ambigue names. *(partially fixable)*
 
 
 ## Recommended config

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ Configure it in `package.json`.
 - [prefer-node-append](docs/rules/prefer-node-append.md) - Prefer `append` over `appendChild`. *(fixable)*
 - [prefer-query-selector](docs/rules/prefer-query-selector.md) - Prefer `querySelector` over `getElementById`, `querySelectorAll` over `getElementsByClassName` and `getElementsByTagName`. *(partly fixable)*
 - [prefer-node-remove](docs/rules/prefer-node-remove.md) - Prefer `remove` over `parentNode.removeChild` and `parentElement.removeChild`. *(fixable)*
-- [prefer-better-name](docs/rules/prefer-better-name.md) - Prefer one variables names over the others(configurable). Prefer not tohave ambigue names. *(partially fixable)*
+- [prefer-better-name](docs/rules/prefer-better-name.md) - Prefer one variables names over the others(configurable). Prefer not to have ambigue names. *(partially fixable)*
 
 
 ## Recommended config

--- a/rules/prefer-better-name.js
+++ b/rules/prefer-better-name.js
@@ -73,7 +73,9 @@ const compileReplaceMap = (rulesetName, additionalRules) => {
 		Object.keys(rules).forEach(fromRule => {
 			let toRule = rules[fromRule];
 
-			if (toRule.includes('|')) {
+			if (toRule === '' || toRule === null || toRule === undefined) {
+				toRule = undefined;
+			} else if (toRule.includes('|')) {
 				toRule = toRule.split('|').map(word => word.trim());
 			}
 

--- a/rules/prefer-better-name.js
+++ b/rules/prefer-better-name.js
@@ -61,7 +61,12 @@ const compileReplaceMap = (rulesetName, additionalRules) => {
 	if (rulesetName === null) {
 		ruleset = [];
 	} else {
-		ruleset = rulesets[rulesetName].slice(0);
+
+		if (rulesets[rulesetName] === undefined) {
+			throw new Error(`unknown ruleset \`${rulesetName}\``);
+		} else {
+			ruleset = rulesets[rulesetName].slice(0);
+		}
 	}
 
 	if (additionalRules !== null && additionalRules !== undefined) {
@@ -84,6 +89,7 @@ const compileReplaceMap = (rulesetName, additionalRules) => {
 			});
 		});
 	});
+	// throw new Error(JSON.stringify(replaceMap));
 	return replaceMap;
 };
 
@@ -100,7 +106,8 @@ const findFreeName = (scope, baseName) => {
 };
 
 const create = context => {
-	const replaceMap = compileReplaceMap(context.options[0], context.options[1]);
+	const options = context.options[1] || {}
+	const replaceMap = compileReplaceMap(options.baseRuleset, options.rules);
 
 	function checkId(node, replaceId, getReferences) {
 		const {name} = node;

--- a/rules/prefer-better-name.js
+++ b/rules/prefer-better-name.js
@@ -1,0 +1,162 @@
+'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
+const defaultRules = {
+	err: 'error',
+	cb: 'callback',
+	opts: 'options',
+	str: 'string',
+	obj: 'object',
+	num: 'number',
+	val: 'value',
+	e: 'event|error',
+	el: 'element',
+	req: 'request',
+	res: 'response|result',
+	btn: 'button',
+	msg: 'message',
+	len: 'length',
+	env: 'environment',
+	dev: 'development',
+	prod: 'production',
+	tmp: 'temporary',
+	arg: 'argument',
+	tbl: 'table',
+	db: 'database',
+	ctx: 'context',
+	mod: 'module'
+};
+
+const extendedRules = {
+	elem: 'element',
+	arr: 'array',
+	btn: 'button',
+	msg: 'message',
+	len: 'length',
+	tmp: 'temporary',
+	ans: 'answer',
+	arg: 'argument',
+	rec: 'record',
+	attrs: 'attributes',
+	ns: 'namespace',
+	prop: 'property',
+	ref: 'reference',
+	cmd: 'command',
+	k: 'key',
+	v: 'value',
+	idx: 'index'
+};
+
+const rulesets = {
+	default: [defaultRules],
+	extended: [defaultRules, extendedRules]
+};
+
+const compileReplaceMap = (rulesetName, additionalRules) => {
+	let ruleset;
+	if (rulesetName === undefined) {
+		rulesetName = 'default';
+	}
+
+	if (rulesetName === null) {
+		ruleset = [];
+	} else {
+		ruleset = rulesets[rulesetName].slice(0);
+	}
+
+	if (additionalRules !== null && additionalRules !== undefined) {
+		ruleset.push(additionalRules);
+	}
+
+	const replaceMap = {};
+	ruleset.forEach(rules => {
+		Object.keys(rules).forEach(fromRule => {
+			let toRule = rules[fromRule];
+
+			if (toRule.includes('|')) {
+				toRule = toRule.split('|').map(word => word.trim());
+			}
+
+			fromRule.split('|').forEach(word => {
+				replaceMap[word.trim()] = toRule;
+			});
+		});
+	});
+	return replaceMap;
+};
+
+const findFreeName = (scope, baseName) => {
+	const variables = scope.variableScope.set;
+	let name = baseName;
+	let index = 0;
+	while (variables.has(name)) {
+		index++;
+		name = baseName + index;
+	}
+
+	return name;
+};
+
+const create = context => {
+	const replaceMap = compileReplaceMap(context.options[0], context.options[1]);
+
+	function checkId(node, replaceId, getReferences) {
+		const {name} = node;
+		let betterName = replaceMap[name];
+		if (betterName !== undefined && betterName !== null) {
+			if (Array.isArray(betterName)) {
+				context.report({
+					node,
+					message: `Name \`${name}\` is ambiguous, is it ${betterName.map(word => `\`${word}\``).join(' or ')} or something else`
+				});
+			} else {
+				betterName = findFreeName(context.getScope(), betterName);
+				context.report({
+					node,
+					fix: fixer => {
+						const fixes = [];
+
+						if (replaceId) {
+							fixes.push(fixer.replaceText(node, betterName));
+						}
+
+						getReferences().forEach(reference => {
+							fixes.push(fixer.replaceText(reference.identifier, betterName));
+						});
+						return fixes;
+					},
+					message: `Prefer \`${betterName}\` over \`${name}\``
+				});
+			}
+		}
+	}
+
+	return {
+		FunctionDeclaration: node => {
+			context.getDeclaredVariables(node).forEach(variable => {
+				checkId(variable.defs[0].name, true, () => variable.references);
+			});
+		},
+		VariableDeclarator: node => {
+			checkId(node.id, false, () => {
+				return context.getDeclaredVariables(node)[0].references;
+			});
+		},
+		CatchClause: node => {
+			checkId(node.param, true, () => {
+				return context.getDeclaredVariables(node)[0].references;
+			});
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		type: 'suggestion',
+		docs: {
+			url: getDocsUrl(__filename)
+		},
+		fixable: 'code'
+	}
+};

--- a/rules/prefer-better-name.js
+++ b/rules/prefer-better-name.js
@@ -60,13 +60,10 @@ const compileReplaceMap = (rulesetName, additionalRules) => {
 
 	if (rulesetName === null) {
 		ruleset = [];
+	} else if (rulesets[rulesetName] === undefined) {
+		throw new Error(`unknown ruleset \`${rulesetName}\``);
 	} else {
-
-		if (rulesets[rulesetName] === undefined) {
-			throw new Error(`unknown ruleset \`${rulesetName}\``);
-		} else {
-			ruleset = rulesets[rulesetName].slice(0);
-		}
+		ruleset = rulesets[rulesetName].slice(0);
 	}
 
 	if (additionalRules !== null && additionalRules !== undefined) {
@@ -89,7 +86,6 @@ const compileReplaceMap = (rulesetName, additionalRules) => {
 			});
 		});
 	});
-	// throw new Error(JSON.stringify(replaceMap));
 	return replaceMap;
 };
 
@@ -106,7 +102,7 @@ const findFreeName = (scope, baseName) => {
 };
 
 const create = context => {
-	const options = context.options[1] || {}
+	const options = context.options[1] || {};
 	const replaceMap = compileReplaceMap(options.baseRuleset, options.rules);
 
 	function checkId(node, replaceId, getReferences) {

--- a/test/prefer-better-name.js
+++ b/test/prefer-better-name.js
@@ -14,7 +14,7 @@ const ruleTester = avaRuleTester(test, {
 const options = {
 	disabled: ['error', {
 		baseRuleset: null,
-		rules: {},
+		rules: {}
 	}],
 	changed: ['error', {
 		baseRuleset: 'default',
@@ -25,7 +25,7 @@ const options = {
 	custom: ['error', {
 		baseRuleset: null,
 		rules: {
-			spider: 'arachnide',
+			spider: 'arachnide'
 		}
 	}]
 };
@@ -34,7 +34,7 @@ const makeAmbiguousError = (name, betterNames) => {
 	return {
 		message: `Name \`${name}\` is ambiguous, is it ${betterNames.map(word => `\`${word}\``).join(' or ')} or something else`
 	};
-}
+};
 
 const makeReplaceError = (name, betterName) => {
 	return {message: `Prefer \`${betterName}\` over \`${name}\``};
@@ -55,13 +55,13 @@ ruleTester.run('prefer-better-name', rule, {
 		},
 		{
 			code: 'let str = 3',
-			options: options.disabled,
+			options: options.disabled
 		}
 	],
 	invalid: [
 		{
-			code: 'let str = "abc"; str+= str; console.log(`${str}`);',
-			output: 'let string = "abc"; string+= string; console.log(`${string}`);',
+			code: 'let str = "abc"; str+= str; console.log(str);',
+			output: 'let string = "abc"; string+= string; console.log(string);',
 			errors: [makeReplaceError('str', 'string')]
 		},
 		{
@@ -75,7 +75,7 @@ ruleTester.run('prefer-better-name', rule, {
 				const error = null;
 				console.log(err);
 			}`,
-			output:`
+			output: `
 			function test(error1){
 				const error = null;
 				console.log(error1);
@@ -98,6 +98,17 @@ ruleTester.run('prefer-better-name', rule, {
 			output: 'let arachnide = {type:"scary"};',
 			options: options.custom,
 			errors: [makeReplaceError('spider', 'arachnide')]
+		},
+		{
+			code: `
+			function test(...err){
+				console.log(err);
+			}`,
+			output: `
+			function test(...error){
+				console.log(error);
+			}`,
+			errors: [makeReplaceError('err', 'error')]
 		}
 	]
 });

--- a/test/prefer-better-name.js
+++ b/test/prefer-better-name.js
@@ -1,0 +1,65 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-better-name';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	},
+	parserOptions: {
+		sourceType: 'module'
+	}
+});
+
+const invalidAmbiguousTestCase = (code, name, betterNames) => {
+	return {
+		code,
+		output: code,
+		errors: [{message: `Name \`${name}\` is ambiguous, is it ${betterNames.map(word => `\`${word}\``).join(' or ')} or something else`}]
+	};
+};
+
+const makeReplaceError = (name, betterName) => {
+	return {message: `Prefer \`${betterName}\` over \`${name}\``};
+};
+
+const invalidReplaceTestCase = (code, output, name, betterName) => {
+	return {
+		code,
+		output,
+		errors: [makeReplaceError(name, betterName)]
+	};
+};
+
+ruleTester.run('prefer-better-name', rule, {
+	valid: [
+		'let error'
+	],
+	invalid: [
+		invalidReplaceTestCase(
+			'let str = "abc"; console.log(str);',
+			'let string = "abc"; console.log(string);',
+			'str',
+			'string'),
+		invalidReplaceTestCase(
+			'try {} catch(err) { throw err; }',
+			'try {} catch(error) { throw error; }',
+			'err',
+			'error'),
+		invalidReplaceTestCase(
+			`function test(err){
+				const error = null;
+				console.log(err);
+			}`,
+			`function test(error1){
+				const error = null;
+				console.log(error1);
+			}`,
+			'err',
+			'error1'),
+		invalidAmbiguousTestCase(
+			'let e;',
+			'e',
+			['event', 'error'])
+	]
+});

--- a/test/prefer-better-name.js
+++ b/test/prefer-better-name.js
@@ -37,8 +37,8 @@ ruleTester.run('prefer-better-name', rule, {
 	],
 	invalid: [
 		invalidReplaceTestCase(
-			'let str = "abc"; console.log(str);',
-			'let string = "abc"; console.log(string);',
+			'let str = "abc"; str+= str; console.log(`${str}`);',
+			'let string = "abc"; string+= string; console.log(`${string}`);',
 			'str',
 			'string'),
 		invalidReplaceTestCase(


### PR DESCRIPTION
I took a freedom to rethink the concept a bit to make the rule more general and usable by more people. It should also help testing various rules before finalizing default rule sets.

Initial rules implemented in `default` rule set, community suggestions implemented in `extended` rule set, but it is also fully configurable for highly specific and differently opinionated use cases.

I also used the name `prefer-better-name` as it seems to suit the rule better.
However, if needed the rule can be reverted to original specification in #169 by changing a couple of names.