### PR TITLE
Add `consistent-function-scoping` rule

### DIFF
--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -1,6 +1,6 @@
-# Prefer consistent function scoping
+# Move function definitions to the highest possible scope
 
-A function definition should be placed as close to the top-level scope as possible without breaking its captured values.
+A function definition should be placed as close to the top-level scope as possible without breaking its captured values. This improves readability and allows JavaScript engines to better optimize performance.
 
 
 ## Fail
@@ -40,5 +40,20 @@ export function doFoo(foo) {
   }
 
   return doBar;
+}
+```
+
+## Limitations
+
+This rule does not detect or remove extraneous code blocks:
+
+```js
+function doFoo(foo) {
+  {
+		function doBar(bar) {
+			return bar;
+		}
+	}
+  return foo;
 }
 ```

--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -7,12 +7,12 @@ A function definition should be placed as close to the top-level scope as possib
 
 ```js
 export function doFoo(foo) {
-  // Does not capture anything from the scope, can be moved to the outer scope
-  function doBar(bar) {
-    return bar === 'bar';
-  }
+	// Does not capture anything from the scope, can be moved to the outer scope
+	function doBar(bar) {
+		return bar === 'bar';
+	}
 
-  return doBar;
+	return doBar;
 }
 
 function doFoo(foo) {
@@ -27,21 +27,22 @@ function doFoo(foo) {
 
 ```js
 function doBar(bar) {
-  return bar === 'bar';
+	return bar === 'bar';
 }
 
 export function doFoo(foo) {
-  return doBar;
+	return doBar;
 }
 
 export function doFoo(foo) {
-  function doBar(bar) {
-    return bar === 'bar' && foo.doBar(bar);
-  }
+	function doBar(bar) {
+		return bar === 'bar' && foo.doBar(bar);
+	}
 
-  return doBar;
+	return doBar;
 }
 ```
+
 
 ## Limitations
 
@@ -49,11 +50,12 @@ This rule does not detect or remove extraneous code blocks inside of functions:
 
 ```js
 function doFoo(foo) {
-  {
+	{
 		function doBar(bar) {
 			return bar;
 		}
 	}
-  return foo;
+
+	return foo;
 }
 ```

--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -45,7 +45,7 @@ export function doFoo(foo) {
 
 ## Limitations
 
-This rule does not detect or remove extraneous code blocks:
+This rule does not detect or remove extraneous code blocks inside of functions:
 
 ```js
 function doFoo(foo) {

--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -1,8 +1,10 @@
 # Prefer consistent function scoping
 
-A function definition should be placed as close to the top level scope as possible without breaking it's captured values.
+A function definition should be placed as close to the top-level scope as possible without breaking its captured values.
+
 
 ## Fail
+
 ```js
 export function doFoo(foo) {
   // Does not capture anything from the scope, can be moved to the outer scope
@@ -14,13 +16,15 @@ export function doFoo(foo) {
 }
 
 function doFoo(foo) {
-	const doBar = (bar) => {
+	const doBar = bar => {
 		return bar === 'bar';
 	};
 }
 ```
 
+
 ## Pass
+
 ```js
 function doBar(bar) {
   return bar === 'bar';

--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -1,6 +1,6 @@
 # Move function definitions to the highest possible scope
 
-A function definition should be placed as close to the top-level scope as possible without breaking its captured values. This improves readability and allows JavaScript engines to better optimize performance.
+A function definition should be placed as close to the top-level scope as possible without breaking its captured values. This improves readability, [directly improves performance](https://stackoverflow.com/a/81329/207247) and allows JavaScript engines to [better optimize performance](https://ponyfoo.com/articles/javascript-performance-pitfalls-v8#optimization-limit).
 
 
 ## Fail

--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -1,0 +1,40 @@
+# Prefer consistent function scoping
+
+A function definition should be placed as close to the top level scope as possible without breaking it's captured values.
+
+## Fail
+```js
+export function doFoo(foo) {
+  // Does not capture anything from the scope, can be moved to the outer scope
+  function doBar(bar) {
+    return bar === 'bar';
+  }
+
+  return doBar;
+}
+
+function doFoo(foo) {
+	const doBar = (bar) => {
+		return bar === 'bar';
+	};
+}
+```
+
+## Pass
+```js
+function doBar(bar) {
+  return bar === 'bar';
+}
+
+export function doFoo(foo) {
+  return doBar;
+}
+
+export function doFoo(foo) {
+  function doBar(bar) {
+    return bar === 'bar' && foo.doBar(bar);
+  }
+
+  return doBar;
+}
+```

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
 			],
 			rules: {
 				'unicorn/catch-error-name': 'error',
+				'unicorn/consistent-function-scoping': 'error',
 				'unicorn/custom-error-definition': 'off',
 				'unicorn/error-message': 'error',
 				'unicorn/escape-case': 'error',

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ Configure it in `package.json`.
 ## Rules
 
 - [catch-error-name](docs/rules/catch-error-name.md) - Enforce a specific parameter name in catch clauses.
-- [consistent-function-scoping](docs/rules/consistent-function-scoping.md) - Prefer consistent function scoping.
+- [consistent-function-scoping](docs/rules/consistent-function-scoping.md) - Move function definitions to the highest possible scope.
 - [custom-error-definition](docs/rules/custom-error-definition.md) - Enforce correct `Error` subclassing. *(fixable)*
 - [error-message](docs/rules/error-message.md) - Enforce passing a `message` value when throwing a built-in error.
 - [escape-case](docs/rules/escape-case.md) - Require escape sequences to use uppercase values. *(fixable)*

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ Configure it in `package.json`.
 		],
 		"rules": {
 			"unicorn/catch-error-name": "error",
+			"unicorn/consistent-function-scoping": "error",
 			"unicorn/custom-error-definition": "off",
 			"unicorn/error-message": "error",
 			"unicorn/escape-case": "error",
@@ -79,6 +80,7 @@ Configure it in `package.json`.
 ## Rules
 
 - [catch-error-name](docs/rules/catch-error-name.md) - Enforce a specific parameter name in catch clauses.
+- [consistent-function-scoping](docs/rules/consistent-function-scoping.md) - Prefer consistent function scoping.
 - [custom-error-definition](docs/rules/custom-error-definition.md) - Enforce correct `Error` subclassing. *(fixable)*
 - [error-message](docs/rules/error-message.md) - Enforce passing a `message` value when throwing a built-in error.
 - [escape-case](docs/rules/escape-case.md) - Require escape sequences to use uppercase values. *(fixable)*

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -124,8 +124,8 @@ module.exports = {
 			url: getDocsUrl(__filename)
 		},
 		messages: {
-			[MESSAGE_ID_ARROW]: 'Move arrow function to outer scope.',
-			[MESSAGE_ID_FUNCTION]: 'Move function to outer scope.'
+			[MESSAGE_ID_ARROW]: 'Move arrow function to the outer scope.',
+			[MESSAGE_ID_FUNCTION]: 'Move function to the outer scope.'
 		}
 	}
 };

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -1,7 +1,8 @@
 'use strict';
 const getDocsUrl = require('./utils/get-docs-url');
 
-const MESSAGE_ID = 'consistentFunctionScoping';
+const MESSAGE_ID_ARROW = 'ArrowFunctionExpression';
+const MESSAGE_ID_FUNCTION = 'FunctionDeclaration';
 
 function checkReferences(scope, parents, scopeManager) {
 	if (!scope) {
@@ -118,7 +119,7 @@ const create = context => {
 
 			context.report({
 				node,
-				messageId: MESSAGE_ID
+				messageId: MESSAGE_ID_ARROW
 			});
 		},
 		FunctionDeclaration(node) {
@@ -130,7 +131,7 @@ const create = context => {
 
 			context.report({
 				node,
-				messageId: MESSAGE_ID
+				messageId: MESSAGE_ID_FUNCTION
 			});
 		}
 	};
@@ -144,7 +145,8 @@ module.exports = {
 			url: getDocsUrl(__filename)
 		},
 		messages: {
-			[MESSAGE_ID]: 'Move function to outer scope.'
+			[MESSAGE_ID_ARROW]: 'Move arrow function to outer scope.',
+			[MESSAGE_ID_FUNCTION]: 'Move function to outer scope.'
 		}
 	}
 };

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -1,0 +1,84 @@
+'use strict';
+const getDocsUrl = require('./utils/get-docs-url');
+
+const MESSAGE_ID = 'consistentFunctionScoping';
+
+function checkVariables(scope, variables) {
+	if (!variables || variables.length === 0) {
+		return false;
+	}
+
+	const hit = variables.some(variable => {
+		if (!variable.references || variable.references.length === 0) {
+			return false;
+		}
+
+		return variable.references.some(reference => {
+			return reference.from === scope;
+		});
+	});
+
+	if (hit) {
+		return hit;
+	}
+
+	return scope.childScopes.some(scope => {
+		return checkVariables(scope, variables);
+	});
+}
+
+const create = context => {
+	const sourceCode = context.getSourceCode();
+	const {scopeManager} = sourceCode;
+
+	return {
+		FunctionDeclaration(node) {
+			const scope = scopeManager.acquire(node);
+			if (!scope) {
+				return;
+			}
+
+			if (scope.type === 'global') {
+				return;
+			}
+
+			let parentNode = node.parent;
+			if (!parentNode) {
+				return;
+			}
+
+			if (parentNode.type === 'BlockStatement') {
+				parentNode = parentNode.parent;
+			}
+
+			const parentScope = scopeManager.acquire(parentNode);
+			if (!parentScope || parentScope.type === 'global') {
+				return;
+			}
+
+			const hit = checkVariables(scope, parentScope.variables);
+
+			if (hit) {
+				return;
+			}
+
+			context.report({
+				node,
+				messageId: MESSAGE_ID
+			});
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		type: 'suggestion',
+		docs: {
+			url: getDocsUrl(__filename)
+		},
+		messages: {
+			[MESSAGE_ID]: 'Move function to outer scope.'
+		}
+	}
+};

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -104,14 +104,14 @@ ruleTester.run('consistent-function-scoping', rule, {
 			}
 		`,
 		outdent`
-			const doFoo = (foo) => {
+			const doFoo = foo => {
 				return foo;
 			}
 		`,
 		outdent`
 			const doFoo =
-				(foo) =>
-				(bar) =>
+				foo =>
+				bar =>
 				foo + bar;
 		`,
 		outdent`

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -21,11 +21,28 @@ ruleTester.run('consistent-function-scoping', rule, {
 		}
 		`,
 		`
+		const doFoo = (foo) => foo;
+		`,
+		`
 		function doFoo(foo) {
 			function doBar(bar) {
 				return foo + bar;
 			}
 			return foo;
+		}
+		`,
+		`
+		function doFoo(foo) {
+			function doBar(bar) {
+				return foo + bar;
+			}
+		}
+		`,
+		`
+		function doFoo(foo = 'foo') {
+			function doBar(bar) {
+				return foo + bar;
+			}
 		}
 		`,
 		`
@@ -71,10 +88,18 @@ ruleTester.run('consistent-function-scoping', rule, {
 		}
 		`,
 		`
-		const doFoo = (foo) => (bar) => foo + bar;
+		const xxx =
+			(yyy) =>
+			(zzz) =>
+			yyy + zzz;
 		`,
 		`
 		const doFoo = () => {
+			return (bar) => bar;
+		}
+		`,
+		`
+		function doFoo() {
 			return (bar) => bar;
 		}
 		`,
@@ -147,6 +172,6 @@ ruleTester.run('consistent-function-scoping', rule, {
 			}
 			`,
 			errors: [error]
-		},
+		}
 	]
 });

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -8,9 +8,14 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-const error = {
+const arrowError = {
 	ruleId: 'consistent-function-scoping',
-	messageId: 'consistentFunctionScoping'
+	messageId: 'ArrowFunctionExpression'
+};
+
+const functionError = {
+	ruleId: 'consistent-function-scoping',
+	messageId: 'FunctionDeclaration'
 };
 
 ruleTester.run('consistent-function-scoping', rule, {
@@ -122,7 +127,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return foo;
 			}
 			`,
-			errors: [error]
+			errors: [functionError]
 		},
 		{
 			code: `
@@ -134,7 +139,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return foo;
 			}
 			`,
-			errors: [error]
+			errors: [functionError]
 		},
 		{
 			code: `
@@ -144,7 +149,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 			}
 			`,
-			errors: [error]
+			errors: [functionError]
 		},
 		{
 			code: `
@@ -154,13 +159,13 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 			}
 			`,
-			errors: [error]
+			errors: [arrowError]
 		},
 		{
 			code: `
 			const doFoo = () => (bar) => bar;
 			`,
-			errors: [error]
+			errors: [arrowError]
 		},
 		{
 			code: `
@@ -171,7 +176,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return foo;
 			}
 			`,
-			errors: [error]
+			errors: [functionError]
 		}
 	]
 });

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -87,13 +87,6 @@ ruleTester.run('consistent-function-scoping', rule, {
 			}
 		`,
 		outdent`
-			for (let foo = 0; foo < 1; foo++) {
-				function doBar(bar) {
-					return bar;
-				}
-			}
-		`,
-		outdent`
 			let foo = 0;
 			function doFoo() {
 				foo = 1;
@@ -255,6 +248,16 @@ ruleTester.run('consistent-function-scoping', rule, {
 						function doBar(bar) {
 							return bar;
 						}
+					}
+				}
+			`,
+			errors: [functionError]
+		},
+		{
+			code: outdent`
+				for (let foo = 0; foo < 1; foo++) {
+					function doBar(bar) {
+						return bar;
 					}
 				}
 			`,

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -61,7 +61,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 		`,
 		outdent`
 			function doFoo() {
-				var foo = 'foo';
+				const foo = 'foo';
 				function doBar(bar) {
 					return foo + bar;
 				}
@@ -80,21 +80,21 @@ ruleTester.run('consistent-function-scoping', rule, {
 			}
 		`,
 		outdent`
-			for (var foo = 0; foo < 1; foo++) {
+			for (let foo = 0; foo < 1; foo++) {
 				function doBar(bar) {
 					return bar + foo;
 				}
 			}
 		`,
 		outdent`
-			for (var foo = 0; foo < 1; foo++) {
+			for (let foo = 0; foo < 1; foo++) {
 				function doBar(bar) {
 					return bar;
 				}
 			}
 		`,
 		outdent`
-			var foo = 0;
+			let foo = 0;
 			function doFoo() {
 				foo = 1;
 				function doBar(bar) {
@@ -168,7 +168,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 		{
 			code: outdent`
 				function doFoo() {
-					var foo = 'foo';
+					const foo = 'foo';
 					function doBar(bar) {
 						return bar;
 					}

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -29,12 +29,59 @@ ruleTester.run('consistent-function-scoping', rule, {
 		}
 		`,
 		`
+		function doFoo() {
+			var foo = 'foo';
+			function doBar(bar) {
+				return foo + bar;
+			}
+			return foo;
+		}
+		`,
+		`
 		function doFoo(foo) {
 			function doBar(bar) {
 				function doZaz(zaz) {
 					return foo + bar + zaz;
 				}
 				return bar;
+			}
+			return foo;
+		}
+		`,
+		`
+		for (var foo = 0; foo < 1; foo++) {
+			function doBar(bar) {
+			  	return bar + foo;
+			}
+		}
+		`,
+		`
+		var foo = 0;
+		function doFoo() {
+			foo = 1;
+			function doBar(bar) {
+				return foo + bar;
+			}
+			return foo;
+		}
+		`,
+		`
+		const doFoo = (foo) => {
+			return foo;
+		}
+		`,
+		`
+		const doFoo = (foo) => (bar) => foo + bar;
+		`,
+		`
+		const doFoo = () => {
+			return (bar) => bar;
+		}
+		`,
+		`
+		const doFoo = (foo) => {
+			const doBar = (bar) => {
+				return foo + bar;
 			}
 			return foo;
 		}
@@ -45,12 +92,61 @@ ruleTester.run('consistent-function-scoping', rule, {
 			code: `
 			function doFoo(foo) {
 				function doBar(bar) {
-				  return bar;
+				  	return bar;
 				}
 				return foo;
 			}
 			`,
 			errors: [error]
-		}
+		},
+		{
+			code: `
+			function doFoo() {
+				var foo = 'foo';
+				function doBar(bar) {
+				  	return bar;
+				}
+				return foo;
+			}
+			`,
+			errors: [error]
+		},
+		{
+			code: `
+			function doFoo() {
+				function doBar(bar) {
+					return bar;
+				}
+			}
+			`,
+			errors: [error]
+		},
+		{
+			code: `
+			const doFoo = () => {
+				const doBar = (bar) => {
+					return bar;
+				}
+			}
+			`,
+			errors: [error]
+		},
+		{
+			code: `
+			const doFoo = () => (bar) => bar;
+			`,
+			errors: [error]
+		},
+		{
+			code: `
+			function doFoo(foo) {
+				function doBar(bar) {
+					return doBar(bar);
+				}
+				return foo;
+			}
+			`,
+			errors: [error]
+		},
 	]
 });

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -26,7 +26,15 @@ ruleTester.run('consistent-function-scoping', rule, {
 		}
 		`,
 		`
+		function doFoo(foo) {
+			return bar;
+		}
+		`,
+		`
 		const doFoo = (foo) => foo;
+		`,
+		`
+		(foo) => foo;
 		`,
 		`
 		function doFoo(foo) {
@@ -78,6 +86,13 @@ ruleTester.run('consistent-function-scoping', rule, {
 		}
 		`,
 		`
+		for (var foo = 0; foo < 1; foo++) {
+			function doBar(bar) {
+				return bar;
+			}
+		}
+		`,
+		`
 		var foo = 0;
 		function doFoo() {
 			foo = 1;
@@ -93,10 +108,10 @@ ruleTester.run('consistent-function-scoping', rule, {
 		}
 		`,
 		`
-		const xxx =
-			(yyy) =>
-			(zzz) =>
-			yyy + zzz;
+		const doFoo =
+			(foo) =>
+			(bar) =>
+			foo + bar;
 		`,
 		`
 		const doFoo = () => {
@@ -185,6 +200,14 @@ ruleTester.run('consistent-function-scoping', rule, {
 				  	return bar;
 				}
 				return doBar;
+			}
+			`,
+			errors: [functionError]
+		},
+		{
+			code: `
+			function doFoo() {
+				function doBar() {}
 			}
 			`,
 			errors: [functionError]

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
+import {outdent} from 'outdent';
 import rule from '../rules/consistent-function-scoping';
 
 const ruleTester = avaRuleTester(test, {
@@ -20,195 +21,242 @@ const functionError = {
 
 ruleTester.run('consistent-function-scoping', rule, {
 	valid: [
-		`
-		function doFoo(foo) {
-			return foo;
-		}
-		`,
-		`
-		function doFoo(foo) {
-			return bar;
-		}
-		`,
-		`
-		const doFoo = (foo) => foo;
-		`,
-		`
-		(foo) => foo;
-		`,
-		`
-		function doFoo(foo) {
-			function doBar(bar) {
-				return foo + bar;
+		outdent`
+			function doFoo(foo) {
+				return foo;
 			}
-			return foo;
-		}
 		`,
-		`
-		function doFoo(foo) {
-			function doBar(bar) {
-				return foo + bar;
+		outdent`
+			function doFoo(foo) {
+				return bar;
 			}
-		}
 		`,
-		`
-		function doFoo(foo = 'foo') {
-			function doBar(bar) {
-				return foo + bar;
-			}
-		}
+		outdent`
+			const doFoo = (foo) => foo;
 		`,
-		`
-		function doFoo() {
-			var foo = 'foo';
-			function doBar(bar) {
-				return foo + bar;
-			}
-			return foo;
-		}
+		outdent`
+			(foo) => foo;
 		`,
-		`
-		function doFoo(foo) {
-			function doBar(bar) {
-				function doZaz(zaz) {
-					return foo + bar + zaz;
+		outdent`
+			function doFoo(foo) {
+				function doBar(bar) {
+					return foo + bar;
 				}
-				return bar;
+				return foo;
 			}
-			return foo;
-		}
 		`,
-		`
-		for (var foo = 0; foo < 1; foo++) {
-			function doBar(bar) {
-			  	return bar + foo;
+		outdent`
+			function doFoo(foo) {
+				function doBar(bar) {
+					return foo + bar;
+				}
 			}
-		}
 		`,
-		`
-		for (var foo = 0; foo < 1; foo++) {
-			function doBar(bar) {
-				return bar;
+		outdent`
+			function doFoo(foo = 'foo') {
+				function doBar(bar) {
+					return foo + bar;
+				}
 			}
-		}
 		`,
-		`
-		var foo = 0;
-		function doFoo() {
-			foo = 1;
-			function doBar(bar) {
-				return foo + bar;
+		outdent`
+			function doFoo() {
+				var foo = 'foo';
+				function doBar(bar) {
+					return foo + bar;
+				}
+				return foo;
 			}
-			return foo;
-		}
 		`,
-		`
-		const doFoo = (foo) => {
-			return foo;
-		}
-		`,
-		`
-		const doFoo =
-			(foo) =>
-			(bar) =>
-			foo + bar;
-		`,
-		`
-		const doFoo = () => {
-			return (bar) => bar;
-		}
-		`,
-		`
-		function doFoo() {
-			return (bar) => bar;
-		}
-		`,
-		`
-		const doFoo = (foo) => {
-			const doBar = (bar) => {
-				return foo + bar;
+		outdent`
+			function doFoo(foo) {
+				function doBar(bar) {
+					function doZaz(zaz) {
+						return foo + bar + zaz;
+					}
+					return bar;
+				}
+				return foo;
 			}
-			return foo;
-		}
+		`,
+		outdent`
+			for (var foo = 0; foo < 1; foo++) {
+				function doBar(bar) {
+					return bar + foo;
+				}
+			}
+		`,
+		outdent`
+			for (var foo = 0; foo < 1; foo++) {
+				function doBar(bar) {
+					return bar;
+				}
+			}
+		`,
+		outdent`
+			var foo = 0;
+			function doFoo() {
+				foo = 1;
+				function doBar(bar) {
+					return foo + bar;
+				}
+				return foo;
+			}
+		`,
+		outdent`
+			const doFoo = (foo) => {
+				return foo;
+			}
+		`,
+		outdent`
+			const doFoo =
+				(foo) =>
+				(bar) =>
+				foo + bar;
+		`,
+		outdent`
+			const doFoo = () => {
+				return (bar) => bar;
+			}
+		`,
+		outdent`
+			function doFoo() {
+				return (bar) => bar;
+			}
+		`,
+		outdent`
+			const doFoo = (foo) => {
+				const doBar = (bar) => {
+					return foo + bar;
+				}
+				return foo;
+			}
+		`,
+		outdent`
+			function doFoo() {
+				{
+					const foo = 'foo';
+					function doBar(bar) {
+						return bar + foo;
+					}
+				}
+			}
+		`,
+		outdent`
+			function doFoo(foo) {
+				{
+					function doBar(bar) {
+						return bar;
+					}
+				}
+				return foo;
+			}
 		`
 	],
 	invalid: [
 		{
-			code: `
-			function doFoo(foo) {
-				function doBar(bar) {
-				  	return bar;
+			code: outdent`
+				function doFoo(foo) {
+					function doBar(bar) {
+						return bar;
+					}
+					return foo;
 				}
-				return foo;
-			}
 			`,
 			errors: [functionError]
 		},
 		{
-			code: `
-			function doFoo() {
-				var foo = 'foo';
-				function doBar(bar) {
-				  	return bar;
+			code: outdent`
+				function doFoo() {
+					var foo = 'foo';
+					function doBar(bar) {
+						return bar;
+					}
+					return foo;
 				}
-				return foo;
-			}
 			`,
 			errors: [functionError]
 		},
 		{
-			code: `
-			function doFoo() {
-				function doBar(bar) {
-					return bar;
+			code: outdent`
+				function doFoo() {
+					function doBar(bar) {
+						return bar;
+					}
 				}
-			}
 			`,
 			errors: [functionError]
 		},
 		{
-			code: `
-			const doFoo = () => {
-				const doBar = (bar) => {
-					return bar;
+			code: outdent`
+				const doFoo = () => {
+					const doBar = (bar) => {
+						return bar;
+					}
 				}
-			}
 			`,
 			errors: [arrowError]
 		},
 		{
-			code: `
-			const doFoo = () => (bar) => bar;
+			code: outdent`
+				const doFoo = () => (bar) => bar;
 			`,
 			errors: [arrowError]
 		},
 		{
-			code: `
-			function doFoo(foo) {
-				function doBar(bar) {
-					return doBar(bar);
+			code: outdent`
+				function doFoo(foo) {
+					function doBar(bar) {
+						return doBar(bar);
+					}
+					return foo;
 				}
-				return foo;
-			}
 			`,
 			errors: [functionError]
 		},
 		{
-			code: `
-			function doFoo(foo) {
-				function doBar(bar) {
-				  	return bar;
+			code: outdent`
+				function doFoo(foo) {
+					function doBar(bar) {
+						return bar;
+					}
+					return doBar;
 				}
-				return doBar;
-			}
 			`,
 			errors: [functionError]
 		},
 		{
-			code: `
-			function doFoo() {
-				function doBar() {}
-			}
+			code: outdent`
+				function doFoo() {
+					function doBar() {}
+				}
+			`,
+			errors: [functionError]
+		},
+		{
+			code: outdent`
+				function doFoo(foo) {
+					{
+						{
+							function doBar(bar) {
+								return bar;
+							}
+						}
+					}
+					return foo;
+				}
+			`,
+			errors: [functionError]
+		},
+		{
+			code: outdent`
+				{
+					{
+						function doBar(bar) {
+							return bar;
+						}
+					}
+				}
 			`,
 			errors: [functionError]
 		}

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -32,10 +32,10 @@ ruleTester.run('consistent-function-scoping', rule, {
 			}
 		`,
 		outdent`
-			const doFoo = (foo) => foo;
+			const doFoo = foo => foo;
 		`,
 		outdent`
-			(foo) => foo;
+			foo => foo;
 		`,
 		outdent`
 			function doFoo(foo) {
@@ -116,17 +116,17 @@ ruleTester.run('consistent-function-scoping', rule, {
 		`,
 		outdent`
 			const doFoo = () => {
-				return (bar) => bar;
+				return bar => bar;
 			}
 		`,
 		outdent`
 			function doFoo() {
-				return (bar) => bar;
+				return bar => bar;
 			}
 		`,
 		outdent`
-			const doFoo = (foo) => {
-				const doBar = (bar) => {
+			const doFoo = foo => {
+				const doBar = bar => {
 					return foo + bar;
 				}
 				return foo;
@@ -190,7 +190,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 		{
 			code: outdent`
 				const doFoo = () => {
-					const doBar = (bar) => {
+					const doBar = bar => {
 						return bar;
 					}
 				}
@@ -199,7 +199,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 		},
 		{
 			code: outdent`
-				const doFoo = () => (bar) => bar;
+				const doFoo = () => bar => bar;
 			`,
 			errors: [arrowError]
 		},

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -1,0 +1,56 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/consistent-function-scoping';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const error = {
+	ruleId: 'consistent-function-scoping',
+	messageId: 'consistentFunctionScoping'
+};
+
+ruleTester.run('consistent-function-scoping', rule, {
+	valid: [
+		`
+		function doFoo(foo) {
+			return foo;
+		}
+		`,
+		`
+		function doFoo(foo) {
+			function doBar(bar) {
+				return foo + bar;
+			}
+			return foo;
+		}
+		`,
+		`
+		function doFoo(foo) {
+			function doBar(bar) {
+				function doZaz(zaz) {
+					return foo + bar + zaz;
+				}
+				return bar;
+			}
+			return foo;
+		}
+		`
+	],
+	invalid: [
+		{
+			code: `
+			function doFoo(foo) {
+				function doBar(bar) {
+				  return bar;
+				}
+				return foo;
+			}
+			`,
+			errors: [error]
+		}
+	]
+});

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -177,6 +177,17 @@ ruleTester.run('consistent-function-scoping', rule, {
 			}
 			`,
 			errors: [functionError]
+		},
+		{
+			code: `
+			function doFoo(foo) {
+				function doBar(bar) {
+				  	return bar;
+				}
+				return doBar;
+			}
+			`,
+			errors: [functionError]
 		}
 	]
 });


### PR DESCRIPTION
Closes #230.

Covers functions and arrow functions. Does NOT cover things like for loops.