### PR TITLE
Add `no-zero-fractions` rule

### DIFF
--- a/docs/rules/no-zero-fractions.md
+++ b/docs/rules/no-zero-fractions.md
@@ -1,6 +1,8 @@
 # Disallow number literals with zero fractions or dangling dots
 
-Disallows number literals with zero fractions or dangling dots, as there is no difference in JS between one having it and one not having it.
+There is no difference in JS between e.g. `1`, `1.0` and `1.`, so prefer the former for consistency.
+
+This rule is fixable.
 
 ## Fail
 

--- a/docs/rules/no-zero-fractions.md
+++ b/docs/rules/no-zero-fractions.md
@@ -1,6 +1,6 @@
 # Disallow number literals with zero fractions or dangling dots
 
-There is no difference in JS between e.g. `1`, `1.0` and `1.`, so prefer the former for consistency.
+There is no difference in JavaScript between, for example, `1`, `1.0` and `1.`, so prefer the former for consistency.
 
 This rule is fixable.
 

--- a/docs/rules/no-zero-fractions.md
+++ b/docs/rules/no-zero-fractions.md
@@ -1,0 +1,25 @@
+# Disallow number literals with zero fractions or dangling dots
+
+Disallows number literals with zero fractions or dangling dots, as there is no difference in JS between one having it and one not having it.
+
+## Fail
+
+```js
+const foo = 1.0;
+const foo = -1.0;
+const foo = 123123123.0;
+const foo = 1.;
+```
+
+
+## Pass
+
+```js
+const foo = 1;
+const foo = -1;
+const foo = 123123123;
+const foo = 1.1;
+const foo = -1.1;
+const foo = 123123123.4;
+const foo = 1e3;
+```

--- a/docs/rules/no-zero-fractions.md
+++ b/docs/rules/no-zero-fractions.md
@@ -11,6 +11,8 @@ const foo = 1.0;
 const foo = -1.0;
 const foo = 123123123.0;
 const foo = 1.;
+const foo = 123.111000000;
+const foo = 123.00e20;
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ module.exports = {
 				'unicorn/prefer-query-selector': 'error',
 				'unicorn/prefer-node-remove': 'error',
 				'unicorn/prefer-text-content': 'error',
-				'unicorn/no-for-loop': 'error'
+				'unicorn/no-for-loop': 'error',
+				'unicorn/no-zero-fractions': 'off'
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = {
 				'unicorn/prefer-node-remove': 'error',
 				'unicorn/prefer-text-content': 'error',
 				'unicorn/no-for-loop': 'error',
-				'unicorn/no-zero-fractions': 'off'
+				'unicorn/no-zero-fractions': 'error'
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
 				'unicorn/no-for-loop': 'error',
 				'unicorn/prevent-abbreviations': 'error',
 				'unicorn/prefer-includes': 'error',
-        'unicorn/no-zero-fractions': 'error'
+				'unicorn/no-zero-fractions': 'error'
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,8 @@ Configure it in `package.json`.
 			"unicorn/prefer-query-selector": "error",
 			"unicorn/prefer-node-remove": "error",
 			"unicorn/prefer-text-content": "error",
-			"unicorn/no-for-loop": "error"
+			"unicorn/no-for-loop": "error",
+			"unicorn/no-zero-fractions": "off"
 		}
 	}
 }
@@ -104,6 +105,7 @@ Configure it in `package.json`.
 - [prefer-node-remove](docs/rules/prefer-node-remove.md) - Prefer `remove` over `parentNode.removeChild` and `parentElement.removeChild`. *(fixable)*
 - [prefer-text-content](docs/rules/prefer-text-content.md) - Prefer `textContent` over `innerText`. *(fixable)*
 - [no-for-loop](docs/rules/no-for-loop.md) - Do not use a `for` loop that can be replaced with a `for-of` loop. *(fixable)*
+- [no-zero-fractions](docs/rules/no-zero-fractions.md) - Disallow number literals with zero fractions or dangling dots. *(fixable)*
 
 
 ## Recommended config

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Configure it in `package.json`.
 			"unicorn/prefer-node-remove": "error",
 			"unicorn/prefer-text-content": "error",
 			"unicorn/no-for-loop": "error",
-			"unicorn/no-zero-fractions": "off"
+			"unicorn/no-zero-fractions": "error"
 		}
 	}
 }

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -1,18 +1,35 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const message = 'Zero fraction or dangling dot in number.';
+const MSG_ZERO_FRACTION = 'Zero fraction in number.';
+const MSG_DANGLING_DOT = 'Dangling dot in number.';
 
