### PR TITLE
Fix `prevent-abbreviations` breaking shorthand properties in assignment patterns

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -402,7 +402,17 @@ const shouldFix = variable => {
 
 const isShorthandPropertyIdentifier = identifier => {
 	return identifier.parent.type === 'Property' &&
+		identifier.parent.key === identifier &&
 		identifier.parent.shorthand;
+};
+
+const isAssignmentPatternShorthandPropertyIdentifier = identifier => {
+	return identifier.parent.type === 'AssignmentPattern' &&
+		identifier.parent.left === identifier &&
+		identifier.parent.parent.type === 'Property' &&
+		identifier.parent.parent.key === identifier &&
+		identifier.parent.parent.value === identifier.parent &&
+		identifier.parent.parent.shorthand;
 };
 
 const isShorthandImportIdentifier = identifier => {
@@ -418,7 +428,7 @@ const isShorthandExportIdentifier = identifier => {
 };
 
 const fixIdentifier = (fixer, replacement) => identifier => {
-	if (isShorthandPropertyIdentifier(identifier)) {
+	if (isShorthandPropertyIdentifier(identifier) || isAssignmentPatternShorthandPropertyIdentifier(identifier)) {
 		return fixer.replaceText(identifier, `${identifier.name}: ${replacement}`);
 	}
 

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -580,6 +580,12 @@ ruleTester.run('prevent-abbreviations', rule, {
 			options: customOptions,
 			errors: createErrors()
 		},
+		{
+			code: 'const {err} = foo;',
+			output: 'const {err: error} = foo;',
+			options: customOptions,
+			errors: createErrors()
+		},
 
 		noFixingTestCase({
 			code: 'const foo = {err: 1}',
@@ -887,6 +893,22 @@ ruleTester.run('prevent-abbreviations', rule, {
 				let arguments_;
 				function f() {
 					return g.apply(this, arguments) + arguments_;
+				}
+			`,
+			errors: createErrors()
+		},
+
+		{
+			code: `
+				function unicorn(unicorn) {
+					const {docs = {}} = unicorn;
+					return docs;
+				}
+			`,
+			output: `
+				function unicorn(unicorn) {
+					const {docs: documents = {}} = unicorn;
+					return documents;
 				}
 			`,
 			errors: createErrors()


### PR DESCRIPTION
Fixes #266