### PR TITLE
Add `cur` and `curr` -> `current` replacement to `prevent-abbreviations`

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -153,7 +153,7 @@ const defaultReplacements = {
 	},
 	cur: {
 		current: true
-  },
+	},
 	acc: {
 		accumulator: true
 	},

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -147,6 +147,12 @@ const defaultReplacements = {
 	prev: {
 		previous: true
 	},
+	curr: {
+		current: true
+	},
+	cur: {
+		current: true
+	},
 	rel: {
 		relative: true,
 		related: true,


### PR DESCRIPTION
Fixes #349 

I also add `cur`

`cur` is even more often seen `24M` https://github.com/search?q=cur+prev+next&type=Code compares to `10M` https://github.com/search?q=curr+prev+next&type=Code