### PR TITLE
Fix `prefer-includes` example

### DIFF
--- a/docs/rules/prefer-includes.md
+++ b/docs/rules/prefer-includes.md
@@ -17,7 +17,7 @@ x.indexOf('foo') === -1
 ## Pass
 
 ```js
-const x = 'foobar';
+const str = 'foobar';
 str.indexOf('foo') !== -n;
 str.indexOf('foo') !== 1;
 !str.indexOf('foo') === 1;


### PR DESCRIPTION
`x` is never mentioned in the same codeblock again, whereas `str` is.