### PR TITLE
Don't use non-standard AST property in `no-for-loop` rule

### DIFF
--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -168,7 +168,7 @@ const checkUpdateExpression = (forStatement, indexIdentifierName) => {
 
 const getRemovalRange = (node, sourceCode) => {
 	const nodeText = sourceCode.getText(node);
-	const {line} = sourceCode.getLocFromIndex(node.start);
+	const {line} = sourceCode.getLocFromIndex(node.range[0]);
 	const lineText = sourceCode.lines[line - 1];
 
 	const isOnlyNodeOnItsLine = lineText.trim() === nodeText;


### PR DESCRIPTION
This pull request makes the rule work with `@typescript-eslint/parser`

Fixes #272