### PR TITLE
prefer-exponentiation-operator: Fix operator precedence bugs

### DIFF
--- a/rules/prefer-exponentiation-operator.js
+++ b/rules/prefer-exponentiation-operator.js
@@ -12,17 +12,34 @@ const isMathPow = node => {
 	);
 };
 
-const parseArgument = (context, arg) => {
-	if (arg.type === 'Identifier') {
-		return arg.name;
-	}
+const parseArgument = (source, arg) => {
+	const text = source.getText(arg);
 
-	return context.getSourceCode().getText(arg);
+	switch (arg.type) {
+		case 'Identifier':
+			return arg.name;
+		case 'Literal':
+			return text;
+		case 'CallExpression':
+			return text;
+		case 'UnaryExpression':
+			return text;
+		default:
+			// Handle cases like Math.pow(2, 2-1);
+			return `(${text})`;
+	}
 };
 
 const fix = (context, node, fixer) => {
-	const base = parseArgument(context, node.arguments[0]);
-	const exponent = parseArgument(context, node.arguments[1]);
+	const source = context.getSourceCode();
+	const comments = source.getCommentsInside(node);
+
+	if (comments && comments.length > 0) {
+		return;
+	}
+
+	const base = parseArgument(source, node.arguments[0]);
+	const exponent = parseArgument(source, node.arguments[1]);
 
 	const replacement = `${base} ** ${exponent}`;
 

--- a/test/prefer-exponentiation-operator.js
+++ b/test/prefer-exponentiation-operator.js
@@ -24,7 +24,7 @@ ruleTester.run('prefer-exponentiation-operator', rule, {
 		{
 			code: 'const x = Math.pow(-2, (2 - 4) +0 -0.2);',
 			errors: [{message}],
-			output: 'const x = -2 ** (2 - 4) +0 -0.2;'
+			output: 'const x = -2 ** ((2 - 4) +0 -0.2);'
 		},
 		{
 			code: 'const x = Math.pow(Math.pow(2, 4), 8);',
@@ -48,6 +48,36 @@ ruleTester.run('prefer-exponentiation-operator', rule, {
 			code: 'const x = Math.pow(foo(), bar());',
 			errors: [{message}],
 			output: 'const x = foo() ** bar();'
+		},
+		{
+			code: 'const x = Math.pow(-2, 2 - 4);',
+			errors: [{message}],
+			output: 'const x = -2 ** (2 - 4);'
+		},
+		{
+			code: 'const x = Math.pow(4 - 2, 2 - 4);',
+			errors: [{message}],
+			output: 'const x = (4 - 2) ** (2 - 4);'
+		},
+		{
+			code: 'const x = Math.pow(\n2,\n2);',
+			errors: [{message}],
+			output: 'const x = 2 ** 2;'
+		},
+		{
+			code: 'const x = Math.pow(\n2,2 +\n2);',
+			errors: [{message}],
+			output: 'const x = 2 ** (2 +\n2);'
+		},
+		{
+			code: 'const x = Math.pow(\n2, // foo\n2);',
+			errors: [{message}],
+			output: 'const x = Math.pow(\n2, // foo\n2);'
+		},
+		{
+			code: 'const x = Math.pow(// foo\n2, 2);',
+			errors: [{message}],
+			output: 'const x = Math.pow(// foo\n2, 2);'
 		}
 	]
 });


### PR DESCRIPTION
Fixes #304.

* Wraps things in parentheses by default
* Removes parentheses for known safe node types
* Also turns the fixer off if it detects comments since fixing with comments is non-trivial