-const regexpEndsWithZeroFraction = /\.0*$/;
+// Groups:
+// 1 - integer part
+// 2 - dangling dot or dot with zeroes
+// 3 - dot with digits except last zeroes
+// 4 - scientific notation
+const RE_DANGLINGDOT_OR_ZERO_FRACTIONS = /^([+-]?[0-9]*)(?:(\.0*)|(\.[0-9]*[1-9])0+)(e[+-]?[0-9]+)?$/;
+
 const create = context => {
 	return {
 		Literal: node => {
-			if (typeof node.value === 'number' && node.value % 1 === 0 && regexpEndsWithZeroFraction.test(node.raw)) {
-				context.report({
-					node,
-					message,
-					fix: fixer => fixer.replaceText(node, `${node.value}`)
-				});
+			if (typeof node.value === 'number'){
+				const m = RE_DANGLINGDOT_OR_ZERO_FRACTIONS.exec(node.raw);
+				if(m !== null){
+					const isDanglingDot = m[2] === '.';
+					context.report({
+						node,
+						message: isDanglingDot ? MSG_DANGLING_DOT : MSG_ZERO_FRACTION,
+						fix: fixer => {
+							let wantedStr = (m[2] === undefined) ? m[1]+m[3] : m[1];
+							if(m[4] !== undefined){
+								wantedStr+= m[4];
+							}
+							return fixer.replaceText(node, wantedStr);
+						}
+					});
+				}
 			}
 		}
 	};

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -1,33 +1,34 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const MSG_ZERO_FRACTION = 'Don\'t use a zero fraction in the number.';
-const MSG_DANGLING_DOT = 'Don\'t use a dangling dot in the number.';
+const MESSAGE_ZERO_FRACTION = 'Don\'t use a zero fraction in the number.';
+const MESSAGE_DANGLING_DOT = 'Don\'t use a dangling dot in the number.';
 
 // Groups:
 // 1 - integer part
 // 2 - dangling dot or dot with zeroes
 // 3 - dot with digits except last zeroes
 // 4 - scientific notation
-const RE_DANGLINGDOT_OR_ZERO_FRACTIONS = /^([+-]?\d*)(?:(\.0*)|(\.\d*[1-9])0+)(e[+-]?\d+)?$/;
+const RE_DANGLINGDOT_OR_ZERO_FRACTIONS = /^([+-]?\d*)(?:(\.0*)|(\.\d*[1-9])0+)(e[+-]?\d+)?$/; // TODO Possibly use named capture groups when targeting Node.js 10
 
 const create = context => {
 	return {
 		Literal: node => {
 			if (typeof node.value === 'number') {
-				const m = RE_DANGLINGDOT_OR_ZERO_FRACTIONS.exec(node.raw);
-				if (m !== null) {
-					const isDanglingDot = m[2] === '.';
+				const match = RE_DANGLINGDOT_OR_ZERO_FRACTIONS.exec(node.raw);
+				if (match !== null) {
+					const [, integerPart, dotAndZeroes, dotAndDigits, scientificNotationSuffix] = match;
+					const isDanglingDot = dotAndZeroes === '.';
 					context.report({
 						node,
-						message: isDanglingDot ? MSG_DANGLING_DOT : MSG_ZERO_FRACTION,
+						message: isDanglingDot ? MESSAGE_DANGLING_DOT : MESSAGE_ZERO_FRACTION,
 						fix: fixer => {
-							let wantedStr = (m[2] === undefined) ? m[1] + m[3] : m[1];
-							if (m[4] !== undefined) {
-								wantedStr += m[4];
+							let wantedString = (dotAndZeroes === undefined) ? integerPart + dotAndDigits : integerPart;
+							if (scientificNotationSuffix !== undefined) {
+								wantedString += scientificNotationSuffix;
 							}
 
-							return fixer.replaceText(node, wantedStr);
+							return fixer.replaceText(node, wantedString);
 						}
 					});
 				}

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -5,11 +5,11 @@ const MESSAGE_ZERO_FRACTION = 'Don\'t use a zero fraction in the number.';
 const MESSAGE_DANGLING_DOT = 'Don\'t use a dangling dot in the number.';
 
 // Groups:
-// 1 - integer part
-// 2 - dangling dot or dot with zeroes
-// 3 - dot with digits except last zeroes
-// 4 - scientific notation
-const RE_DANGLINGDOT_OR_ZERO_FRACTIONS = /^([+-]?\d*)(?:(\.0*)|(\.\d*[1-9])0+)(e[+-]?\d+)?$/; // TODO Possibly use named capture groups when targeting Node.js 10
+// 1. Integer part
+// 2. Dangling dot or dot with zeroes
+// 3. Dot with digits except last zeroes
+// 4. Scientific notation
+const RE_DANGLINGDOT_OR_ZERO_FRACTIONS = /^([+-]?\d*)(?:(\.0*)|(\.\d*[1-9])0+)(e[+-]?\d+)?$/; // TODO: Possibly use named capture groups when targeting Node.js 10
 
 const create = context => {
 	return {

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -21,6 +21,7 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
+		type: 'suggestion',
 		docs: {
 			url: getDocsUrl(__filename)
 		},

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -9,23 +9,24 @@ const MSG_DANGLING_DOT = 'Dangling dot in number.';
 // 2 - dangling dot or dot with zeroes
 // 3 - dot with digits except last zeroes
 // 4 - scientific notation
-const RE_DANGLINGDOT_OR_ZERO_FRACTIONS = /^([+-]?[0-9]*)(?:(\.0*)|(\.[0-9]*[1-9])0+)(e[+-]?[0-9]+)?$/;
+const RE_DANGLINGDOT_OR_ZERO_FRACTIONS = /^([+-]?\d*)(?:(\.0*)|(\.\d*[1-9])0+)(e[+-]?\d+)?$/;
 
 const create = context => {
 	return {
 		Literal: node => {
-			if (typeof node.value === 'number'){
+			if (typeof node.value === 'number') {
 				const m = RE_DANGLINGDOT_OR_ZERO_FRACTIONS.exec(node.raw);
-				if(m !== null){
+				if (m !== null) {
 					const isDanglingDot = m[2] === '.';
 					context.report({
 						node,
 						message: isDanglingDot ? MSG_DANGLING_DOT : MSG_ZERO_FRACTION,
 						fix: fixer => {
-							let wantedStr = (m[2] === undefined) ? m[1]+m[3] : m[1];
-							if(m[4] !== undefined){
-								wantedStr+= m[4];
+							let wantedStr = (m[2] === undefined) ? m[1] + m[3] : m[1];
+							if (m[4] !== undefined) {
+								wantedStr += m[4];
 							}
+
 							return fixer.replaceText(node, wantedStr);
 						}
 					});

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -1,8 +1,8 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const MSG_ZERO_FRACTION = 'Zero fraction in number.';
-const MSG_DANGLING_DOT = 'Dangling dot in number.';
+const MSG_ZERO_FRACTION = 'Don\'t use a zero fraction in the number.';
+const MSG_DANGLING_DOT = 'Don\'t use a dangling dot in the number.';
 
 // Groups:
 // 1 - integer part

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -1,0 +1,29 @@
+'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
+const message = 'Zero fraction or dangling dot in number.';
+
+const regexpEndsWithZeroFraction = /\.0*$/;
+const create = context => {
+	return {
+		Literal: node => {
+			if (typeof node.value === 'number' && node.value % 1 === 0 && regexpEndsWithZeroFraction.test(node.raw)) {
+				context.report({
+					node,
+					message,
+					fix: fixer => fixer.replaceText(node, `${node.value}`)
+				});
+			}
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		docs: {
+			url: getDocsUrl(__filename)
+		},
+		fixable: 'code'
+	}
+};

--- a/test/no-zero-fractions.js
+++ b/test/no-zero-fractions.js
@@ -29,18 +29,32 @@ ruleTester.run('no-zero-fractions', rule, {
 	invalid: [
 		{
 			code: 'const foo = 1.0',
+			output: 'const foo = 1',
+			errors: [error]
+		},
+		{
+			code: 'const foo = 1.00',
+			output: 'const foo = 1',
+			errors: [error]
+		},
+		{
+			code: 'const foo = 1.00000',
+			output: 'const foo = 1',
 			errors: [error]
 		},
 		{
 			code: 'const foo = -1.0',
+			output: 'const foo = -1',
 			errors: [error]
 		},
 		{
 			code: 'const foo = 123123123.0',
+			output: 'const foo = 123123123',
 			errors: [error]
 		},
 		{
 			code: 'const foo = 1.',
+			output: 'const foo = 1',
 			errors: [error]
 		}
 	]

--- a/test/no-zero-fractions.js
+++ b/test/no-zero-fractions.js
@@ -11,14 +11,21 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-const error = {
+const errorZeroFraction = {
 	ruleId: 'no-zero-fractions',
-	message: 'Zero fraction or dangling dot in number.'
+	message: 'Zero fraction in number.'
+};
+const errorDanglingDot = {
+	ruleId: 'no-zero-fractions',
+	message: 'Dangling dot in number.'
 };
 
 ruleTester.run('no-zero-fractions', rule, {
 	valid: [
+		'const foo = "123.1000"',
+		'foo("123.1000")',
 		'const foo = 1',
+		'const foo = 1 + 2',
 		'const foo = -1',
 		'const foo = 123123123',
 		'const foo = 1.1',
@@ -30,32 +37,72 @@ ruleTester.run('no-zero-fractions', rule, {
 		{
 			code: 'const foo = 1.0',
 			output: 'const foo = 1',
-			errors: [error]
+			errors: [errorZeroFraction]
+		},
+		{
+			code: 'const foo = 1.0 + 1',
+			output: 'const foo = 1 + 1',
+			errors: [errorZeroFraction]
+		},
+		{
+			code: 'foo(1.0 + 1)',
+			output: 'foo(1 + 1)',
+			errors: [errorZeroFraction]
 		},
 		{
 			code: 'const foo = 1.00',
 			output: 'const foo = 1',
-			errors: [error]
+			errors: [errorZeroFraction]
 		},
 		{
 			code: 'const foo = 1.00000',
 			output: 'const foo = 1',
-			errors: [error]
+			errors: [errorZeroFraction]
 		},
 		{
 			code: 'const foo = -1.0',
 			output: 'const foo = -1',
-			errors: [error]
+			errors: [errorZeroFraction]
 		},
 		{
 			code: 'const foo = 123123123.0',
 			output: 'const foo = 123123123',
-			errors: [error]
+			errors: [errorZeroFraction]
+		},
+		{
+			code: 'const foo = 123.11100000000',
+			output: 'const foo = 123.111',
+			errors: [errorZeroFraction]
 		},
 		{
 			code: 'const foo = 1.',
 			output: 'const foo = 1',
-			errors: [error]
+			errors: [errorDanglingDot]
+		},
+		{
+			code: 'const foo = +1.',
+			output: 'const foo = +1',
+			errors: [errorDanglingDot]
+		},
+		{
+			code: 'const foo = -1.',
+			output: 'const foo = -1',
+			errors: [errorDanglingDot]
+		},
+		{
+			code: 'const foo = 1.e10',
+			output: 'const foo = 1e10',
+			errors: [errorDanglingDot]
+		},
+		{
+			code: 'const foo = +1.e-10',
+			output: 'const foo = +1e-10',
+			errors: [errorDanglingDot]
+		},
+		{
+			code: 'const foo = -1.e+10',
+			output: 'const foo = -1e+10',
+			errors: [errorDanglingDot]
 		}
 	]
 });

--- a/test/no-zero-fractions.js
+++ b/test/no-zero-fractions.js
@@ -1,0 +1,47 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-zero-fractions';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	},
+	parserOptions: {
+		sourceType: 'module'
+	}
+});
+
+const error = {
+	ruleId: 'no-zero-fractions',
+	message: 'Zero fraction or dangling dot in number.'
+};
+
+ruleTester.run('no-zero-fractions', rule, {
+	valid: [
+		'const foo = 1',
+		'const foo = -1',
+		'const foo = 123123123',
+		'const foo = 1.1',
+		'const foo = -1.1',
+		'const foo = 123123123.4',
+		'const foo = 1e3'
+	],
+	invalid: [
+		{
+			code: 'const foo = 1.0',
+			errors: [error]
+		},
+		{
+			code: 'const foo = -1.0',
+			errors: [error]
+		},
+		{
+			code: 'const foo = 123123123.0',
+			errors: [error]
+		},
+		{
+			code: 'const foo = 1.',
+			errors: [error]
+		}
+	]
+});

--- a/test/no-zero-fractions.js
+++ b/test/no-zero-fractions.js
@@ -13,11 +13,11 @@ const ruleTester = avaRuleTester(test, {
 
 const errorZeroFraction = {
 	ruleId: 'no-zero-fractions',
-	message: 'Zero fraction in number.'
+	message: 'Don\'t use a zero fraction in the number.'
 };
 const errorDanglingDot = {
 	ruleId: 'no-zero-fractions',
-	message: 'Dangling dot in number.'
+	message: 'Don\'t use a dangling dot in the number.'
 };
 
 ruleTester.run('no-zero-fractions', rule, {


### PR DESCRIPTION
Added removing dangling dots too, as there is also no difference in JS between `1.` and `1`.

(Sorry, while rebasing to upstream I managed to trigger some weird github rule, which automatically closed previous pull request.)

---

Fixes #207 