### PR TITLE
Add `param` and `params` replacement to the `prevent-abbreviations` rule

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -78,6 +78,12 @@ const defaultReplacements = {
 	args: {
 		arguments: true
 	},
+	param: {
+		parameter: true
+	},
+	params: {
+		parameters: true
+	},
 	tbl: {
 		table: true
 	},


### PR DESCRIPTION
Fixes #364