### PR TITLE
Refactor the `prevent-abbreviations` rule

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -232,12 +232,12 @@ const getWordReplacements = (word, replacements) => {
 	return wordReplacement.length > 0 ? wordReplacement.sort() : [];
 };
 
-const getReplacementsFromCombined = (combined, length = Infinity) => {
-	const total = combined.reduce((total, {length}) => total * length, 1);
+const getReplacementsFromCombinations = (combinations, length = Infinity) => {
+	const total = combinations.reduce((total, {length}) => total * length, 1);
 
 	const samples = Array.from({length: Math.min(total, length)}, (_, sampleIndex) => {
 		let indexLeft = sampleIndex;
-		return combined.reduceRight((words, replacements) => {
+		return combinations.reduceRight((words, replacements) => {
 			const {length} = replacements;
 			const replacementIndex = indexLeft % length;
 			indexLeft -= replacementIndex;
@@ -253,14 +253,12 @@ const getReplacementsFromCombined = (combined, length = Infinity) => {
 };
 
 const getNameReplacements = (name, {replacements, whitelist}, limit = 3) => {
-	if (whitelist.get(name)) {
+	// Skip constants and whitelist
+	if (isUpperCase(name) || whitelist.get(name)) {
 		return {total: 0};
 	}
 
-	if (isUpperCase(name)) {
-		return {total: 0};
-	}
-
+	// Find exact replacements
 	const exactReplacements = getWordReplacements(name, replacements);
 
 	if (exactReplacements.length > 0) {
@@ -270,10 +268,11 @@ const getNameReplacements = (name, {replacements, whitelist}, limit = 3) => {
 		};
 	}
 
+	// Split words
 	const words = name.split(/(?=[^a-z])|(?<=[^a-zA-Z])/g).filter(Boolean);
 
 	let hasReplacements = false;
-	const combined = words.map(word => {
+	const combinations = words.map(word => {
 		const wordReplacements = getWordReplacements(word, replacements);
 
 		if (wordReplacements.length > 0) {
@@ -289,7 +288,7 @@ const getNameReplacements = (name, {replacements, whitelist}, limit = 3) => {
 		return {total: 0};
 	}
 
-	return getReplacementsFromCombined(combined, limit);
+	return getReplacementsFromCombinations(combinations, limit);
 };
 
 const anotherNameMessage = 'A more descriptive name will do too.';

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -8,10 +8,9 @@ const getDocsUrl = require('./utils/get-docs-url');
 const avoidCapture = require('./utils/avoid-capture');
 
 const isUpperCase = string => string === string.toUpperCase();
-const lowerFirst = string => string[0].toLowerCase() + string.slice(1);
-const isLowerFirst = string => string[0].toLowerCase() === string[0];
-const upperFirst = string => string[0].toUpperCase() + string.slice(1);
 const isUpperFirst = string => isUpperCase(string[0]);
+const lowerFirst = string => string[0].toLowerCase() + string.slice(1);
+const upperFirst = string => string[0].toUpperCase() + string.slice(1);
 
 const defaultReplacements = {
 	err: {
@@ -222,16 +221,13 @@ const flat = Array.prototype.flat ? array => array.flat() : array => [].concat(.
 const getWordReplacement = (word, replacements) => {
 	const replacement = replacements.get(lowerFirst(word)) ||
 		replacements.get(word) ||
-		replacements.get(upperFirst);
+		replacements.get(upperFirst(word));
 
-	let wordReplacement = replacement ? [...replacement.keys()].filter(name => replacement.get(name)) : [];
-
-	if (isLowerFirst(word)) {
-		wordReplacement = wordReplacement.map(lowerFirst);
-	}
-
-	if (isUpperFirst(word)) {
-		wordReplacement = wordReplacement.map(upperFirst);
+	let wordReplacement = [];
+	if (replacement) {
+		wordReplacement = [...replacement.keys()]
+			.filter(name => replacement.get(name))
+			.map(isUpperFirst(word) ? upperFirst : lowerFirst);
 	}
 
 	return wordReplacement.length > 0 ? wordReplacement.sort() : [word];
@@ -273,9 +269,7 @@ const getNameReplacements = (name, {replacements, whitelist, limit = 16}) => {
 		options = options.map(words => [...words, ...restWords]);
 	}
 
-	options = options.map(words => words.join('')).sort().filter(nameReplacement => nameReplacement !== name);
-
-	return options.sort();
+	return options.map(words => words.join('')).filter(nameReplacement => nameReplacement !== name).sort();
 };
 
 const anotherNameMessage = 'A more descriptive name will do too.';

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -250,20 +250,19 @@ const getNameReplacements = (name, {replacements, whitelist, limit = 16}) => {
 
 	const words = name.split(/(?=[^a-z])|(?<=[^a-zA-Z])/g).filter(Boolean);
 
-	let hasReplacements = false
+	let hasReplacements = false;
 	const combined = words.map(word => {
 		const wordReplacements = getWordReplacements(word, replacements);
 		if (!hasReplacements && wordReplacements.length > 0) {
-			hasReplacements = true
+			hasReplacements = true;
 		}
 
-		return wordReplacements.length > 0 ? wordReplacements : [word]
+		return wordReplacements.length > 0 ? wordReplacements : [word];
 	});
-
 
 	// No replacements for any word
 	if (!hasReplacements) {
-		return []
+		return [];
 	}
 
 	let options = [[]];

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -940,8 +940,8 @@ ruleTester.run('prevent-abbreviations', rule, {
 		},
 		{
 			code: 'foo();',
-			filename: '_err.js',
-			errors: createErrors('The filename `_err.js` should be named `_error.js`. A more descriptive name will do too.')
+			filename: '/path/to/doc/__prev-Attr$1Err__.conf.js',
+			errors: createErrors('The filename `/path/to/doc/__prev-Attr$1Err__.conf.js` should be named `__previous-Attribute$1Error__.config.js`. A more descriptive name will do too.')
 		},
 		{
 			code: 'foo();',

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -977,7 +977,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 		{
 			code: 'foo();',
 			filename: 'e.js',
-			errors: createErrors(formatMessage('e.js', ['error.js','event.js'], 'filename'))
+			errors: createErrors(formatMessage('e.js', ['error.js', 'event.js'], 'filename'))
 		},
 		{
 			code: 'foo();',

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -43,6 +43,34 @@ const createErrors = message => {
 	return [error];
 };
 
+const anotherNameMessage = 'A more descriptive name will do too.';
+
+const formatMessage = (discouragedName, replacements, nameTypeText, replacementsLimit = 3) => {
+	replacements = replacements.sort();
+
+	const message = [];
+
+	if (replacements.length === 1) {
+		message.push(`The ${nameTypeText} \`${discouragedName}\` should be named \`${replacements[0]}\`.`);
+	} else {
+		let replacementsText = replacements.slice(0, replacementsLimit)
+			.map(replacement => `\`${replacement}\``)
+			.join(', ');
+
+		const omittedReplacementsCount = replacements.length - replacementsLimit;
+		if (omittedReplacementsCount > 0) {
+			replacementsText += `, ... (${omittedReplacementsCount} more omitted)`;
+		}
+
+		message.push(`Please rename the ${nameTypeText} \`${discouragedName}\`.`);
+		message.push(`Suggested names are: ${replacementsText}.`);
+	}
+
+	message.push(anotherNameMessage);
+
+	return message.join(' ');
+};
+
 const extendedOptions = [{
 	replacements: {
 		e: false,
@@ -200,64 +228,62 @@ ruleTester.run('prevent-abbreviations', rule, {
 	invalid: [
 		noFixingTestCase({
 			code: 'let e',
-			errors: createErrors('Please rename the variable `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('e', ['event', 'error'], 'variable'))
 		}),
 		noFixingTestCase({
 			code: 'let eCbOpts',
-			errors: createErrors('Please rename the variable `eCbOpts`. Suggested names are: `errorCallbackOptions`, `eventCallbackOptions`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('eCbOpts', ['errorCallbackOptions', 'eventCallbackOptions'], 'variable'))
 		}),
 		noFixingTestCase({
 			code: '({e: 1})',
-			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('e', ['event', 'error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: 'this.e = 1',
-			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('e', ['event', 'error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: '({e() {}})',
-			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('e', ['event', 'error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: '(class {e() {}})',
-			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('e', ['event', 'error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: 'this.eResDir = 1',
-			errors: createErrors('Please rename the property `eResDir`. Suggested names are: `errorResponseDirectory`, `errorResultDirectory`, `eventResponseDirectory`, ... (1 more omitted). A more descriptive name will do too.')
+			errors: createErrors(formatMessage('eResDir', ['errorResponseDirectory', 'errorResultDirectory', 'eventResponseDirectory', 'eventResultDirectory'], 'property'))
 		}),
-
 		{
 			code: 'let err',
 			output: 'let error',
-			errors: createErrors('The variable `err` should be named `error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('err', ['error'], 'variable'))
 		},
 		{
 			code: 'let errCbOptsObj',
 			output: 'let errorCallbackOptionsObject',
-			errors: createErrors('The variable `errCbOptsObj` should be named `errorCallbackOptionsObject`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('errCbOptsObj', ['errorCallbackOptionsObject'], 'variable'))
 		},
 		noFixingTestCase({
 			code: '({err: 1})',
-			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('err', ['error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: 'this.err = 1',
-			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('err', ['error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: '({err() {}})',
-			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('err', ['error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: '(class {err() {}})',
-			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('err', ['error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: 'this.errCbOptsObj = 1',
-			errors: createErrors('The property `errCbOptsObj` should be named `errorCallbackOptionsObject`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('errCbOptsObj', ['errorCallbackOptionsObject'], 'property'))
 		}),
-
 		{
 			code: 'let successCb',
 			output: 'let successCallback',
@@ -286,15 +312,15 @@ ruleTester.run('prevent-abbreviations', rule, {
 
 		{
 			code: 'let evt',
-			errors: createErrors('The variable `evt` should be named `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('evt', ['event'], 'variable'))
 		},
 		noFixingTestCase({
 			code: '({evt: 1})',
-			errors: createErrors('The property `evt` should be named `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('evt', ['event'], 'property'))
 		}),
 		noFixingTestCase({
 			code: 'foo.evt = 1',
-			errors: createErrors('The property `evt` should be named `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('evt', ['event'], 'property'))
 		}),
 
 		// Testing that options apply
@@ -638,15 +664,15 @@ ruleTester.run('prevent-abbreviations', rule, {
 
 		noFixingTestCase({
 			code: 'this._err = 1',
-			errors: createErrors('The property `_err` should be named `_error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('_err', ['_error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: 'this.__err__ = 1',
-			errors: createErrors('The property `__err__` should be named `__error__`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('__err__', ['__error__'], 'property'))
 		}),
 		noFixingTestCase({
 			code: 'this.e_ = 1',
-			errors: createErrors('Please rename the property `e_`. Suggested names are: `error_`, `event_`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('e_', ['error_', 'event_'], 'property'))
 		}),
 
 		{
@@ -661,22 +687,22 @@ ruleTester.run('prevent-abbreviations', rule, {
 		},
 		noFixingTestCase({
 			code: 'let _e',
-			errors: createErrors('Please rename the variable `_e`. Suggested names are: `_error`, `_event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('_e', ['_error', '_event'], 'variable'))
 		}),
 
 		{
 			code: 'class Err {}',
 			output: 'class Error_ {}',
-			errors: createErrors('The variable `Err` should be named `Error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('Err', ['Error'], 'variable'))
 		},
 		{
 			code: 'class Cb {}',
 			output: 'class Callback {}',
-			errors: createErrors('The variable `Cb` should be named `Callback`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('Cb', ['Callback'], 'variable'))
 		},
 		noFixingTestCase({
 			code: 'class Res {}',
-			errors: createErrors('Please rename the variable `Res`. Suggested names are: `Response`, `Result`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('Res', ['Response', 'Result'], 'variable'))
 		}),
 		{
 			code: 'const Err = 1;',
@@ -690,11 +716,11 @@ ruleTester.run('prevent-abbreviations', rule, {
 		},
 		noFixingTestCase({
 			code: '({Err: 1})',
-			errors: createErrors('The property `Err` should be named `Error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('Err', ['Error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: '({Res: 1})',
-			errors: createErrors('Please rename the property `Res`. Suggested names are: `Response`, `Result`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('Res', ['Response', 'Result'], 'property'))
 		}),
 
 		{
@@ -937,6 +963,33 @@ ruleTester.run('prevent-abbreviations', rule, {
 			code: 'foo();',
 			filename: 'http-err.js',
 			errors: createErrors()
+		},
+		{
+			code: 'foo();',
+			filename: '_err.js',
+			errors: createErrors(formatMessage('_err.js', ['_error.js'], 'filename'))
+		},
+		{
+			code: 'foo();',
+			filename: 'http.err.js',
+			errors: createErrors(formatMessage('http.err.js', ['http.error.js'], 'filename'))
+		},
+		{
+			code: 'foo();',
+			filename: 'e.js',
+			errors: createErrors(formatMessage('e.js', ['error.js','event.js'], 'filename'))
+		},
+		{
+			code: 'foo();',
+			filename: 'c.js',
+			options: extendedOptions,
+			errors: createErrors(formatMessage('c.js', ['custom.js'], 'filename'))
+		},
+		{
+			code: 'foo();',
+			filename: 'cb.js',
+			options: extendedOptions,
+			errors: createErrors(formatMessage('cb.js', ['circuitBreacker.js'], 'filename'))
 		}
 	]
 });
@@ -1189,11 +1242,11 @@ babelRuleTester.run('prevent-abbreviations', rule, {
 
 		noFixingTestCase({
 			code: '(class {e = 1})',
-			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('e', ['error', 'event'], 'property'))
 		}),
 		noFixingTestCase({
 			code: '(class {err = 1})',
-			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
+			errors: createErrors(formatMessage('err', ['error'], 'property'))
 		}),
 		noFixingTestCase({
 			code: outdent`

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -43,34 +43,6 @@ const createErrors = message => {
 	return [error];
 };
 
-const anotherNameMessage = 'A more descriptive name will do too.';
-
-const formatMessage = (discouragedName, replacements, nameTypeText, replacementsLimit = 3) => {
-	replacements = replacements.sort();
-
-	const message = [];
-
-	if (replacements.length === 1) {
-		message.push(`The ${nameTypeText} \`${discouragedName}\` should be named \`${replacements[0]}\`.`);
-	} else {
-		let replacementsText = replacements.slice(0, replacementsLimit)
-			.map(replacement => `\`${replacement}\``)
-			.join(', ');
-
-		const omittedReplacementsCount = replacements.length - replacementsLimit;
-		if (omittedReplacementsCount > 0) {
-			replacementsText += `, ... (${omittedReplacementsCount} more omitted)`;
-		}
-
-		message.push(`Please rename the ${nameTypeText} \`${discouragedName}\`.`);
-		message.push(`Suggested names are: ${replacementsText}.`);
-	}
-
-	message.push(anotherNameMessage);
-
-	return message.join(' ');
-};
-
 const extendedOptions = [{
 	replacements: {
 		e: false,
@@ -228,62 +200,64 @@ ruleTester.run('prevent-abbreviations', rule, {
 	invalid: [
 		noFixingTestCase({
 			code: 'let e',
-			errors: createErrors(formatMessage('e', ['event', 'error'], 'variable'))
+			errors: createErrors('Please rename the variable `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: 'let eCbOpts',
-			errors: createErrors(formatMessage('eCbOpts', ['errorCallbackOptions', 'eventCallbackOptions'], 'variable'))
+			errors: createErrors('Please rename the variable `eCbOpts`. Suggested names are: `errorCallbackOptions`, `eventCallbackOptions`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: '({e: 1})',
-			errors: createErrors(formatMessage('e', ['event', 'error'], 'property'))
+			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: 'this.e = 1',
-			errors: createErrors(formatMessage('e', ['event', 'error'], 'property'))
+			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: '({e() {}})',
-			errors: createErrors(formatMessage('e', ['event', 'error'], 'property'))
+			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: '(class {e() {}})',
-			errors: createErrors(formatMessage('e', ['event', 'error'], 'property'))
+			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: 'this.eResDir = 1',
-			errors: createErrors(formatMessage('eResDir', ['errorResponseDirectory', 'errorResultDirectory', 'eventResponseDirectory', 'eventResultDirectory'], 'property'))
+			errors: createErrors('Please rename the property `eResDir`. Suggested names are: `errorResponseDirectory`, `errorResultDirectory`, `eventResponseDirectory`, ... (1 more omitted). A more descriptive name will do too.')
 		}),
+
 		{
 			code: 'let err',
 			output: 'let error',
-			errors: createErrors(formatMessage('err', ['error'], 'variable'))
+			errors: createErrors('The variable `err` should be named `error`. A more descriptive name will do too.')
 		},
 		{
 			code: 'let errCbOptsObj',
 			output: 'let errorCallbackOptionsObject',
-			errors: createErrors(formatMessage('errCbOptsObj', ['errorCallbackOptionsObject'], 'variable'))
+			errors: createErrors('The variable `errCbOptsObj` should be named `errorCallbackOptionsObject`. A more descriptive name will do too.')
 		},
 		noFixingTestCase({
 			code: '({err: 1})',
-			errors: createErrors(formatMessage('err', ['error'], 'property'))
+			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: 'this.err = 1',
-			errors: createErrors(formatMessage('err', ['error'], 'property'))
+			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: '({err() {}})',
-			errors: createErrors(formatMessage('err', ['error'], 'property'))
+			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: '(class {err() {}})',
-			errors: createErrors(formatMessage('err', ['error'], 'property'))
+			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: 'this.errCbOptsObj = 1',
-			errors: createErrors(formatMessage('errCbOptsObj', ['errorCallbackOptionsObject'], 'property'))
+			errors: createErrors('The property `errCbOptsObj` should be named `errorCallbackOptionsObject`. A more descriptive name will do too.')
 		}),
+
 		{
 			code: 'let successCb',
 			output: 'let successCallback',
@@ -312,15 +286,15 @@ ruleTester.run('prevent-abbreviations', rule, {
 
 		{
 			code: 'let evt',
-			errors: createErrors(formatMessage('evt', ['event'], 'variable'))
+			errors: createErrors('The variable `evt` should be named `event`. A more descriptive name will do too.')
 		},
 		noFixingTestCase({
 			code: '({evt: 1})',
-			errors: createErrors(formatMessage('evt', ['event'], 'property'))
+			errors: createErrors('The property `evt` should be named `event`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: 'foo.evt = 1',
-			errors: createErrors(formatMessage('evt', ['event'], 'property'))
+			errors: createErrors('The property `evt` should be named `event`. A more descriptive name will do too.')
 		}),
 
 		// Testing that options apply
@@ -664,15 +638,15 @@ ruleTester.run('prevent-abbreviations', rule, {
 
 		noFixingTestCase({
 			code: 'this._err = 1',
-			errors: createErrors(formatMessage('_err', ['_error'], 'property'))
+			errors: createErrors('The property `_err` should be named `_error`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: 'this.__err__ = 1',
-			errors: createErrors(formatMessage('__err__', ['__error__'], 'property'))
+			errors: createErrors('The property `__err__` should be named `__error__`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: 'this.e_ = 1',
-			errors: createErrors(formatMessage('e_', ['error_', 'event_'], 'property'))
+			errors: createErrors('Please rename the property `e_`. Suggested names are: `error_`, `event_`. A more descriptive name will do too.')
 		}),
 
 		{
@@ -687,22 +661,22 @@ ruleTester.run('prevent-abbreviations', rule, {
 		},
 		noFixingTestCase({
 			code: 'let _e',
-			errors: createErrors(formatMessage('_e', ['_error', '_event'], 'variable'))
+			errors: createErrors('Please rename the variable `_e`. Suggested names are: `_error`, `_event`. A more descriptive name will do too.')
 		}),
 
 		{
 			code: 'class Err {}',
 			output: 'class Error_ {}',
-			errors: createErrors(formatMessage('Err', ['Error'], 'variable'))
+			errors: createErrors('The variable `Err` should be named `Error`. A more descriptive name will do too.')
 		},
 		{
 			code: 'class Cb {}',
 			output: 'class Callback {}',
-			errors: createErrors(formatMessage('Cb', ['Callback'], 'variable'))
+			errors: createErrors('The variable `Cb` should be named `Callback`. A more descriptive name will do too.')
 		},
 		noFixingTestCase({
 			code: 'class Res {}',
-			errors: createErrors(formatMessage('Res', ['Response', 'Result'], 'variable'))
+			errors: createErrors('Please rename the variable `Res`. Suggested names are: `Response`, `Result`. A more descriptive name will do too.')
 		}),
 		{
 			code: 'const Err = 1;',
@@ -716,11 +690,11 @@ ruleTester.run('prevent-abbreviations', rule, {
 		},
 		noFixingTestCase({
 			code: '({Err: 1})',
-			errors: createErrors(formatMessage('Err', ['Error'], 'property'))
+			errors: createErrors('The property `Err` should be named `Error`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: '({Res: 1})',
-			errors: createErrors(formatMessage('Res', ['Response', 'Result'], 'property'))
+			errors: createErrors('Please rename the property `Res`. Suggested names are: `Response`, `Result`. A more descriptive name will do too.')
 		}),
 
 		{
@@ -967,29 +941,29 @@ ruleTester.run('prevent-abbreviations', rule, {
 		{
 			code: 'foo();',
 			filename: '_err.js',
-			errors: createErrors(formatMessage('_err.js', ['_error.js'], 'filename'))
+			errors: createErrors('The filename `_err.js` should be named `_error.js`. A more descriptive name will do too.')
 		},
 		{
 			code: 'foo();',
-			filename: 'http.err.js',
-			errors: createErrors(formatMessage('http.err.js', ['http.error.js'], 'filename'))
+			filename: '.http.err.js',
+			errors: createErrors('The filename `.http.err.js` should be named `.http.error.js`. A more descriptive name will do too.')
 		},
 		{
 			code: 'foo();',
 			filename: 'e.js',
-			errors: createErrors(formatMessage('e.js', ['error.js', 'event.js'], 'filename'))
+			errors: createErrors('Please rename the filename `e.js`. Suggested names are: `error.js`, `event.js`. A more descriptive name will do too.')
 		},
 		{
 			code: 'foo();',
 			filename: 'c.js',
 			options: extendedOptions,
-			errors: createErrors(formatMessage('c.js', ['custom.js'], 'filename'))
+			errors: createErrors('The filename `c.js` should be named `custom.js`. A more descriptive name will do too.')
 		},
 		{
 			code: 'foo();',
 			filename: 'cb.js',
 			options: extendedOptions,
-			errors: createErrors(formatMessage('cb.js', ['circuitBreacker.js'], 'filename'))
+			errors: createErrors('The filename `cb.js` should be named `circuitBreacker.js`. A more descriptive name will do too.')
 		}
 	]
 });
@@ -1242,11 +1216,11 @@ babelRuleTester.run('prevent-abbreviations', rule, {
 
 		noFixingTestCase({
 			code: '(class {e = 1})',
-			errors: createErrors(formatMessage('e', ['error', 'event'], 'property'))
+			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: '(class {err = 1})',
-			errors: createErrors(formatMessage('err', ['error'], 'property'))
+			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
 		}),
 		noFixingTestCase({
 			code: outdent`


### PR DESCRIPTION
What I have done:

1, refact `getNameReplacements`, It should handle more kinds of strings, hope @futpib don't mind
2, update test fix #336 review