### PR TITLE
regex-shorthand: new option to fix #157

### DIFF
--- a/docs/rules/regex-shorthand.md
+++ b/docs/rules/regex-shorthand.md
@@ -25,3 +25,17 @@ const regex = /\W/;
 const regex = /\W/i;
 const regex = /\d\.\w\-\D/i;
 ```
+
+
+## Options
+
+You can set the option like this:
+
+```js
+"unicorn/regex-shorthand": ["error", [
+  'charClassToMeta', // [0-9] -> [\d]
+  'charClassToSingleChar' // [\d] -> \d
+]]
+```
+
+[available values](https://github.com/DmitrySoshnikov/regexp-tree/tree/master/src/optimizer): any transform name (from package regexp-tree).

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"xo"
 	],
 	"dependencies": {
-		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.0.0",
 		"import-modules": "^1.1.0",
 		"lodash.camelcase": "^4.1.1",
@@ -40,6 +39,7 @@
 		"lodash.snakecase": "^4.0.1",
 		"lodash.topairs": "^4.3.0",
 		"lodash.upperfirst": "^4.2.0",
+		"regexp-tree": "^0.1.5",
 		"reserved-words": "^0.1.2",
 		"safe-regex": "^2.0.1"
 	},

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"xo"
 	],
 	"dependencies": {
+		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.0.0",
 		"import-modules": "^1.1.0",
 		"lodash.camelcase": "^4.1.1",

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const cleanRegexp = require('clean-regexp');
+
 const {parse, generate, optimize} = require('regexp-tree');
 
 const getDocsUrl = require('./utils/get-docs-url');
@@ -14,23 +16,60 @@ const create = context => {
 	];
 
 	return {
-		'Literal[regex]': node => {
-			const {type, value} = sourceCode.getFirstToken(node);
+		'NewExpression[callee.name="RegExp"]': node => {
+			const args = node.arguments;
 
-			if (type !== 'RegularExpression') {
+			if (args.length === 0 || args[0].type !== 'Literal') {
 				return;
 			}
+
+			const hasRegExp = args[0].regex;
+
+			let oldPattern = null;
+			let flags = null;
+
+			if (hasRegExp) {
+				oldPattern = args[0].regex.pattern;
+				flags = args[1] && args[1].type === 'Literal' ? args[1].value : args[0].regex.flags;
+				return;
+			} else {
+				oldPattern = args[0].value;
+				flags = args[1] && args[1].type === 'Literal' ? args[1].value : '';
+			}
+
+			const newPattern = cleanRegexp(oldPattern, flags);
+
+			if (oldPattern !== newPattern) {
+				let fixed;
+				if (hasRegExp) {
+					fixed = `/${newPattern}/`;
+				} else {
+					// Escape backslash and apostrophe because we wrap the result in single quotes.
+					fixed = (newPattern || '').replace(/\\/, '\\\\');
+					fixed = fixed.replace(/'/, '\'');
+					fixed = `'${fixed}'`;
+				}
+
+				context.report({
+					node,
+					message,
+					fix: fixer => fixer.replaceTextRange(args[0].range, fixed)
+				});
+			}
+		},
+		'Literal[regex]': node => {
+			const {type, value} = sourceCode.getFirstToken(node);
 
 			let parsedSource;
 			try {
 				parsedSource = parse(value);
-			} catch (error) {
+			} catch ({message}) {
 				context.report({
 					node,
 					message: '{{original}} can\'t be parsed: {{message}}',
 					data: {
 						original: value,
-						message: error.message
+						message
 					}
 				});
 

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -24,18 +24,12 @@ const create = context => {
 			}
 
 			const hasRegExp = args[0].regex;
-
-			let oldPattern = null;
-			let flags = null;
-
 			if (hasRegExp) {
-				oldPattern = args[0].regex.pattern;
-				flags = args[1] && args[1].type === 'Literal' ? args[1].value : args[0].regex.flags;
 				return;
-			} else {
-				oldPattern = args[0].value;
-				flags = args[1] && args[1].type === 'Literal' ? args[1].value : '';
 			}
+
+			const oldPattern = args[0].value;
+			const flags = args[1] && args[1].type === 'Literal' ? args[1].value : '';
 
 			const newPattern = cleanRegexp(oldPattern, flags);
 
@@ -58,18 +52,18 @@ const create = context => {
 			}
 		},
 		'Literal[regex]': node => {
-			const {type, value} = sourceCode.getFirstToken(node);
+			const {value} = sourceCode.getFirstToken(node);
 
 			let parsedSource;
 			try {
 				parsedSource = parse(value);
-			} catch ({message}) {
+			} catch (error) {
 				context.report({
 					node,
 					message: '{{original}} can\'t be parsed: {{message}}',
 					data: {
 						original: value,
-						message
+						message: error.message
 					}
 				});
 

--- a/test/regex-shorthand.js
+++ b/test/regex-shorthand.js
@@ -23,7 +23,6 @@ ruleTester.run('regex-shorthand', rule, {
 		'const foo = /\\w/ig',
 		'const foo = /[a-z]/ig',
 		'const foo = /\\d*?/ig',
-		'const foo = /[a-z0-9_]/',
 		'const foo = new RegExp(\'\\d\')',
 		'const foo = new RegExp(\'\\d\', \'ig\')',
 		'const foo = new RegExp(\'\\d*?\')',
@@ -32,8 +31,7 @@ ruleTester.run('regex-shorthand', rule, {
 		'const foo = new RegExp(/\\d/ig)',
 		'const foo = new RegExp(/\\d/, \'ig\')',
 		'const foo = new RegExp(/\\d*?/)',
-		'const foo = new RegExp(/[a-z]/, \'i\')',
-		'const foo = new RegExp(/^[^*]*[*]?$/)'
+		'const foo = new RegExp(/[a-z]/, \'i\')'
 	],
 	invalid: [
 		{
@@ -59,7 +57,7 @@ ruleTester.run('regex-shorthand', rule, {
 		{
 			code: 'const foo = /[0-9]/ig',
 			errors: [error],
-			output: 'const foo = /\\d/ig'
+			output: 'const foo = /\\d/gi'
 		},
 		{
 			code: 'const foo = new RegExp(\'[0-9]\', \'ig\')',
@@ -129,12 +127,12 @@ ruleTester.run('regex-shorthand', rule, {
 		{
 			code: 'const foo = /[^a-z\\d_]/ig',
 			errors: [error],
-			output: 'const foo = /\\W/ig'
+			output: 'const foo = /\\W/gi'
 		},
 		{
 			code: 'const foo = /[^\\d_a-z]/ig',
 			errors: [error],
-			output: 'const foo = /\\W/ig'
+			output: 'const foo = /\\W/gi'
 		},
 		{
 			code: 'const foo = new RegExp(/[0-9]/)',
@@ -155,6 +153,16 @@ ruleTester.run('regex-shorthand', rule, {
 			code: 'const foo = new RegExp(/[0-9]/, \'ig\')',
 			errors: [error],
 			output: 'const foo = new RegExp(/\\d/, \'ig\')'
+		},
+		{
+			code: 'const foo = new RegExp(/^[^*]*[*]?$/)',
+			errors: [error],
+			output: 'const foo = new RegExp(/^[^*]*\\*?$/)'
+		},
+		{
+			code: 'const foo = /[a-z0-9_]/',
+			errors: [error],
+			output: 'const foo = /[a-z\\d_]/'
 		}
 	]
 });


### PR DESCRIPTION
Adding a new option to rule `regex-shorthand` to fix #157.

FYI: I have adapted the code from "optimize-regex/optimize-regex", a [good Eslint plugin](https://github.com/BrainMaestro/eslint-plugin-optimize-regex).

And it's the same licence for code: MIT.