### PR TITLE
Add `prefer-flat-map` rule

### DIFF
--- a/docs/rules/prefer-flat-map.md
+++ b/docs/rules/prefer-flat-map.md
@@ -1,18 +1,19 @@
-# Prefer `.flatMap()` over `.map(...).flat()`.
+# Prefer `.flatMap()` over `.map(…).flat()`.
 
-[`.flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) performs [`.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`.flat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) in one step.
+[`Array#flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) performs [`Array#map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`Array#flat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) in one step.
 
 This rule is fixable.
+
 
 ## Fail
 
 ```js
-[1,2,3].map(i => [i]).flat();
+[1, 2, 3].map(i => [i]).flat();
 ```
 
 ## Pass
 
 ```js
-[1,2,3].flatMap(i => [i]);
-[1,2,3].map(i => [i]).foo().flat();
+[1, 2, 3].flatMap(i => [i]);
+[1, 2, 3].map(i => [i]).foo().flat();
 ```

--- a/docs/rules/prefer-flat-map.md
+++ b/docs/rules/prefer-flat-map.md
@@ -1,4 +1,4 @@
-# Prefer `.flatMap(…)` over `.map(…).flat()`.
+# Prefer `.flatMap(…)` over `.map(…).flat()`
 
 [`Array#flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) performs [`Array#map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`Array#flat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) in one step.
 

--- a/docs/rules/prefer-flat-map.md
+++ b/docs/rules/prefer-flat-map.md
@@ -1,4 +1,4 @@
-# Prefer `.flatMap()` over `.map(…).flat()`.
+# Prefer `.flatMap(…)` over `.map(…).flat()`.
 
 [`Array#flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) performs [`Array#map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`Array#flat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) in one step.
 

--- a/docs/rules/prefer-flat-map.md
+++ b/docs/rules/prefer-flat-map.md
@@ -1,0 +1,18 @@
+# Prefer `.flatMap()` over `.map(...).flat()`.
+
+[`.flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) performs [`.map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`.flat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) in one step.
+
+This rule is fixable.
+
+## Fail
+
+```js
+[1,2,3].map(i => [i]).flat();
+```
+
+## Pass
+
+```js
+[1,2,3].flatMap(i => [i]);
+[1,2,3].map(i => [i]).foo().flat();
+```

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
 				'unicorn/number-literal-case': 'error',
 				'unicorn/prefer-add-event-listener': 'error',
 				'unicorn/prefer-exponentiation-operator': 'error',
+				'unicorn/prefer-flat-map': 'error',
 				'unicorn/prefer-includes': 'error',
 				'unicorn/prefer-node-append': 'error',
 				'unicorn/prefer-node-remove': 'error',

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ Configure it in `package.json`.
 - [number-literal-case](docs/rules/number-literal-case.md) - Enforce lowercase identifier and uppercase value for number literals. *(fixable)*
 - [prefer-add-event-listener](docs/rules/prefer-add-event-listener.md) - Prefer `addEventListener` over `on`-functions. *(fixable)*
 - [prefer-exponentiation-operator](docs/rules/prefer-exponentiation-operator.md) - Prefer the exponentiation operator over `Math.pow()` *(fixable)*
-- [prefer-flat-map](docs/rules/prefer-flat-map.md) - Prefer `.flatMap()` over `.map(...).flat()`. *(fixable)*
+- [prefer-flat-map](docs/rules/prefer-flat-map.md) - Prefer `.flatMap()` over `.map(…).flat()`. *(fixable)*
 - [prefer-includes](docs/rules/prefer-includes.md) - Prefer `.includes()` over `.indexOf()` when checking for existence or non-existence. *(fixable)*
 - [prefer-node-append](docs/rules/prefer-node-append.md) - Prefer `append` over `appendChild`. *(fixable)*
 - [prefer-node-remove](docs/rules/prefer-node-remove.md) - Prefer `remove` over `parentNode.removeChild` and `parentElement.removeChild`. *(fixable)*

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ Configure it in `package.json`.
 - [number-literal-case](docs/rules/number-literal-case.md) - Enforce lowercase identifier and uppercase value for number literals. *(fixable)*
 - [prefer-add-event-listener](docs/rules/prefer-add-event-listener.md) - Prefer `addEventListener` over `on`-functions. *(fixable)*
 - [prefer-exponentiation-operator](docs/rules/prefer-exponentiation-operator.md) - Prefer the exponentiation operator over `Math.pow()` *(fixable)*
-- [prefer-flat-map](docs/rules/prefer-flat-map.md) - Prefer `.flatMap()` over `.map(…).flat()`. *(fixable)*
+- [prefer-flat-map](docs/rules/prefer-flat-map.md) - Prefer `.flatMap(…)` over `.map(…).flat()`. *(fixable)*
 - [prefer-includes](docs/rules/prefer-includes.md) - Prefer `.includes()` over `.indexOf()` when checking for existence or non-existence. *(fixable)*
 - [prefer-node-append](docs/rules/prefer-node-append.md) - Prefer `append` over `appendChild`. *(fixable)*
 - [prefer-node-remove](docs/rules/prefer-node-remove.md) - Prefer `remove` over `parentNode.removeChild` and `parentElement.removeChild`. *(fixable)*

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ Configure it in `package.json`.
 			"unicorn/number-literal-case": "error",
 			"unicorn/prefer-add-event-listener": "error",
 			"unicorn/prefer-exponentiation-operator": "error",
+			"unicorn/prefer-flat-map": "error",
 			"unicorn/prefer-includes": "error",
 			"unicorn/prefer-node-append": "error",
 			"unicorn/prefer-node-remove": "error",
@@ -100,6 +101,7 @@ Configure it in `package.json`.
 - [number-literal-case](docs/rules/number-literal-case.md) - Enforce lowercase identifier and uppercase value for number literals. *(fixable)*
 - [prefer-add-event-listener](docs/rules/prefer-add-event-listener.md) - Prefer `addEventListener` over `on`-functions. *(fixable)*
 - [prefer-exponentiation-operator](docs/rules/prefer-exponentiation-operator.md) - Prefer the exponentiation operator over `Math.pow()` *(fixable)*
+- [prefer-flat-map](docs/rules/prefer-flat-map.md) - Prefer `.flatMap()` over `.map(...).flat()`. *(fixable)*
 - [prefer-includes](docs/rules/prefer-includes.md) - Prefer `.includes()` over `.indexOf()` when checking for existence or non-existence. *(fixable)*
 - [prefer-node-append](docs/rules/prefer-node-append.md) - Prefer `append` over `appendChild`. *(fixable)*
 - [prefer-node-remove](docs/rules/prefer-node-remove.md) - Prefer `remove` over `parentNode.removeChild` and `parentElement.removeChild`. *(fixable)*

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -1,0 +1,65 @@
+'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
+const MESSAGE_ID = 'preferFlatMap';
+
+const isFlat = node => {
+	return (
+		node.type === 'CallExpression' &&
+		node.callee.type === 'MemberExpression' &&
+		node.callee.property.type === 'Identifier' &&
+		node.callee.property.name === 'flat'
+	);
+};
+
+const isMap = node => {
+	return (
+		node.type === 'CallExpression' &&
+		node.callee.type === 'MemberExpression' &&
+		node.callee.property.type === 'Identifier' &&
+		node.callee.property.name === 'map'
+	);
+};
+
+const report = (context, nodeFlat, nodeMap) => {
+	context.report({
+		node: nodeFlat,
+		messageId: MESSAGE_ID,
+		fix: fixer => {
+			return [
+				fixer.removeRange([nodeMap.end, nodeFlat.end]),
+				fixer.replaceText(nodeMap.callee.property, 'flatMap')
+			];
+		}
+	});
+};
+
+const create = context => ({
+	CallExpression: node => {
+		if (!isFlat(node)) {
+			return;
+		}
+
+		const parent = node.callee.object;
+
+		if (!isMap(parent)) {
+			return;
+		}
+
+		report(context, node, parent);
+	}
+});
+
+module.exports = {
+	create,
+	meta: {
+		type: 'suggestion',
+		docs: {
+			url: getDocsUrl(__filename)
+		},
+		fixable: 'code',
+		messages: {
+			[MESSAGE_ID]: 'Use `.flatMap()`, rather than `.map(...).flat()`.'
+		}
+	}
+};

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -22,13 +22,25 @@ const isMap = node => {
 };
 
 const report = (context, nodeFlat, nodeMap) => {
+	// Location will be:
+	//   map(...).flat();
+	//                 ^
+	const flatEnd = nodeFlat && nodeFlat.end;
+
+	// Location will be:
+	//   map(...).flat();
+	//          ^
+	const mapEnd = nodeMap && nodeMap.end;
+
+	const mapProperty = nodeMap && nodeMap.callee && nodeMap.callee.property;
+
 	context.report({
 		node: nodeFlat,
 		messageId: MESSAGE_ID,
 		fix: fixer => {
 			return [
-				fixer.removeRange([nodeMap.end, nodeFlat.end]),
-				fixer.replaceText(nodeMap.callee.property, 'flatMap')
+				fixer.removeRange([mapEnd, flatEnd]),
+				fixer.replaceText(mapProperty, 'flatMap')
 			];
 		}
 	});
@@ -40,7 +52,7 @@ const create = context => ({
 			return;
 		}
 
-		const parent = node.callee.object;
+		const parent = node && node.callee && node.callee.object;
 
 		if (!isMap(parent)) {
 			return;

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -1,25 +1,8 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
+const isMethodNamed = require('./utils/is-method-named');
 
 const MESSAGE_ID = 'preferFlatMap';
-
-const isFlat = node => {
-	return (
-		node.type === 'CallExpression' &&
-		node.callee.type === 'MemberExpression' &&
-		node.callee.property.type === 'Identifier' &&
-		node.callee.property.name === 'flat'
-	);
-};
-
-const isMap = node => {
-	return (
-		node.type === 'CallExpression' &&
-		node.callee.type === 'MemberExpression' &&
-		node.callee.property.type === 'Identifier' &&
-		node.callee.property.name === 'map'
-	);
-};
 
 const report = (context, nodeFlat, nodeMap) => {
 	const source = context.getSourceCode();
@@ -111,13 +94,13 @@ const report = (context, nodeFlat, nodeMap) => {
 
 const create = context => ({
 	CallExpression: node => {
-		if (!isFlat(node)) {
+		if (!isMethodNamed(node, 'flat')) {
 			return;
 		}
 
 		const parent = node.callee.object;
 
-		if (!isMap(parent)) {
+		if (!isMethodNamed(parent, 'map')) {
 			return;
 		}
 

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -59,7 +59,7 @@ module.exports = {
 		},
 		fixable: 'code',
 		messages: {
-			[MESSAGE_ID]: 'Use `.flatMap()`, rather than `.map(...).flat()`.'
+			[MESSAGE_ID]: 'Prefer `.flatMap()` over `.map(...).flat()`.'
 		}
 	}
 };

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -25,51 +25,51 @@ const report = (context, nodeFlat, nodeMap) => {
 	const source = context.getSourceCode();
 
 	// Node covers:
-	//   map(...).flat();
+	//   map(…).flat();
+	//          ^^^^
+	//   (map(…)).flat();
 	//            ^^^^
-	//   (map(...)).flat();
-	//              ^^^^
 	const flatIdentifer = nodeFlat.callee.property;
 
 	// Location will be:
-	//   map(...).flat();
+	//   map(…).flat();
+	//         ^
+	//   (map(…)).flat();
 	//           ^
-	//   (map(...)).flat();
-	//             ^
 	const dot = source.getTokenBefore(flatIdentifer);
 
 	// Location will be:
-	//   map(...).flat();
+	//   map(…).flat();
+	//                ^
+	//   (map(…)).flat();
 	//                  ^
-	//   (map(...)).flat();
-	//                    ^
 	const maybeSemicolon = source.getTokenAfter(nodeFlat);
 	const hasSemicolon = Boolean(maybeSemicolon) && maybeSemicolon.value === ';';
 
 	// Location will be:
-	//   (map(...)).flat();
-	//            ^
+	//   (map(…)).flat();
+	//          ^
 	const tokenBetween = source.getLastTokenBetween(nodeMap, dot);
 
 	// Location will be:
-	//   map(...).flat();
+	//   map(…).flat();
+	//        ^
+	//   (map(…)).flat();
 	//          ^
-	//   (map(...)).flat();
-	//            ^
 	const beforeSemicolon = tokenBetween || nodeMap;
 
 	// Location will be:
-	//   map(...).flat();
+	//   map(…).flat();
+	//               ^
+	//   (map(…)).flat();
 	//                 ^
-	//   (map(...)).flat();
-	//                   ^
 	const fixEnd = nodeFlat.end;
 
 	// Location will be:
-	//   map(...).flat();
+	//   map(…).flat();
+	//         ^
+	//   (map(…)).flat();
 	//           ^
-	//   (map(...)).flat();
-	//             ^
 	const fixStart = dot.start;
 
 	const mapProperty = nodeMap.callee.property;
@@ -80,26 +80,26 @@ const report = (context, nodeFlat, nodeMap) => {
 		fix: fixer => {
 			const fixings = [
 				// Removes:
-				//   map(...).flat();
+				//   map(…).flat();
+				//         ^^^^^^^
+				//   (map(…)).flat();
 				//           ^^^^^^^
-				//   (map(...)).flat();
-				//             ^^^^^^^
 				fixer.removeRange([fixStart, fixEnd]),
 
 				// Renames:
-				//   map(...).flat();
+				//   map(…).flat();
 				//   ^^^
-				//   (map(...)).flat();
+				//   (map(…)).flat();
 				//    ^^^
 				fixer.replaceText(mapProperty, 'flatMap')
 			];
 
 			if (hasSemicolon) {
 				// Moves semicolon to:
-				//   map(...).flat();
+				//   map(…).flat();
+				//         ^
+				//   (map(…)).flat();
 				//           ^
-				//   (map(...)).flat();
-				//             ^
 				fixings.push(fixer.insertTextAfter(beforeSemicolon, ';'));
 				fixings.push(fixer.remove(maybeSemicolon));
 			}
@@ -134,7 +134,7 @@ module.exports = {
 		},
 		fixable: 'code',
 		messages: {
-			[MESSAGE_ID]: 'Prefer `.flatMap()` over `.map(...).flat()`.'
+			[MESSAGE_ID]: 'Prefer `.flatMap(…)` over `.map(…).flat()`.'
 		}
 	}
 };

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -52,7 +52,7 @@ const create = context => ({
 			return;
 		}
 
-		const parent = node && node.callee && node.callee.object;
+		const parent = node.callee.object;
 
 		if (!isMap(parent)) {
 			return;

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -22,26 +22,89 @@ const isMap = node => {
 };
 
 const report = (context, nodeFlat, nodeMap) => {
+	const source = context.getSourceCode();
+
+	// Node covers:
+	//   map(...).flat();
+	//            ^^^^
+	//   (map(...)).flat();
+	//              ^^^^
+	const flatIdentifer = nodeFlat.callee.property;
+
 	// Location will be:
 	//   map(...).flat();
-	//                 ^
-	const flatEnd = nodeFlat && nodeFlat.end;
+	//           ^
+	//   (map(...)).flat();
+	//             ^
+	const dot = source.getTokenBefore(flatIdentifer);
+
+	// Location will be:
+	//   map(...).flat();
+	//                  ^
+	//   (map(...)).flat();
+	//                    ^
+	const maybeSemicolon = source.getTokenAfter(nodeFlat);
+	const hasSemicolon = Boolean(maybeSemicolon) && maybeSemicolon.value === ';';
+
+	// Location will be:
+	//   (map(...)).flat();
+	//            ^
+	const tokenBetween = source.getLastTokenBetween(nodeMap, dot);
 
 	// Location will be:
 	//   map(...).flat();
 	//          ^
-	const mapEnd = nodeMap && nodeMap.end;
+	//   (map(...)).flat();
+	//            ^
+	const beforeSemicolon = tokenBetween || nodeMap;
 
-	const mapProperty = nodeMap && nodeMap.callee && nodeMap.callee.property;
+	// Location will be:
+	//   map(...).flat();
+	//                 ^
+	//   (map(...)).flat();
+	//                   ^
+	const fixEnd = nodeFlat.end;
+
+	// Location will be:
+	//   map(...).flat();
+	//           ^
+	//   (map(...)).flat();
+	//             ^
+	const fixStart = dot.start;
+
+	const mapProperty = nodeMap.callee.property;
 
 	context.report({
 		node: nodeFlat,
 		messageId: MESSAGE_ID,
 		fix: fixer => {
-			return [
-				fixer.removeRange([mapEnd, flatEnd]),
+			const fixings = [
+				// Removes:
+				//   map(...).flat();
+				//           ^^^^^^^
+				//   (map(...)).flat();
+				//             ^^^^^^^
+				fixer.removeRange([fixStart, fixEnd]),
+
+				// Renames:
+				//   map(...).flat();
+				//   ^^^
+				//   (map(...)).flat();
+				//    ^^^
 				fixer.replaceText(mapProperty, 'flatMap')
 			];
+
+			if (hasSemicolon) {
+				// Moves semicolon to:
+				//   map(...).flat();
+				//           ^
+				//   (map(...)).flat();
+				//             ^
+				fixings.push(fixer.insertTextAfter(beforeSemicolon, ';'));
+				fixings.push(fixer.remove(maybeSemicolon));
+			}
+
+			return fixings;
 		}
 	});
 };

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -1,14 +1,6 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
-
-const isIndexOf = node => {
-	return (
-		node.type === 'CallExpression' &&
-		node.callee.type === 'MemberExpression' &&
-		node.callee.property.type === 'Identifier' &&
-		node.callee.property.name === 'indexOf'
-	);
-};
+const isMethodNamed = require('./utils/is-method-named');
 
 const isNegativeOne = (operator, value) => operator === '-' && value === 1;
 
@@ -34,7 +26,7 @@ const create = context => ({
 	BinaryExpression: node => {
 		const {left, right} = node;
 
-		if (isIndexOf(left)) {
+		if (isMethodNamed(left, 'indexOf')) {
 			const target = left.callee.object;
 			const pattern = left.arguments[0];
 

--- a/rules/utils/is-method-named.js
+++ b/rules/utils/is-method-named.js
@@ -1,0 +1,10 @@
+const isMethodNamed = (node, name) => {
+	return (
+		node.type === 'CallExpression' &&
+		node.callee.type === 'MemberExpression' &&
+		node.callee.property.type === 'Identifier' &&
+		node.callee.property.name === name
+	);
+};
+
+module.exports = isMethodNamed;

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -64,6 +64,16 @@ ruleTester.run('prefer-flat-map', rule, {
 			errors: [error]
 		},
 		{
+			code: 'const bar = [1,2,3].sort().map(i => [i]).flat()',
+			output: 'const bar = [1,2,3].sort().flatMap(i => [i])',
+			errors: [error]
+		},
+		{
+			code: 'const bar = (([1,2,3].map(i => [i]))).flat()',
+			output: 'const bar = (([1,2,3].flatMap(i => [i])))',
+			errors: [error]
+		},
+		{
 			code: `
 				let bar = [1,2,3].map(i => {
 					return [i];
@@ -77,25 +87,19 @@ ruleTester.run('prefer-flat-map', rule, {
 			errors: [error]
 		},
 		{
-			code: `
-				let bar = [1,2,3]
-					.map(i => {
-						return [i];
-					})
-					.flat();
-			`,
-			output: `
-				let bar = [1,2,3]
-					.flatMap(i => {
-						return [i];
-					});
-			`,
+			code: 'let bar = [1,2,3].map(i => {\nreturn [i];\n})\n.flat();',
+			output: 'let bar = [1,2,3].flatMap(i => {\nreturn [i];\n});\n',
 			errors: [error]
 		},
 		{
-			code: 'const bar = [1,2,3].sort().map(i => [i]).flat()',
-			output: 'const bar = [1,2,3].sort().flatMap(i => [i])',
+			code: 'let bar = [1,2,3].map(i => {\nreturn [i];\n}) // comment\n.flat();',
+			output: 'let bar = [1,2,3].flatMap(i => {\nreturn [i];\n}); // comment\n',
 			errors: [error]
-		}
+		},
+		{
+			code: 'let bar = [1,2,3].map(i => {\nreturn [i];\n}) // comment\n.flat(); // other',
+			output: 'let bar = [1,2,3].flatMap(i => {\nreturn [i];\n}); // comment\n // other',
+			errors: [error]
+		},
 	]
 });

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -100,6 +100,6 @@ ruleTester.run('prefer-flat-map', rule, {
 			code: 'let bar = [1,2,3].map(i => {\nreturn [i];\n}) // comment\n.flat(); // other',
 			output: 'let bar = [1,2,3].flatMap(i => {\nreturn [i];\n}); // comment\n // other',
 			errors: [error]
-		},
+		}
 	]
 });

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -77,6 +77,22 @@ ruleTester.run('prefer-flat-map', rule, {
 			errors: [error]
 		},
 		{
+			code: `
+				let bar = [1,2,3]
+					.map(i => {
+						return [i];
+					})
+					.flat();
+			`,
+			output: `
+				let bar = [1,2,3]
+					.flatMap(i => {
+						return [i];
+					});
+			`,
+			errors: [error]
+		},
+		{
 			code: 'const bar = [1,2,3].sort().map(i => [i]).flat()',
 			output: 'const bar = [1,2,3].sort().flatMap(i => [i])',
 			errors: [error]

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -21,7 +21,11 @@ ruleTester.run('prefer-flat-map', rule, {
 		'const bar = [1,2,3].map((i) => { return i; })',
 		'const bar = foo.map(i => i)',
 		'const bar = [[1],[2],[3]].flat()',
-		'const bar = [1,2,3].map(i => [i]).sort().flat()'
+		'const bar = [1,2,3].map(i => [i]).sort().flat()',
+		`
+			let bar = [1,2,3].map(i => [i]);
+			bar = bar.flat();
+		`
 	],
 	invalid: [
 		{
@@ -57,6 +61,24 @@ ruleTester.run('prefer-flat-map', rule, {
 		{
 			code: 'const bar = [1,2,3].map(i => i).map(i => [i]).flat()',
 			output: 'const bar = [1,2,3].map(i => i).flatMap(i => [i])',
+			errors: [error]
+		},
+		{
+			code: `
+				let bar = [1,2,3].map(i => {
+					return [i];
+				}).flat();
+			`,
+			output: `
+				let bar = [1,2,3].flatMap(i => {
+					return [i];
+				});
+			`,
+			errors: [error]
+		},
+		{
+			code: 'const bar = [1,2,3].sort().map(i => [i]).flat()',
+			output: 'const bar = [1,2,3].sort().flatMap(i => [i])',
 			errors: [error]
 		}
 	]

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -100,6 +100,21 @@ ruleTester.run('prefer-flat-map', rule, {
 			code: 'let bar = [1,2,3].map(i => {\nreturn [i];\n}) // comment\n.flat(); // other',
 			output: 'let bar = [1,2,3].flatMap(i => {\nreturn [i];\n}); // comment\n // other',
 			errors: [error]
+		},
+		{
+			code: 'let bar = [1,2,3]\n  .map(i => { return [i]; })\n  .flat();',
+			output: 'let bar = [1,2,3]\n  .flatMap(i => { return [i]; });\n  ',
+			errors: [error]
+		},
+		{
+			code: 'let bar = [1,2,3].map(i => { return [i]; })\n  .flat();',
+			output: 'let bar = [1,2,3].flatMap(i => { return [i]; });\n  ',
+			errors: [error]
+		},
+		{
+			code: 'let bar = [1,2,3] . map( x => y ) . flat () // 🤪',
+			output: 'let bar = [1,2,3] . flatMap( x => y )  // 🤪',
+			errors: [error]
 		}
 	]
 });

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -1,0 +1,63 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-flat-map';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const error = {
+	ruleId: 'prefer-flat-map',
+	messageId: 'preferFlatMap'
+};
+
+ruleTester.run('prefer-flat-map', rule, {
+	valid: [
+		'const bar = [1,2,3].map()',
+		'const bar = [1,2,3].map(i => i)',
+		'const bar = [1,2,3].map((i) => i)',
+		'const bar = [1,2,3].map((i) => { return i; })',
+		'const bar = foo.map(i => i)',
+		'const bar = [[1],[2],[3]].flat()',
+		'const bar = [1,2,3].map(i => [i]).sort().flat()'
+	],
+	invalid: [
+		{
+			code: 'const bar = [1,2,3].map(i => [i]).flat()',
+			output: 'const bar = [1,2,3].flatMap(i => [i])',
+			errors: [error]
+		},
+		{
+			code: 'const bar = [1,2,3].map((i) => [i]).flat()',
+			output: 'const bar = [1,2,3].flatMap((i) => [i])',
+			errors: [error]
+		},
+		{
+			code: 'const bar = [1,2,3].map((i) => { return [i]; }).flat()',
+			output: 'const bar = [1,2,3].flatMap((i) => { return [i]; })',
+			errors: [error]
+		},
+		{
+			code: 'const bar = [1,2,3].map(foo).flat()',
+			output: 'const bar = [1,2,3].flatMap(foo)',
+			errors: [error]
+		},
+		{
+			code: 'const bar = foo.map(i => [i]).flat()',
+			output: 'const bar = foo.flatMap(i => [i])',
+			errors: [error]
+		},
+		{
+			code: 'const bar = { map: () => {} }.map(i => [i]).flat()',
+			output: 'const bar = { map: () => {} }.flatMap(i => [i])',
+			errors: [error]
+		},
+		{
+			code: 'const bar = [1,2,3].map(i => i).map(i => [i]).flat()',
+			output: 'const bar = [1,2,3].map(i => i).flatMap(i => [i])',
+			errors: [error]
+		}
+	]
+});


### PR DESCRIPTION
Basic check with a fixer. Fixes #204.

Converts ```[1,2,3].map(i => [i]).flat();``` to ```[1,2,3].flatMap(i => [i]);```

----

There are two scenarios that are a bit more complicated:

```
[1,2,3].map(i => [i]).foo().flat();
```

If the `map` and `flat` are not adjacent in the call chain than the rule will ignore it. It wouldn't be terribly hard to detect this case if desired but I don't think we should auto-fix it.

```
let foo = [1,2,3].map(i => [i]);
foo = foo.flat();
```

The complexity around this scenario is _much_ higher. It would require a totally different type of implementation.
