### PR TITLE
custom-error-definition: Cover exports name

### DIFF
--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -118,17 +118,15 @@ ruleTester.run('custom-error-definition', rule, {
 		`
 			exports.whatever = class Whatever {};
 		`,
-		{
-			code: `
-				class FooError extends Error {
-					constructor(error) {
-						super(error);
-						this.name = 'FooError';
-					}
-				};
-				exports.fooError = FooError;
-			`
-		}
+		`
+			class FooError extends Error {
+				constructor(error) {
+					super(error);
+					this.name = 'FooError';
+				}
+			};
+			exports.fooError = FooError;
+		`
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Fixes #190.

I cheated a bit for this one. If the rule is turned on it will force the error name to be correct so the rule only has to check for a mismatch on the `exports` identifier in the case where the right hand side is an error class.

There was another interesting case that I did NOT cover:

```js
class FooError extends Error {
	constructor(error) {
		super(error);
		this.name = 'FooError';
	}
};
exports.fooError = FooError;
```

It would theoretically be possible to find an error definition from earlier in the same file. If we want this scenario covered, then I can add it in.
