### PR TITLE
prefer-node-append: Only fix when expression is not used

### DIFF
--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -3,16 +3,30 @@ const getDocsUrl = require('./utils/get-docs-url');
 
 const getMethodName = memberExpression => memberExpression.property.name;
 
+const ignoredParentTypes = [
+	'VariableDeclarator',
+	'CallExpression'
+];
+
 const create = context => {
 	return {
 		CallExpression(node) {
-			const {callee} = node;
+			const {
+				callee,
+				parent
+			} = node;
 
 			if (callee.type === 'MemberExpression' && getMethodName(callee) === 'appendChild') {
+				let fix = fixer => fixer.replaceText(callee.property, 'append');
+
+				if (parent && ignoredParentTypes.includes(parent.type)) {
+					fix = undefined;
+				}
+
 				context.report({
 					node,
 					message: 'Prefer `Node#append()` over `Node#appendChild()`.',
-					fix: fixer => fixer.replaceText(callee.property, 'append')
+					fix
 				});
 			}
 		}

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -4,8 +4,13 @@ const getDocsUrl = require('./utils/get-docs-url');
 const getMethodName = memberExpression => memberExpression.property.name;
 
 const ignoredParentTypes = [
-	'VariableDeclarator',
-	'CallExpression'
+	'IfStatement',
+	'MemberExpression',
+	'VariableDeclarator'
+];
+
+const ignoredGrandparentTypes = [
+	'ExpressionStatement'
 ];
 
 const create = context => {
@@ -16,10 +21,18 @@ const create = context => {
 				parent
 			} = node;
 
+			const {
+				parent: grandparent
+			} = (parent || {});
+
 			if (callee.type === 'MemberExpression' && getMethodName(callee) === 'appendChild') {
 				let fix = fixer => fixer.replaceText(callee.property, 'append');
 
 				if (parent && ignoredParentTypes.includes(parent.type)) {
+					fix = undefined;
+				}
+
+				if (grandparent && ignoredGrandparentTypes.includes(grandparent.type)) {
 					fix = undefined;
 				}
 

--- a/test/prefer-node-append.js
+++ b/test/prefer-node-append.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
+import {outdent} from 'outdent';
 import rule from '../rules/prefer-node-append';
 
 const ruleTester = avaRuleTester(test, {
@@ -40,6 +41,29 @@ ruleTester.run('prefer-node-append', rule, {
 		{
 			code: 'node.appendChild(null)',
 			output: 'node.append(null)',
+			errors
+		},
+		{
+			code: outdent`
+				function foo() {
+					node.appendChild(null);
+				}
+			`,
+			output: outdent`
+				function foo() {
+					node.append(null);
+				}
+			`,
+			errors
+		},
+		{
+			code: 'const foo = node.appendChild(child);',
+			output: 'const foo = node.appendChild(child);',
+			errors
+		},
+		{
+			code: 'console.log(node.appendChild(child));',
+			output: 'console.log(node.appendChild(child));',
 			errors
 		}
 	]

--- a/test/prefer-node-append.js
+++ b/test/prefer-node-append.js
@@ -9,11 +9,9 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-const errors = [
-	{
-		message: 'Prefer `Node#append()` over `Node#appendChild()`.'
-	}
-];
+const error = {
+	message: 'Prefer `Node#append()` over `Node#appendChild()`.'
+};
 
 ruleTester.run('prefer-node-append', rule, {
 	valid: [
@@ -26,22 +24,22 @@ ruleTester.run('prefer-node-append', rule, {
 		{
 			code: 'node.appendChild(child);',
 			output: 'node.append(child);',
-			errors
+			errors: [error]
 		},
 		{
 			code: 'document.body.appendChild(child);',
 			output: 'document.body.append(child);',
-			errors
+			errors: [error]
 		},
 		{
 			code: 'node.appendChild()',
 			output: 'node.append()',
-			errors
+			errors: [error]
 		},
 		{
 			code: 'node.appendChild(null)',
 			output: 'node.append(null)',
-			errors
+			errors: [error]
 		},
 		{
 			code: outdent`
@@ -54,17 +52,52 @@ ruleTester.run('prefer-node-append', rule, {
 					node.append(null);
 				}
 			`,
-			errors
+			errors: [error]
 		},
 		{
 			code: 'const foo = node.appendChild(child);',
 			output: 'const foo = node.appendChild(child);',
-			errors
+			errors: [error]
 		},
 		{
 			code: 'console.log(node.appendChild(child));',
 			output: 'console.log(node.appendChild(child));',
-			errors
+			errors: [error]
+		},
+		{
+			code: 'node.appendChild(child).appendChild(grandchild);',
+			output: 'node.appendChild(child).append(grandchild);',
+			errors: [error, error]
+		},
+		{
+			code: 'node.appendChild(child) || "foo";',
+			output: 'node.appendChild(child) || "foo";',
+			errors: [error]
+		},
+		{
+			code: 'node.appendChild(child) + 0;',
+			output: 'node.appendChild(child) + 0;',
+			errors: [error]
+		},
+		{
+			code: 'node.appendChild(child) + 0;',
+			output: 'node.appendChild(child) + 0;',
+			errors: [error]
+		},
+		{
+			code: '+node.appendChild(child);',
+			output: '+node.appendChild(child);',
+			errors: [error]
+		},
+		{
+			code: 'node.appendChild(child) ? "foo" : "bar";',
+			output: 'node.appendChild(child) ? "foo" : "bar";',
+			errors: [error]
+		},
+		{
+			code: 'if (node.appendChild(child)) {}',
+			output: 'if (node.appendChild(child)) {}',
+			errors: [error]
 		}
 	]
 });


### PR DESCRIPTION
Fixes #319.

There are three possible approaches here and I didn't know exactly which was best:

1. Never fix
2. Only fix when parent node type is in a whitelist
3. Only fix when parent node type is not in a blacklist

This PR uses approach 3 but approach 2 would be a more conservative approach. Before I go digging up all sorts of variants of the pattern I figured I'd confirm the blacklist approach is the way we wanted to go.

Also, I chose to leave the warning enabled even when the fixer is disabled. Should we not even warn if the return value is being used?