### PR TITLE
Apply `escape-case` to regex literal and remove transformation of `\c` escape on string literal

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"lodash.snakecase": "^4.0.1",
 		"lodash.topairs": "^4.3.0",
 		"lodash.upperfirst": "^4.2.0",
+		"regexpp": "^2.0.1",
 		"reserved-words": "^0.1.2",
 		"safe-regex": "^2.0.1"
 	},

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -34,7 +34,7 @@ const findLowercaseEscape = value => {
 
 	let escapeNodePosition;
 	visitRegExpAST(ast, {
-/**
+		/**
 Record escaped node position in regexpp ASTNode. Returns undefined if not found.
 @param {ASTNode} node A regexpp ASTNode. Note that it is of different type to the ASTNode of ESLint parsers
 @returns {undefined}
@@ -109,10 +109,13 @@ const create = context => {
 			const matches = node.value.raw.match(escapeWithLowercase);
 
 			if (matches && matches[2].slice(1).match(hasLowercaseCharacter)) {
+				// Move cursor inside the head and tail apostrophe
+				const start = node.range[0] + 1;
+				const end = node.range[1] - 1;
 				context.report({
 					node,
 					message,
-					fix: fixer => fixer.replaceTextRange([node.start, node.end], fix(node.value.raw, escapeWithLowercase))
+					fix: fixer => fixer.replaceTextRange([start, end], fix(node.value.raw, escapeWithLowercase))
 				});
 			}
 		}

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -1,7 +1,7 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const escapeWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u\{(?:[a-f\d]{1,})\}|c[a-z])/;
+const escapeWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u\{(?:[a-f\d]{1,})\})/;
 const hasLowercaseCharacter = /[a-z]+/;
 const message = 'Use uppercase characters for the value of the escape sequence.';
 

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -6,8 +6,8 @@ const {
 
 const getDocsUrl = require('./utils/get-docs-url');
 
-const escapeWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u\{(?:[a-f\d]{1,})\})/;
-const escapePatternWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u\{(?:[a-f\d]{1,})\}|c[a-z])/;
+const escapeWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u{(?:[a-f\d]+)})/;
+const escapePatternWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u{(?:[a-f\d]+)}|c[a-z])/;
 const hasLowercaseCharacter = /[a-z]+/;
 const message = 'Use uppercase characters for the value of the escape sequence.';
 

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -24,12 +24,14 @@ const fix = (value, regexp) => {
 };
 
 /**
- * Find the [start, end] position of the lowercase escape sequence in regular expression literal ASTNode
- * @param {string} value a string representation of a literal ASTNode
- * @return {number[]|null} [start, end] pair if found, null if not found
- */
+Find the `[start, end]` position of the lowercase escape sequence in a regular expression literal ASTNode.
+
+@param {string} value - String representation of a literal ASTNode.
+@returns {number[] | null} The `[start, end]` pair if found, or null if not.
+*/
 const findLowercaseEscape = value => {
 	const ast = parseRegExpLiteral(value);
+
 	let escapeNodePosition = null;
 	visitRegExpAST(ast, {
 		onCharacterLeave(node) {
@@ -44,21 +46,22 @@ const findLowercaseEscape = value => {
 			}
 		}
 	});
+
 	return escapeNodePosition;
 };
 
 /**
- * Produce a fix if there is any lowercase escape sequence in node
- * @param {ASTNode} node The Regular Expression Literal ASTNode to check
- * @return {string} The fixed `node.raw` string
- */
+Produce a fix if there is a lowercase escape sequence in the node.
+
+@param {ASTNode} node - The regular expression literal ASTNode to check.
+@returns {string} The fixed `node.raw` string.
+*/
 const fixRegExp = node => {
 	const escapeNodePosition = findLowercaseEscape(node.raw);
 	const {raw} = node;
 
 	if (escapeNodePosition) {
 		const [start, end] = escapeNodePosition;
-
 		return raw.slice(0, start) + fix(raw.slice(start, end), escapePatternWithLowercase) + raw.slice(end, raw.length);
 	}
 

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -27,13 +27,18 @@ const fix = (value, regexp) => {
 Find the `[start, end]` position of the lowercase escape sequence in a regular expression literal ASTNode.
 
 @param {string} value - String representation of a literal ASTNode.
-@returns {number[] | null} The `[start, end]` pair if found, or null if not.
+@returns {number[] | undefined} The `[start, end]` pair if found, or null if not.
 */
 const findLowercaseEscape = value => {
 	const ast = parseRegExpLiteral(value);
 
-	let escapeNodePosition = null;
+	let escapeNodePosition;
 	visitRegExpAST(ast, {
+/**
+Record escaped node position in regexpp ASTNode. Returns undefined if not found.
+@param {ASTNode} node A regexpp ASTNode. Note that it is of different type to the ASTNode of ESLint parsers
+@returns {undefined}
+*/
 		onCharacterLeave(node) {
 			if (escapeNodePosition) {
 				return;
@@ -81,7 +86,7 @@ const create = context => {
 				context.report({
 					node,
 					message,
-					fix: fixer => fixer.replaceTextRange([node.start, node.end], fix(node.raw, escapeWithLowercase))
+					fix: fixer => fixer.replaceText(node, fix(node.raw, escapeWithLowercase))
 				});
 			}
 		},
@@ -92,7 +97,7 @@ const create = context => {
 				context.report({
 					node,
 					message,
-					fix: fixer => fixer.replaceTextRange([node.start, node.end], fixRegExp(node))
+					fix: fixer => fixer.replaceText(node, fixRegExp(node))
 				});
 			}
 		},

--- a/test/escape-case.js
+++ b/test/escape-case.js
@@ -42,7 +42,15 @@ ruleTester.run('escape-case', rule, {
 		'const foo = `foo\\\\xbar`;',
 		'const foo = `foo\\\\ubarbaz`;',
 		'const foo = `foo\\\\\\\\xbar`;',
-		'const foo = `foo\\\\\\\\ubarbaz`;'
+		'const foo = `foo\\\\\\\\ubarbaz`;',
+		'const foo = /\\xA9/',
+		'const foo = /\\uD834/',
+		'const foo = /\\u{1D306}/u',
+		'const foo = /\\cA/',
+		'const foo = new RegExp("/\\xA9")',
+		'const foo = new RegExp("/\\uD834/")',
+		'const foo = new RegExp("/\\u{1D306}/", "u")',
+		'const foo = new RegExp("/\\cA/")'
 	],
 	invalid: [
 		{
@@ -139,6 +147,41 @@ ruleTester.run('escape-case', rule, {
 			code: 'const foo = `foo \\\\\\ud834`;',
 			errors,
 			output: 'const foo = `foo \\\\\\uD834`;'
+		},
+		{
+			code: 'const foo = /\\xa9/;',
+			errors,
+			output: 'const foo = /\\xA9/;'
+		},
+		{
+			code: 'const foo = /\\ud834/',
+			errors,
+			output: 'const foo = /\\uD834/'
+		},
+		{
+			code: 'const foo = /\\u{1d306}/u',
+			errors,
+			output: 'const foo = /\\u{1D306}/u'
+		},
+		{
+			code: 'const foo = /\\ca/',
+			errors,
+			output: 'const foo = /\\cA/'
+		},
+		{
+			code: 'const foo = new RegExp("/\\xa9")',
+			errors,
+			output: 'const foo = new RegExp("/\\xA9")'
+		},
+		{
+			code: 'const foo = new RegExp("/\\ud834/")',
+			errors,
+			output: 'const foo = new RegExp("/\\uD834/")'
+		},
+		{
+			code: 'const foo = new RegExp("/\\u{1d306}/", "u")',
+			errors,
+			output: 'const foo = new RegExp("/\\u{1D306}/", "u")'
 		}
 	]
 });

--- a/test/escape-case.js
+++ b/test/escape-case.js
@@ -21,11 +21,9 @@ ruleTester.run('escape-case', rule, {
 		'const foo = "\\xA9";',
 		'const foo = "\\uD834";',
 		'const foo = "\\u{1D306}";',
-		'const foo = "\\cA";',
 		'const foo = `\\xA9`;',
 		'const foo = `\\uD834`;',
 		'const foo = `\\u{1D306}`;',
-		'const foo = `\\cA`;',
 		'const foo = `\\uD834foo`;',
 		'const foo = `foo\\uD834`;',
 		'const foo = `foo \\uD834`;',
@@ -63,11 +61,6 @@ ruleTester.run('escape-case', rule, {
 			output: 'const foo = "\\u{1D306}";'
 		},
 		{
-			code: 'const foo = "\\ca";',
-			errors,
-			output: 'const foo = "\\cA";'
-		},
-		{
 			code: 'const foo = `\\xa9`;',
 			errors,
 			output: 'const foo = `\\xA9`;'
@@ -81,11 +74,6 @@ ruleTester.run('escape-case', rule, {
 			code: 'const foo = `\\u{1d306}`;',
 			errors,
 			output: 'const foo = `\\u{1D306}`;'
-		},
-		{
-			code: 'const foo = `\\ca`;',
-			errors,
-			output: 'const foo = `\\cA`;'
 		},
 		{
 			code: 'const foo = `\\ud834foo`;',


### PR DESCRIPTION
This PR addresses issue and feature request in #273. I've made separate commit on this.

Although the owner suggested using https://github.com/mysticatea/regexpp, I decide not to use it for performance considerations -- There would be many regular expression in a mature codebase and we can not afford the extra regular expression parse + replace cycle only to find whether there is any escapable sequence.

The original `escapeWithLowercase` pattern should work good enough on regular expression under most situation. I have minimally modified the code to support slightly difference escape syntax between string literal and RegExp literal/objects.

Fixes #273