### PR TITLE
Fix integration travis task not failing unless unit tests fail too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ matrix:
     - node_js: 10
       env: INTEGRATION=true
 script:
-  - "[ \"$INTEGRATION\" = true ] && npm run integration || npm test"
+  - if [ $INTEGRATION == true ]; then npm run integration; else npm test; fi
 after_success:
   - './node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls'

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -12,7 +12,6 @@ const packages = new Map([
 	['chalk', 'https://github.com/chalk/chalk'],
 	['wrap-ansi', 'https://github.com/chalk/wrap-ansi'],
 	['got', 'https://github.com/sindresorhus/got'],
-	['pageres', 'https://github.com/sindresorhus/pageres'],
 	['np', 'https://github.com/sindresorhus/np'],
 	['ora', 'https://github.com/sindresorhus/ora'],
 	['p-map', 'https://github.com/sindresorhus/p-map'],


### PR DESCRIPTION
The old script is equivalent to 
```bash
([ "$INTEGRATION" == true ] && npm run integration) || npm test
```
which will exit with 0 whenever `npm test` exists with 0.

PS: I bet this question has played a part in this: https://stackoverflow.com/questions/3953645/ternary-operator-in-bash