### PR TITLE
Add Node.js 12 to testing, use for integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
   - '6'
 matrix:
   include:
-    - node_js: 10
+    - node_js: 12
       env: INTEGRATION=true
 script:
   - if [ $INTEGRATION == true ]; then npm run integration; else npm test; fi


### PR DESCRIPTION
I assumed `INTEGRATION=true` is wanted for newest version of node.js so I switched that from 10 to 12.