### PR TITLE
Add `cases `option to the `filename-case` rule

### DIFF
--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -46,5 +46,13 @@ You can set the `case` option like this:
 Or set the `cases` option to allow multiple cases:
 
 ```js
-"unicorn/filename-case": ["error", {"cases": {"camelCase": true, "pascalCase": true}}]
+"unicorn/filename-case": [
+	"error",
+	{
+		"cases": {
+			"camelCase": true,
+			"pascalCase": true
+		}
+	}
+]
 ```

--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -42,3 +42,9 @@ You can set the `case` option like this:
 	}
 ]
 ```
+
+Or set the `cases` option to allow multiple cases:
+
+```js
+"unicorn/filename-case": ["error", {"cases": {"camelCase": true, "pascalCase": true}}]
+```

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -91,7 +91,7 @@ function splitFilename(filename) {
 }
 
 /**
-Turns `[a, b, c]` into `a, b or c`.
+Turns `[a, b, c]` into `a, b, or c`.
 
 @param {string[]} words
 @returns {string}
@@ -101,9 +101,13 @@ function englishishJoinWords(words) {
 		return words[0];
 	}
 
+	if (words.length === 2) {
+		return `${words[0]} or ${words[1]}`;
+	}
+
 	words = words.slice();
 	const last = words.pop();
-	return `${words.join(', ')} or ${last}`;
+	return `${words.join(', ')}, or ${last}`;
 }
 
 const create = context => {
@@ -133,7 +137,7 @@ const create = context => {
 					messageId: chosenCases.length > 1 ? 'renameToCases' : 'renameToCase',
 					data: {
 						chosenCases: englishishJoinWords(chosenCases.map(x => cases[x].name)),
-						renamedFilenames: renamedFilenames.map(x => '`' + x + '`').join(', ')
+						renamedFilenames: englishishJoinWords(renamedFilenames.map(x => `\`${x}\``))
 					}
 				});
 			}
