### PR TITLE
Fix exception thrown in `catch-error-name` rule

### DIFF
--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -65,10 +65,15 @@ const create = context => {
 				problem.fix = fixer => {
 					const fixings = [fixer.replaceText(node, expectedName)];
 
-					const scope = scopeManager.acquire(scopeNode);
-					const variable = scope.set.get(node.name);
-					for (const reference of variable.references) {
-						fixings.push(fixer.replaceText(reference.identifier, expectedName));
+					const variables =	scopeManager.getDeclaredVariables(scopeNode);
+					for (const variable of variables) {
+						if (variable.name !== node.name) {
+							continue;
+						}
+
+						for (const reference of variable.references) {
+							fixings.push(fixer.replaceText(reference.identifier, expectedName));
+						}
 					}
 
 					return fixings;

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -315,6 +315,26 @@ ruleTester.run('catch-error-name', rule, {
 					caughtErrorsIgnorePattern: '^skip'
 				}
 			]
+		},
+		{
+			code: outdent`
+				Promise.reject(new Error())
+					.catch(function onError(errorResult) {
+						console.log('errorResult should be fixed to', errorResult)
+					})
+			`,
+			output: outdent`
+				Promise.reject(new Error())
+					.catch(function onError(error) {
+						console.log('errorResult should be fixed to', error)
+					})
+			`,
+			errors: [
+				{
+					ruleId: 'catch-error-message',
+					message: 'The catch parameter should be named `error`.'
+				}
+			]
 		}
 	]
 });


### PR DESCRIPTION
While retrieving variables to fix, in order to get all variables inside the scope, one 
may iterate childScopes recursively.

Or use `getDeclaredVariables`, it always return an array, won't thrown exceptions if there are no matches.

Closes #350.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#350: Cannot read property 'references' of undefined in catch-error-name](https://issuehunt.io/repos/55832243/issues/350)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->