### PR TITLE
Add `prefer-string-slice` rule

### DIFF
--- a/docs/rules/prefer-string-slice.md
+++ b/docs/rules/prefer-string-slice.md
@@ -1,0 +1,19 @@
+# Prefer `String#slice` over `String#substr` and `String#substring`
+
+[`String#substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [`String#substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are the two lesser known legacy ways to slice a string. It's better to use [`String#slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) as a more popular option with clearer behaviour that has a consistent [`Array` counterpart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+
+This rule is fixible when no arguments are passed to the method.
+
+## Fail
+
+```js
+foo.substr(1, 2);
+foo.substring(1, 3);
+```
+
+
+## Pass
+
+```js
+foo.slice(1, 3);
+```

--- a/docs/rules/prefer-string-slice.md
+++ b/docs/rules/prefer-string-slice.md
@@ -1,8 +1,9 @@
 # Prefer `String#slice()` over `String#substr()` and `String#substring()`
 
-[`String#substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [`String#substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are the two lesser known legacy ways to slice a string. It's better to use [`String#slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) as a more popular option with clearer behaviour that has a consistent [`Array` counterpart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+[`String#substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [`String#substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are the two lesser known legacy ways to slice a string. It's better to use [`String#slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) as it's a more popular option with clearer behavior that has a consistent [`Array` counterpart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
 
 This rule is fixible when no arguments are passed to the method.
+
 
 ## Fail
 

--- a/docs/rules/prefer-string-slice.md
+++ b/docs/rules/prefer-string-slice.md
@@ -1,4 +1,4 @@
-# Prefer `String#slice` over `String#substr` and `String#substring`
+# Prefer `String#slice()` over `String#substr()` and `String#substring()`
 
 [`String#substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [`String#substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are the two lesser known legacy ways to slice a string. It's better to use [`String#slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) as a more popular option with clearer behaviour that has a consistent [`Array` counterpart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ module.exports = {
 				'unicorn/prefer-reflect-apply': 'error',
 				'unicorn/prefer-spread': 'error',
 				'unicorn/prefer-starts-ends-with': 'error',
+				'unicorn/prefer-string-slice': 'error',
 				'unicorn/prefer-text-content': 'error',
 				'unicorn/prefer-type-error': 'error',
 				'unicorn/prevent-abbreviations': 'error',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"ci-info": "^2.0.0",
 		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.1.0",
+		"eslint-template-visitor": "^1.0.0",
 		"import-modules": "^1.1.0",
 		"lodash.camelcase": "^4.3.0",
 		"lodash.defaultsdeep": "^4.6.1",
@@ -41,8 +42,8 @@
 		"lodash.snakecase": "^4.1.1",
 		"lodash.topairs": "^4.3.0",
 		"lodash.upperfirst": "^4.3.1",
-		"regexpp": "^3.0.0",
 		"read-pkg": "^5.2.0",
+		"regexpp": "^3.0.0",
 		"reserved-words": "^0.1.2",
 		"safe-regex": "^2.0.2",
 		"semver": "^6.3.0"

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ Configure it in `package.json`.
 			"unicorn/prefer-reflect-apply": "error",
 			"unicorn/prefer-spread": "error",
 			"unicorn/prefer-starts-ends-with": "error",
+			"unicorn/prefer-string-slice": "error",
 			"unicorn/prefer-text-content": "error",
 			"unicorn/prefer-type-error": "error",
 			"unicorn/prevent-abbreviations": "error",
@@ -123,6 +124,7 @@ Configure it in `package.json`.
 - [prefer-reflect-apply](docs/rules/prefer-reflect-apply.md) - Prefer `Reflect.apply()` over `Function#apply()`. *(fixable)*
 - [prefer-spread](docs/rules/prefer-spread.md) - Prefer the spread operator over `Array.from()`. *(fixable)*
 - [prefer-starts-ends-with](docs/rules/prefer-starts-ends-with.md) - Prefer `String#startsWith()` & `String#endsWith()` over more complex alternatives.
+- [prefer-string-slice](docs/rules/prefer-string-slice.md) - Prefer `String#slice()` over `String#substr()` and `String#substring()`. *(partly fixable)*
 - [prefer-text-content](docs/rules/prefer-text-content.md) - Prefer `.textContent` over `.innerText`. *(fixable)*
 - [prefer-type-error](docs/rules/prefer-type-error.md) - Enforce throwing `TypeError` in type checking conditions. *(fixable)*
 - [prevent-abbreviations](docs/rules/prevent-abbreviations.md) - Prevent abbreviations. *(partly fixable)*

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -1,0 +1,64 @@
+'use strict';
+const eslintTemplateVisitor = require('eslint-template-visitor');
+const getDocsUrl = require('./utils/get-docs-url');
+
+const templates = eslintTemplateVisitor();
+
+const objectVariable = templates.variable();
+const argumentsVariable = templates.spreadVariable();
+
+const substrCallTemplate = templates.template`${objectVariable}.substr(${argumentsVariable})`;
+const substringCallTemplate = templates.template`${objectVariable}.substring(${argumentsVariable})`;
+
+const create = context => {
+	const sourceCode = context.getSourceCode();
+
+	return templates.visitor({
+		[substrCallTemplate](node) {
+			const objectNode = substrCallTemplate.context.getMatch(objectVariable);
+			const argumentNodes = substrCallTemplate.context.getMatch(argumentsVariable);
+
+			const problem = {
+				node,
+				message: 'Prefer `String#slice()` over `String#substr()`.'
+			};
+
+			const canFix = argumentNodes.length === 0;
+
+			if (canFix) {
+				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + '.slice()');
+			}
+
+			context.report(problem);
+		},
+
+		[substringCallTemplate](node) {
+			const objectNode = substringCallTemplate.context.getMatch(objectVariable);
+			const argumentNodes = substringCallTemplate.context.getMatch(argumentsVariable);
+
+			const problem = {
+				node,
+				message: 'Prefer `String#slice()` over `String#substring()`.'
+			};
+
+			const canFix = argumentNodes.length === 0;
+
+			if (canFix) {
+				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + '.slice()');
+			}
+
+			context.report(problem);
+		}
+	});
+};
+
+module.exports = {
+	create,
+	meta: {
+		type: 'suggestion',
+		docs: {
+			url: getDocsUrl(__filename)
+		},
+		fixable: 'code'
+	}
+};

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -1,0 +1,83 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/prefer-string-slice';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const errors = [{
+	ruleId: 'prefer-string-slice'
+}];
+
+ruleTester.run('prefer-string-slice', rule, {
+	valid: [
+		'const substr = foo.substr',
+		'const substring = foo.substring',
+
+		'foo.slice()',
+		'foo.slice(0)',
+		'foo.slice(1, 2)',
+		'foo.slice(-3, -2)'
+	],
+
+	invalid: [
+		{
+			code: 'foo.substr()',
+			output: 'foo.slice()',
+			errors
+		},
+		{
+			code: '"foo".substr()',
+			output: '"foo".slice()',
+			errors
+		},
+
+		{
+			code: 'foo.substr(start)',
+			errors
+		},
+		{
+			code: '"foo".substr(1)',
+			errors
+		},
+		{
+			code: 'foo.substr(start, length)',
+			errors
+		},
+		{
+			code: '"foo".substr(1, 2)',
+			errors
+		},
+
+		{
+			code: 'foo.substring()',
+			output: 'foo.slice()',
+			errors
+		},
+		{
+			code: '"foo".substring()',
+			output: '"foo".slice()',
+			errors
+		},
+
+		{
+			code: 'foo.substring(start)',
+			errors
+		},
+		{
+			code: '"foo".substring(1)',
+			errors
+		},
+		{
+			code: 'foo.substring(start, end)',
+			errors
+		},
+		{
+			code: '"foo".substring(1, 3)',
+			errors
+		}
+	]
+});


### PR DESCRIPTION
This is primarily a request for feedback and a showcase of [futpib/eslint-template-visitor](https://github.com/futpib/eslint-template-visitor) (no meaningful readme there for now).

Take a look at the [initial rule implementation](https://github.com/sindresorhus/eslint-plugin-unicorn/pull/288/files#diff-65f4c1557386dc75ca3f6a1d7f0c5f8c). More advanced features like spread matching (would be required to properly match multiple `.substr` arguments) are missing, but the basic API is there.

I aim at eventually removing most of the comparison boilerplate from the rules, such as this, for example: 
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/6bccd4176f5552d5e2ec785a2dae0835b4a8cd4d/rules/no-console-spaces.js#L16-L19

Let me know if this is worthwhile and would be accepted for use in this (or maybe other) project. If so, I'll continue working on it using `prefer-string-slice` as the driving use-case for now. Also feel free to suggest alternative API or features you'd like to see or anything else.

Cc: @sindresorhus @SamVerschueren @jfmengels @MrHen @stroncium (and anybody else who comes by) 

Could eventually fix #65. 