### PR TITLE
Fix usage with `eslint --stdin`

### DIFF
--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -114,7 +114,7 @@ const create = context => {
 	const chosenCases = getChosenCases(context);
 	const filenameWithExtension = context.getFilename();
 
-	if (filenameWithExtension === '<input>') {
+	if (filenameWithExtension === '<input>' || filenameWithExtension === '<text>') {
 		return {};
 	}
 

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -700,7 +700,7 @@ const create = context => {
 				return;
 			}
 
-			if (filenameWithExtension === '<input>') {
+			if (filenameWithExtension === '<input>' || filenameWithExtension === '<text>') {
 				return {};
 			}
 


### PR DESCRIPTION
ESLint uses both [`<text>`](https://github.com/eslint/eslint/blob/4aeeeedb656ee3519ea82ebf0cb41ca801215046/lib/linter/linter.js#L446-L462) and [`<input>`](https://github.com/eslint/eslint/blob/4aeeeedb656ee3519ea82ebf0cb41ca801215046/lib/linter/linter.js#L1222) it seems.

This fixes https://travis-ci.org/xojs/xo/jobs/574092450#L325