### PR TITLE
Extend functionality of `no-for-loop`

### DIFF
--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -1,6 +1,7 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
+const defaultElementName = 'element';
 const isLiteralValue = value => node => node && node.type === 'Literal' && node.value === value;
 const isLiteralZero = isLiteralValue(0);
 const isLiteralOne = isLiteralValue(1);
@@ -311,7 +312,7 @@ const create = context => {
 					const shouldGenerateIndex = isIndexVariableUsedElsewhereInTheLoopBody(indexVariable, bodyScope, arrayIdentifierName);
 
 					const index = indexIdentifierName;
-					const element = elementIdentifierName || 'value';
+					const element = elementIdentifierName || defaultElementName;
 					const array = arrayIdentifierName;
 
 					const replacement = shouldGenerateIndex ?

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -326,7 +326,7 @@ const create = context => {
 						], replacement),
 						...arrayReferences.map(reference => {
 							if (reference === elementReference) {
-								return;
+								return null;
 							}
 
 							return fixer.replaceText(reference.identifier.parent, element);

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -325,12 +325,12 @@ const create = context => {
 						], replacement),
 						...arrayReferences.map(reference => {
 							if (reference === elementReference) {
-								return null;
+								return;
 							}
 
 							return fixer.replaceText(reference.identifier.parent, element);
 						}),
-						elementNode ? fixer.removeRange(getRemovalRange(elementNode, sourceCode)) : null
+						elementNode && fixer.removeRange(getRemovalRange(elementNode, sourceCode))
 					].filter(Boolean);
 				};
 			}

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -85,54 +85,6 @@ const getArrayIdentifierName = (forStatement, indexIdentifierName) => {
 	return getArrayIdentifierNameFromBinaryExpression(test, indexIdentifierName);
 };
 
