### PR TITLE
Add `checkFilenames` option to the `prevent-abbreviations` rule

### DIFF
--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -220,3 +220,10 @@ Type: `boolean`<br>
 Default: `true`
 
 Pass `"checkVariables": false` to disable checking variable names.
+
+### checkFilenames
+
+Type: `boolean`<br>
+Default: `true`
+
+Pass `"checkFilenames": false` to disable checking file names.

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -1,10 +1,12 @@
 'use strict';
+const path = require('path');
 const astUtils = require('eslint-ast-utils');
 const defaultsDeep = require('lodash.defaultsdeep');
 const toPairs = require('lodash.topairs');
 const camelCase = require('lodash.camelcase');
 const kebabCase = require('lodash.kebabcase');
 const upperfirst = require('lodash.upperfirst');
+const snakeCase = require('lodash.snakecase');
 
 const getDocsUrl = require('./utils/get-docs-url');
 const avoidCapture = require('./utils/avoid-capture');
@@ -178,6 +180,16 @@ const defaultWhitelist = {
 	stdDev: true
 };
 
+const getCase = string => {
+	for (const fn of [camelCase, kebabCase, snakeCase, upperfirst]) {
+		if (string === fn(string)) {
+			return fn;
+		}
+	}
+
+	return camelCase;
+};
+
 const prepareOptions = ({
 	checkProperties = true,
 	checkVariables = true,
@@ -185,6 +197,8 @@ const prepareOptions = ({
 	checkDefaultAndNamespaceImports = false,
 	checkShorthandImports = false,
 	checkShorthandProperties = false,
+
+	checkFilenames = true,
 
 	extendDefaultReplacements = true,
 	replacements = {},
@@ -207,6 +221,8 @@ const prepareOptions = ({
 		checkDefaultAndNamespaceImports,
 		checkShorthandImports,
 		checkShorthandProperties,
+
+		checkFilenames,
 
 		replacements: new Map(toPairs(mergedReplacements).map(([discouragedName, replacements]) => {
 			return [discouragedName, new Map(toPairs(replacements))];
@@ -533,6 +549,7 @@ const create = context => {
 		ecmaVersion
 	} = context.parserOptions;
 	const options = prepareOptions(context.options[0]);
+	const filenameWithExtension = context.getFilename();
 
 	// A `class` declaration produces two variables in two scopes:
 	// the inner class scope, and the outer one (whereever the class is declared).
@@ -678,6 +695,38 @@ const create = context => {
 			context.report(problem);
 		},
 
+		Program(node) {
+			if (!options.checkFilenames) {
+				return;
+			}
+
+			if (filenameWithExtension === '<input>') {
+				return {};
+			}
+
+			const extension = path.extname(filenameWithExtension);
+			let dirname = path.dirname(filenameWithExtension);
+			dirname = dirname === '.' ? '' : `${dirname}/`;
+			const filename = path.basename(filenameWithExtension, extension);
+			const originalCase = getCase(filename);
+
+			const filenameReplacements = getNameReplacements(
+				options.replacements,
+				options.whitelist,
+				filename
+			)
+				.map(replacement => `${dirname}${originalCase(replacement)}${extension}`);
+
+			if (filenameReplacements.length === 0) {
+				return;
+			}
+
+			context.report({
+				node,
+				message: formatMessage(filenameWithExtension, filenameReplacements, 'file')
+			});
+		},
+
 		'Program:exit'() {
 			if (!options.checkVariables) {
 				return;
@@ -697,6 +746,8 @@ const schema = [{
 		checkDefaultAndNamespaceImports: {type: 'boolean'},
 		checkShorthandImports: {type: 'boolean'},
 		checkShorthandProperties: {type: 'boolean'},
+
+		checkFilenames: {type: 'boolean'},
 
 		extendDefaultReplacements: {type: 'boolean'},
 		replacements: {$ref: '#/items/0/definitions/abbreviations'},

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -705,8 +705,6 @@ const create = context => {
 			}
 
 			const extension = path.extname(filenameWithExtension);
-			let dirname = path.dirname(filenameWithExtension);
-			dirname = dirname === '.' ? '' : `${dirname}/`;
 			const filename = path.basename(filenameWithExtension, extension);
 			const originalCase = getCase(filename);
 
@@ -715,7 +713,7 @@ const create = context => {
 				options.whitelist,
 				filename
 			)
-				.map(replacement => `${dirname}${originalCase(replacement)}${extension}`);
+				.map(replacement => `${originalCase(replacement)}${extension}`);
 
 			if (filenameReplacements.length === 0) {
 				return;

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -181,7 +181,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 			code: '({__proto__: null})',
 			options: customOptions
 		},
-		// CheckFilenames
+		// `checkFilenames` option
 		{
 			code: 'foo();',
 			filename: 'http-error.js'
@@ -927,7 +927,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 			`,
 			errors: createErrors()
 		},
-		// Options: checkFilenames
+		// `checkFilenames` option
 		{
 			code: 'foo();',
 			filename: 'err/http-err.js',

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -63,6 +63,8 @@ const customOptions = [{
 	checkShorthandImports: true,
 	checkShorthandProperties: true,
 
+	checkFilenames: false,
+
 	extendDefaultReplacements: false,
 	replacements: {
 		args: {
@@ -178,6 +180,20 @@ ruleTester.run('prevent-abbreviations', rule, {
 		{
 			code: '({__proto__: null})',
 			options: customOptions
+		},
+		// CheckFilenames
+		{
+			code: 'foo();',
+			filename: 'http-error.js'
+		},
+		{
+			code: 'foo();',
+			filename: 'http-err.js',
+			options: customOptions
+		},
+		{
+			code: 'foo();',
+			filename: 'err/http-error.js'
 		}
 	],
 
@@ -896,7 +912,6 @@ ruleTester.run('prevent-abbreviations', rule, {
 			`,
 			errors: createErrors()
 		},
-
 		{
 			code: outdent`
 				function unicorn(unicorn) {
@@ -910,6 +925,17 @@ ruleTester.run('prevent-abbreviations', rule, {
 					return documents;
 				}
 			`,
+			errors: createErrors()
+		},
+		// Options: checkFilenames
+		{
+			code: 'foo();',
+			filename: 'err/http-err.js',
+			errors: createErrors()
+		},
+		{
+			code: 'foo();',
+			filename: 'http-err.js',
 			errors: createErrors()
 		}
 	]


### PR DESCRIPTION
fixes: #267