### PR TITLE
Fix `prefer-includes` fixer omitting parentheses

### DIFF
--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -16,7 +16,7 @@ const report = (context, node, target, pattern) => {
 	const sourceCode = context.getSourceCode();
 	const memberExpressionNode = target.parent;
 	const dotToken = sourceCode.getTokenBefore(memberExpressionNode.property);
-	const targetSource = sourceCode.getText().slice(memberExpressionNode.start, dotToken.start);
+	const targetSource = sourceCode.getText().slice(memberExpressionNode.range[0], dotToken.range[0]);
 	const patternSource = sourceCode.getText(pattern);
 	context.report({
 		node,

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -12,13 +12,12 @@ const isIndexOf = node => {
 
 const isNegativeOne = (operator, value) => operator === '-' && value === 1;
 
-const getSourceCode = (context, node) => (
-	context.getSourceCode().getText(node)
-);
-
 const report = (context, node, target, pattern) => {
-	const targetSource = getSourceCode(context, target);
-	const patternSource = getSourceCode(context, pattern);
+	const sourceCode = context.getSourceCode();
+	const memberExpressionNode = target.parent;
+	const dotToken = sourceCode.getTokenBefore(memberExpressionNode.property);
+	const targetSource = sourceCode.getText().slice(memberExpressionNode.start, dotToken.start);
+	const patternSource = sourceCode.getText(pattern);
 	context.report({
 		node,
 		message: 'Use `.includes()`, rather than `.indexOf()`, when checking for existence.',

--- a/test/prefer-includes.js
+++ b/test/prefer-includes.js
@@ -60,6 +60,11 @@ ruleTester.run('prefer-includes', rule, {
 			code: '\'\'.indexOf(\'foo\') < 0',
 			output: '!\'\'.includes(\'foo\')',
 			errors
+		},
+		{
+			code: '(a || b).indexOf(\'foo\') === -1',
+			output: '!(a || b).includes(\'foo\')',
+			errors
 		}
 	]
 });


### PR DESCRIPTION
fixes #278

Since the `memberExpressionNode.object` does not includes the parens, I work around by accessing the text before "dot".