-const isMatchingMemberExpression = (memberExpression, objectIdentifierName, propertyIdentifierName) => {
-	if (!memberExpression || memberExpression.type !== 'MemberExpression') {
-		return false;
-	}
-
-	const {object, property} = memberExpression;
-
-	return isIdentifierWithName(object, objectIdentifierName) &&
-		isIdentifierWithName(property, propertyIdentifierName);
-};
-
-const getElementIdentifierInfo = (forStatement, arrayIdentifierName, indexIdentifierName) => {
-	const {body} = forStatement;
-
-	if (!body ||
-		body.type !== 'BlockStatement'
-	) {
-		return;
-	}
-
-	const [elementVariableDeclaration] = body.body;
-
-	if (!elementVariableDeclaration ||
-		elementVariableDeclaration.type !== 'VariableDeclaration'
-	) {
-		return;
-	}
-
-	if (elementVariableDeclaration.declarations.length !== 1) {
-		return;
-	}
-
-	const [elementVariableDeclarator] = elementVariableDeclaration.declarations;
-
-	if (elementVariableDeclarator.id.type !== 'Identifier') {
-		return;
-	}
-
-	if (!isMatchingMemberExpression(elementVariableDeclarator.init, arrayIdentifierName, indexIdentifierName)) {
-		return;
-	}
-
-	return {
-		elementVariableDeclaration,
-		elementIdentifierName: elementVariableDeclarator.id.name
-	};
-};
-
 const isLiteralOnePlusIdentifierWithName = (node, identifierName) => {
 	if (node && node.type === 'BinaryExpression' && node.operator === '+') {
 		return (isIdentifierWithName(node.left, identifierName) && isLiteralOne(node.right)) ||
@@ -166,20 +118,54 @@ const checkUpdateExpression = (forStatement, indexIdentifierName) => {
 	return false;
 };
 
-const getRemovalRange = (node, sourceCode) => {
-	const nodeText = sourceCode.getText(node);
-	const {line} = sourceCode.getLocFromIndex(node.range[0]);
-	const lineText = sourceCode.lines[line - 1];
+const isOnlyArrayOfIndexVariableRead = (arrayReferences, indexIdentifierName) => {
+	return arrayReferences.every(reference => {
+		const node = reference.identifier.parent;
 
-	const isOnlyNodeOnItsLine = lineText.trim() === nodeText;
-	if (isOnlyNodeOnItsLine) {
-		return [
+		if (node.type !== 'MemberExpression') {
+			return false;
+		}
+
+		if (node.property.name !== indexIdentifierName) {
+			return false;
+		}
+
+		if (node.parent.type === 'AssignmentExpression' && node.parent.left === node) {
+			return false;
+		}
+
+		return true;
+	});
+};
+
+const getRemovalRange = (node, sourceCode) => {
+	const declarationNode = node.parent;
+
+	if (declarationNode.declarations.length === 1) {
+		const {line} = sourceCode.getLocFromIndex(declarationNode.range[0]);
+		const lineText = sourceCode.lines[line - 1];
+
+		const isOnlyNodeOnLine = lineText.trim() === sourceCode.getText(declarationNode);
+
+		return isOnlyNodeOnLine ? [
 			sourceCode.getIndexFromLoc({line, column: 0}),
 			sourceCode.getIndexFromLoc({line: line + 1, column: 0})
+		] : declarationNode.range;
+	}
+
+	const index = declarationNode.declarations.indexOf(node);
+
+	if (index === 0) {
+		return [
+			node.range[0],
+			declarationNode.declarations[1].range[0]
 		];
 	}
 
-	return node.range;
+	return [
+		declarationNode.declarations[index - 1].range[1],
+		node.range[1]
+	];
 };
 
 const resolveIdentifierName = (name, scope) => {
@@ -220,12 +206,24 @@ const nodeContains = (ancestor, descendant) => {
 	return false;
 };
 
-const isIndexVariableUsedElsewhereInTheLoopBody = (indexVariable, bodyScope) => {
+const isIndexVariableUsedElsewhereInTheLoopBody = (indexVariable, bodyScope, arrayIdentifierName) => {
 	const inBodyReferences = indexVariable.references.filter(reference => scopeContains(bodyScope, reference.from));
 
-	// One reference in the body would be the one in the element variable declaration like `const el = arr[i]`.
-	// Any reference besides that should retain the index variable.
-	return inBodyReferences.length > 1;
+	const referencesOtherThanArrayAccess = inBodyReferences.filter(reference => {
+		const node = reference.identifier.parent;
+
+		if (node.type !== 'MemberExpression') {
+			return true;
+		}
+
+		if (node.object.name !== arrayIdentifierName) {
+			return true;
+		}
+
+		return false;
+	});
+
+	return referencesOtherThanArrayAccess.length > 0;
 };
 
 const isIndexVariableAssignedToInTheLoopBody = (indexVariable, bodyScope) => {
@@ -265,34 +263,55 @@ const create = context => {
 				return;
 			}
 
-			const elementIdentifierInfo = getElementIdentifierInfo(node, arrayIdentifierName, indexIdentifierName);
-
-			if (!elementIdentifierInfo) {
+			if (!node.body || node.body.type !== 'BlockStatement') {
 				return;
 			}
 
-			const {elementIdentifierName, elementVariableDeclaration} = elementIdentifierInfo;
+			const forScope = scopeManager.acquire(node);
+			const bodyScope = scopeManager.acquire(node.body);
+
+			const indexVariable = resolveIdentifierName(indexIdentifierName, bodyScope);
+
+			if (isIndexVariableAssignedToInTheLoopBody(indexVariable, bodyScope)) {
+				return;
+			}
+
+			const arrayReferences = bodyScope.references.filter(reference => reference.identifier.name === arrayIdentifierName);
+
+			if (arrayReferences.length === 0) {
+				return;
+			}
+
+			if (!isOnlyArrayOfIndexVariableRead(arrayReferences, indexIdentifierName)) {
+				return;
+			}
 
 			const problem = {
 				node,
 				message: 'Use a `for-of` loop instead of this `for` loop.'
 			};
 
-			const forScope = scopeManager.acquire(node);
-			const bodyScope = scopeManager.acquire(node.body);
+			const elementReference = arrayReferences.find(reference => {
+				const node = reference.identifier.parent;
 
-			const indexVariable = resolveIdentifierName(indexIdentifierName, bodyScope);
-			const elementVariable = resolveIdentifierName(elementIdentifierName, bodyScope);
+				if (node.parent.type !== 'VariableDeclarator') {
+					return false;
+				}
 
-			const shouldFix = !someVariablesLeakOutOfTheLoop(node, [indexVariable, elementVariable], forScope) &&
-				!isIndexVariableAssignedToInTheLoopBody(indexVariable, bodyScope);
+				return true;
+			});
+			const elementNode = elementReference && elementReference.identifier.parent.parent;
+			const elementIdentifierName = elementNode && elementNode.id.name;
+			const elementVariable = elementIdentifierName && resolveIdentifierName(elementIdentifierName, bodyScope);
+
+			const shouldFix = !someVariablesLeakOutOfTheLoop(node, [indexVariable, elementVariable].filter(Boolean), forScope);
 
 			if (shouldFix) {
 				problem.fix = fixer => {
-					const shouldGenerateIndex = isIndexVariableUsedElsewhereInTheLoopBody(indexVariable, bodyScope);
+					const shouldGenerateIndex = isIndexVariableUsedElsewhereInTheLoopBody(indexVariable, bodyScope, arrayIdentifierName);
 
 					const index = indexIdentifierName;
-					const element = elementIdentifierName;
+					const element = elementIdentifierName || 'value';
 					const array = arrayIdentifierName;
 
 					const replacement = shouldGenerateIndex ?
@@ -304,9 +323,15 @@ const create = context => {
 							node.init.range[0],
 							node.update.range[1]
 						], replacement),
+						...arrayReferences.map(reference => {
+							if (reference === elementReference) {
+								return null;
+							}
 
-						fixer.removeRange(getRemovalRange(elementVariableDeclaration, sourceCode))
-					];
+							return fixer.replaceText(reference.identifier.parent, element);
+						}),
+						elementNode ? fixer.removeRange(getRemovalRange(elementNode, sourceCode)) : null
+					].filter(Boolean);
 				};
 			}
 

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -326,7 +326,7 @@ const create = context => {
 						], replacement),
 						...arrayReferences.map(reference => {
 							if (reference === elementReference) {
-								return null;
+								return undefined;
 							}
 
 							return fixer.replaceText(reference.identifier.parent, element);

--- a/test/integration/eslint-config-unicorn-tester/package.json
+++ b/test/integration/eslint-config-unicorn-tester/package.json
@@ -1,3 +1,10 @@
 {
-  "name": "eslint-config-unicorn-tester"
+  "name": "eslint-config-unicorn-tester",
+  "dependencies": {
+    "@typescript-eslint/parser": "^1.9.0",
+    "babel-eslint": "^10.0.1",
+    "eslint": "^5.16.0",
+    "eslint-plugin-unicorn": "file:../../..",
+    "typescript": "^3.4.5"
+  }
 }

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -139,8 +139,8 @@ ruleTester.run('no-for-loop', rule, {
 				console.log(arr[i])
 			}
 		`, `
-			for (const value of arr) {
-				console.log(value)
+			for (const element of arr) {
+				console.log(element)
 			}
 		`),
 

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -97,10 +97,6 @@ ruleTester.run('no-for-loop', rule, {
 			const el = f(i);
 			console.log(i, el);
 		}`,
-		`for (var j = 0; j < xs.length; j = j + 1) {
-			var x = xs[j], y = ys[j];
-			console.log(j, x, y);
-		}`,
 		`for (var j = 0; j < xs.length; j++) {
 			var x;
 		}`,
@@ -109,10 +105,45 @@ ruleTester.run('no-for-loop', rule, {
 		}`,
 		`for (let i = 0; i < arr.length; i++) {
 			console.log(i);
+		}`,
+
+		// Index is assigned to inside the loop body
+		`for (let i = 0; i < input.length; i++) {
+			const el = input[i];
+			i++;
+			console.log(i, el);
+		}`,
+
+		`for (let i = 0; i < input.length; i++) {
+			const el = input[i];
+			i = 4;
+			console.log(i, el);
+		}`,
+
+		// Using the array other than reading the index
+		`for (let i = 0; i < arr.length;i++) {
+			console.log(arr[i]);
+			arr.reverse();
+		}`,
+
+		// Modifying the array element
+		`for (let i = 0; i < arr.length; i++) {
+			arr[i] = i + 2;
 		}`
 	],
 
 	invalid: [
+		// Use default name
+		testCase(`
+			for (let i = 0; i < arr.length; i += 1) {
+				console.log(arr[i])
+			}
+		`, `
+			for (const value of arr) {
+				console.log(value)
+			}
+		`),
+
 		testCase(`
 			for (let i = 0; arr.length > i; i += 1) {
 				let el = arr[i];
@@ -186,19 +217,74 @@ ruleTester.run('no-for-loop', rule, {
 			console.log(el);
 		`),
 
-		// Index is assigned to inside the loop body, should not fix (#252)
+		// Complex element declarations
 		testCase(`
-			for (let i = 0; i < input.length; i++) {
-				const el = input[i];
-				i++;
-				console.log(i, el);
+			for (var j = 0; j < xs.length; j = j + 1) {
+				var x = xs[j], y = ys[j];
+				console.log(j, x, y);
+			}
+		`, `
+			for (const [j, x] of xs.entries()) {
+				var y = ys[j];
+				console.log(j, x, y);
 			}
 		`),
+
 		testCase(`
-			for (let i = 0; i < input.length; i++) {
-				const el = input[i];
-				i = 4;
-				console.log(i, el);
+			for (var j = 0; j < xs.length; j = j + 1) {
+				var y = ys[j], x = xs[j];
+				console.log(j, x, y);
+			}
+		`, `
+			for (const [j, x] of xs.entries()) {
+				var y = ys[j];
+				console.log(j, x, y);
+			}
+		`),
+
+		testCase(`
+			for (var j = 0; j < xs.length; j = j + 1) {
+				var y = ys[j], x = xs[j], i = 10;
+				console.log(j, x, y);
+			}
+		`, `
+			for (const [j, x] of xs.entries()) {
+				var y = ys[j], i = 10;
+				console.log(j, x, y);
+			}
+		`),
+
+		// Complex replacement without index
+		testCase(`
+			for (var i = 0; i < arr.length; i++) {
+				console.log(arr[i]);
+				arr[i].doSomething();
+				counter += arr[i].total;
+				const z = arr[i];
+			}
+		`, `
+			for (const z of arr) {
+				console.log(z);
+				z.doSomething();
+				counter += z.total;
+			}
+		`),
+
+		// Complex replacement with index
+		testCase(`
+			for (var i = 0; i < arr.length; i++) {
+				console.log(arr[i]);
+				arr[i].doSomething();
+				counter += arr[i].total;
+				const z = arr[i];
+				const y = i + 1;
+			}
+		`, `
+			for (const [i, z] of arr.entries()) {
+				console.log(z);
+				z.doSomething();
+				counter += z.total;
+				const y = i + 1;
 			}
 		`)
 	]


### PR DESCRIPTION
Fixes #286 

Works on part of #250 

## Summary
- Will track for variable declaration to `arrayName[indexName]` anywhere in the body
- Will fix even if the declaration is complex : `let x = 1, y = arr[i], z = 13;`
- Replaces all instances of `arr[i]` with the element name
- Will not report if `arr[i]` is set to anything or if the array variable is used any other way than to read `arr[i]` since that might have different effects in a regular `for` loop versus a `for..of`

- Moved the case of #252 to be completely ignored instead of not fixed since this is valid example of that, that can't be moved to `for..of`: 
```
for (let i = 0;i < arr.length;i++) {
  let el = arr[i];
  if (el.skipNext) {
    i++;
  }
  console.log(el);
}
```

So now, any time the index is set to in the loop body, the rule will ignore it

## Question

When there is this case: 
```
/* eslint unicorn/no-for-loop: 2 */
for (let i = 0; i < arr.length; i += 1) {
  console.log(arr[i])
}
```

it can be fixed with 
```
/* eslint unicorn/no-for-loop: 2 */
for (const value of arr) {
  console.log(value)
}
```

But the name `value` is arbitrary since the code doesn't provide a name itself. Do we want to keep it `value`? Or not fix? Or provide an option?