### PR TITLE
Fix exception sometimes thrown in "no-for-loop" in ES5 mode

### DIFF
--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -281,6 +281,10 @@ const create = context => {
 			const forScope = scopeManager.acquire(node);
 			const bodyScope = scopeManager.acquire(node.body);
 
+			if (!bodyScope) {
+				return;
+			}
+
 			const indexVariable = resolveIdentifierName(indexIdentifierName, bodyScope);
 
 			if (isIndexVariableAssignedToInTheLoopBody(indexVariable, bodyScope)) {

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -9,6 +9,12 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
+const ruleTesterEs5 = avaRuleTester(test, {
+	parserOptions: {
+		ecmaVersion: 5
+	}
+});
+
 function testCase(code, output) {
 	return {
 		code,
@@ -34,6 +40,12 @@ ruleTester.run('no-for-loop', rule, {
 				el = arr[i];
 				console.log(i, el);
 			}
+		`,
+		outdent`
+			var foo = function () {
+				for (var i = 0; i < bar.length; i++) {
+				}
+			};
 		`,
 
 		// Screwing with initialization expression
@@ -346,4 +358,25 @@ ruleTester.run('no-for-loop', rule, {
 			}
 		`)
 	]
+});
+
+ruleTesterEs5.run('no-for-loop', rule, {
+	valid: [
+		'for (;;);',
+		'for (;;) {}',
+		'for (var j = 0; j < 10; j++) {}',
+		outdent`
+			for (i = 0; i < arr.length; i++) {
+				el = arr[i];
+				console.log(i, el);
+			}
+		`,
+		outdent`
+			var foo = function () {
+				for (var i = 0; i < bar.length; i++) {
+				}
+			};
+		`
+	],
+	invalid: []
 });


### PR DESCRIPTION
This added minimal test case previously give the error `Cannot read property 'references' of undefined`:

```javascript
var foo = function () {
	for (var i = 0; i < bar.length; i++) {
	}
};
```

I ran across this in a real project and slimmed down the erroneous code to the above code.

Reason why it could fail is that `scopeManager.acquire()` can return `null` in some cases: https://eslint.org/docs/developer-guide/scope-manager-interface#acquirenode-inner--false

And the previous code expects it to never receive null and thus `indexVariable` becomes `undefined` when it tries to look that up in the `bodyScope` and that makes `isIndexVariableAssignedToInTheLoopBody(indexVariable, bodyScope)` fail as it checks `indexVariable.references` with `indexVariable` being `undefined`.

I believe the fix I added is the right one, but I'm not the greatest of masters at ESLint so I could be wrong in my fix.