### PR TITLE
Make the `import-index` rule handle more cases

### DIFF
--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -1,7 +1,7 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const regexp = /^(@.*?\/.*?|[./]+?.*?)(?:\/(?:index(?:\.js)?)?)$/;
+const regexp = /^(@.*?\/.*?|[./]+?.*?)(?:\/((\.\/)*\.|(?:index(?:\.js)?))?)$/;
 const isImportingIndex = m => regexp.test(m);
 const normalize = m => m.replace(regexp, '$1');
 

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -1,7 +1,7 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const regexp = /^(@.*?\/.*?|[./]+?.*?)(?:\/((\.\/)*\.|(?:index(?:\.js)?))?)$/;
+const regexp = /^(@.*?\/.*?|[./]+?.*?)(?:\/(\.|(?:index(?:\.js)?))?)$/;
 const isImportingIndex = m => regexp.test(m);
 const normalize = m => m.replace(regexp, '$1');
 

--- a/test/import-index.js
+++ b/test/import-index.js
@@ -50,6 +50,16 @@ ruleTester.run('import-index', rule, {
 			output: 'const m = require(\'.\')'
 		},
 		{
+			code: 'const m = require(\'./.\')',
+			errors: [error],
+			output: 'const m = require(\'.\')'
+		},
+		{
+			code: 'const m = require(\'././.\')',
+			errors: [error],
+			output: 'const m = require(\'.\')'
+		},
+		{
 			code: 'const m = require(\'./index\')',
 			errors: [error],
 			output: 'const m = require(\'.\')'
@@ -63,6 +73,11 @@ ruleTester.run('import-index', rule, {
 			code: 'const m = require(\'../../index.js\')',
 			errors: [error],
 			output: 'const m = require(\'../..\')'
+		},
+		{
+			code: 'const m = require(\'../.\')',
+			errors: [error],
+			output: 'const m = require(\'..\')'
 		},
 		{
 			code: 'const m = require(\'./foo/index.js\')',

--- a/test/import-index.js
+++ b/test/import-index.js
@@ -55,11 +55,6 @@ ruleTester.run('import-index', rule, {
 			output: 'const m = require(\'.\')'
 		},
 		{
-			code: 'const m = require(\'././.\')',
-			errors: [error],
-			output: 'const m = require(\'.\')'
-		},
-		{
 			code: 'const m = require(\'./index\')',
 			errors: [error],
 			output: 'const m = require(\'.\')'


### PR DESCRIPTION
fixes #292 

`import-index` rule disallows `'../.'` and `'./.'`
