### PR TITLE
Add `dir` -> `direction` to `prevent-abbreviations`

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -112,7 +112,8 @@ const defaultReplacements = {
 		library: true
 	},
 	dir: {
-		directory: true
+		directory: true,
+		direction: true
 	},
 	dirs: {
 		directories: true

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -224,7 +224,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 		}),
 		noFixingTestCase({
 			code: 'this.eResDir = 1',
-			errors: createErrors('Please rename the property `eResDir`. Suggested names are: `errorResponseDirectory`, `errorResultDirectory`, `eventResponseDirectory`, ... (1 more omitted). A more descriptive name will do too.')
+			errors: createErrors('Please rename the property `eResDir`. Suggested names are: `errorResponseDirection`, `errorResponseDirectory`, `errorResultDirection`, ... (5 more omitted). A more descriptive name will do too.')
 		}),
 
 		{


### PR DESCRIPTION
Fixes #348
