### PR TITLE
Do not warn if `.flat()` has more than one parameter or if the one parameter is not `1`

### DIFF
--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -98,6 +98,10 @@ const create = context => ({
 			return;
 		}
 
+		if (node.arguments.length > 0) {
+			return;
+		}
+
 		const parent = node.callee.object;
 
 		if (!isMethodNamed(parent, 'map')) {

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -98,7 +98,11 @@ const create = context => ({
 			return;
 		}
 
-		if (node.arguments.length > 0) {
+		if (node.arguments.length > 1) {
+			return;
+		}
+
+		if (node.arguments.length === 1 && node.arguments[0].type === 'Literal' && node.arguments[0].value !== 1) {
 			return;
 		}
 

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -26,7 +26,9 @@ ruleTester.run('prefer-flat-map', rule, {
 		outdent`
 			let bar = [1,2,3].map(i => [i]);
 			bar = bar.flat();
-		`
+		`,
+		'const bar = [1,2,3].map(i => [i]).flat(1)',
+		'const bar = [[1],[2],[3]].map(i => [i]).flat(2)'
 	],
 	invalid: [
 		{

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -27,8 +27,8 @@ ruleTester.run('prefer-flat-map', rule, {
 			let bar = [1,2,3].map(i => [i]);
 			bar = bar.flat();
 		`,
-		'const bar = [1,2,3].map(i => [i]).flat(1)',
-		'const bar = [[1],[2],[3]].map(i => [i]).flat(2)'
+		'const bar = [[1],[2],[3]].map(i => [i]).flat(2)',
+		'const bar = [[1],[2],[3]].map(i => [i]).flat(1, null)'
 	],
 	invalid: [
 		{
@@ -157,6 +157,11 @@ ruleTester.run('prefer-flat-map', rule, {
 		{
 			code: 'let bar = [1,2,3] . map( x => y ) . flat () // 🤪',
 			output: 'let bar = [1,2,3] . flatMap( x => y )  // 🤪',
+			errors: [error]
+		},
+		{
+			code: 'const bar = [1,2,3].map(i => [i]).flat(1);',
+			output: 'const bar = [1,2,3].flatMap(i => [i]);',
 			errors: [error]
 		}
 	]

--- a/test/prefer-flat-map.js
+++ b/test/prefer-flat-map.js
@@ -161,7 +161,8 @@ ruleTester.run('prefer-flat-map', rule, {
 		},
 		{
 			code: 'const bar = [1,2,3].map(i => [i]).flat(1);',
-			output: 'const bar = [1,2,3].flatMap(i => [i]);'
+			output: 'const bar = [1,2,3].flatMap(i => [i]);',
+			errors: [error]
 		},
 		{
 			code: outdent`


### PR DESCRIPTION
Fixes #315.

A follow up question is if we should warn / fix on `.flat(1)` which is default flattening behavior but I wanted to get the fix out quickly.