@@ -191,7 +195,7 @@ module.exports = {
 		schema,
 		messages: {
 			renameToCase: 'Filename is not in {{chosenCases}}. Rename it to {{renamedFilenames}}.',
-			renameToCases: 'Filename is not in {{chosenCases}}. Rename it to one of [{{renamedFilenames}}].'
+			renameToCases: 'Filename is not in {{chosenCases}}. Rename it to {{renamedFilenames}}.'
 		}
 	}
 };

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -66,7 +66,7 @@ function getChosenCases(context) {
 
 	if (option.cases) {
 		const cases = Object.keys(option.cases)
-			.filter(c => option.cases[c]);
+			.filter(cases => option.cases[cases]);
 
 		return cases.length > 0 ? cases : ['kebabCase'];
 	}

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -52,10 +52,11 @@ const cases = {
 };
 
 /**
- * Get cases specified by option
- * @param {*} context context
- * @returns {string[]} the chosen cases
- */
+Get the cases specified by the option.
+
+@param {unknown} context
+@returns {string[]} The chosen cases.
+*/
 function getChosenCases(context) {
 	const option = context.options[0] || {};
 
@@ -90,10 +91,11 @@ function splitFilename(filename) {
 }
 
 /**
- * Turns `[a, b, c]` into `a, b or c`
- * @param {string[]} words .
- * @returns {string} .
- */
+Turns `[a, b, c]` into `a, b or c`.
+
+@param {string[]} words
+@returns {string}
+*/
 function englishishJoinWords(words) {
 	if (words.length === 1) {
 		return words[0];
@@ -158,10 +160,18 @@ const schema = [{
 			properties: {
 				cases: {
 					properties: {
-						camelCase: {type: 'boolean'},
-						snakeCase: {type: 'boolean'},
-						kebabCase: {type: 'boolean'},
-						pascalCase: {type: 'boolean'}
+						camelCase: {
+							type: 'boolean'
+						},
+						snakeCase: {
+							type: 'boolean'
+						},
+						kebabCase: {
+							type: 'boolean'
+						},
+						pascalCase: {
+							type: 'boolean'
+						}
 					},
 					additionalProperties: false
 				}

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -16,6 +16,14 @@ function testCase(filename, chosenCase, errorMessage) {
 	);
 }
 
+function testManyCases(filename, chosenCases, errorMessage) {
+	return testCaseWithOptions(
+		filename,
+		[{cases: chosenCases}],
+		errorMessage,
+	);
+}
+
 function testCaseWithOptions(filename, options = [], errorMessage) {
 	return {
 		code: 'foo()',
@@ -77,6 +85,10 @@ ruleTester.run('filename-case', rule, {
 		testCase('src/foo/___foo-bar.js', 'kebabCase'),
 		testCase('src/foo/_FooBar.js', 'pascalCase'),
 		testCase('src/foo/___FooBar.js', 'pascalCase'),
+		testManyCases('src/foo/foo-bar.js', undefined),
+		testManyCases('src/foo/fooBar.js', {camelCase: true}),
+		testManyCases('src/foo/FooBar.js', {kebabCase: true, pascalCase: true}),
+		testManyCases('src/foo/___foo_bar.js', {snakeCase: true, pascalCase: true}),
 		testCaseWithOptions('src/foo/bar.js')
 	],
 	invalid: [
@@ -184,6 +196,26 @@ ruleTester.run('filename-case', rule, {
 			'src/foo/___FOO-BAR.js',
 			'pascalCase',
 			'Filename is not in pascal case. Rename it to `___FooBar.js`.'
+		),
+		testManyCases(
+			'src/foo/foo_bar.js',
+			undefined,
+			'Filename is not in kebab case. Rename it to `foo-bar.js`.'
+		),
+		testManyCases(
+			'src/foo/foo-bar.js',
+			{camelCase: true, pascalCase: true},
+			'Filename is not in camel case or pascal case. Rename it to one of [`fooBar.js`, `FooBar.js`].'
+		),
+		testManyCases(
+			'src/foo/_foo_bar.js',
+			{camelCase: true, pascalCase: true, kebabCase: true},
+			'Filename is not in camel case, pascal case or kebab case. Rename it to one of [`_fooBar.js`, `_FooBar.js`, `_foo-bar.js`].'
+		),
+		testManyCases(
+			'src/foo/_FOO-BAR.js',
+			{snakeCase: true},
+			'Filename is not in snake case. Rename it to `_foo_bar.js`.'
 		)
 	]
 });

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -204,17 +204,26 @@ ruleTester.run('filename-case', rule, {
 		),
 		testManyCases(
 			'src/foo/foo-bar.js',
-			{camelCase: true, pascalCase: true},
+			{
+				camelCase: true,
+				pascalCase: true
+			},
 			'Filename is not in camel case or pascal case. Rename it to one of [`fooBar.js`, `FooBar.js`].'
 		),
 		testManyCases(
 			'src/foo/_foo_bar.js',
-			{camelCase: true, pascalCase: true, kebabCase: true},
+			{
+				camelCase: true,
+				pascalCase: true,
+				kebabCase: true
+			},
 			'Filename is not in camel case, pascal case or kebab case. Rename it to one of [`_fooBar.js`, `_FooBar.js`, `_foo-bar.js`].'
 		),
 		testManyCases(
 			'src/foo/_FOO-BAR.js',
-			{snakeCase: true},
+			{
+				snakeCase: true
+			},
 			'Filename is not in snake case. Rename it to `_foo_bar.js`.'
 		)
 	]

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -208,7 +208,7 @@ ruleTester.run('filename-case', rule, {
 				camelCase: true,
 				pascalCase: true
 			},
-			'Filename is not in camel case or pascal case. Rename it to one of [`fooBar.js`, `FooBar.js`].'
+			'Filename is not in camel case or pascal case. Rename it to `fooBar.js` or `FooBar.js`.'
 		),
 		testManyCases(
 			'src/foo/_foo_bar.js',
@@ -217,7 +217,7 @@ ruleTester.run('filename-case', rule, {
 				pascalCase: true,
 				kebabCase: true
 			},
-			'Filename is not in camel case, pascal case or kebab case. Rename it to one of [`_fooBar.js`, `_FooBar.js`, `_foo-bar.js`].'
+			'Filename is not in camel case, pascal case, or kebab case. Rename it to `_fooBar.js`, `_FooBar.js`, or `_foo-bar.js`.'
 		),
 		testManyCases(
 			'src/foo/_FOO-BAR.js',

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -86,6 +86,7 @@ ruleTester.run('filename-case', rule, {
 		testCase('src/foo/_FooBar.js', 'pascalCase'),
 		testCase('src/foo/___FooBar.js', 'pascalCase'),
 		testManyCases('src/foo/foo-bar.js', undefined),
+		testManyCases('src/foo/foo-bar.js', {}),
 		testManyCases('src/foo/fooBar.js', {camelCase: true}),
 		testManyCases('src/foo/FooBar.js', {kebabCase: true, pascalCase: true}),
 		testManyCases('src/foo/___foo_bar.js', {snakeCase: true, pascalCase: true}),


### PR DESCRIPTION
fixes #262 .

This option allows the rule to allow multiple cases.
Example: `cases: {pascalCase: true, camelCase: true}`.
