### PR TITLE
Add `acc` -> `accumulator` replacement to `prevent-abbreviations`

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -147,6 +147,9 @@ const defaultReplacements = {
 	prev: {
 		previous: true
 	},
+	acc: {
+		accumulator: true
+	},
 	rel: {
 		relative: true,
 		related: true,


### PR DESCRIPTION
I've seen this a lot, mostly for `Array#reduce`, may be because examples on MDN use this abbreviation

MDN: 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce

github codes:
https://github.com/search?q=acc+reduce&type=Code