### PR TITLE
Update `prevent-abbreviations` to ignore uppercase letters

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -233,7 +233,12 @@ const prepareOptions = ({
 	};
 };
 
-const getWordReplacements = (word, replacements) => {
+const getWordReplacements = (word, {replacements, whitelist}) => {
+	// Skip constants and whitelist
+	if (isUpperCase(word) || whitelist.get(word)) {
+		return [];
+	}
+
 	const replacement = replacements.get(lowerFirst(word)) ||
 		replacements.get(word) ||
 		replacements.get(upperFirst(word));
@@ -268,14 +273,16 @@ const getReplacementsFromCombinations = (combinations, length = Infinity) => {
 	};
 };
 
-const getNameReplacements = (name, {replacements, whitelist}, limit = 3) => {
+const getNameReplacements = (name, options, limit = 3) => {
+	const {whitelist} = options;
+
 	// Skip constants and whitelist
 	if (isUpperCase(name) || whitelist.get(name)) {
 		return {total: 0};
 	}
 
 	// Find exact replacements
-	const exactReplacements = getWordReplacements(name, replacements);
+	const exactReplacements = getWordReplacements(name, options);
 
 	if (exactReplacements.length > 0) {
 		return {
@@ -289,7 +296,7 @@ const getNameReplacements = (name, {replacements, whitelist}, limit = 3) => {
 
 	let hasReplacements = false;
 	const combinations = words.map(word => {
-		const wordReplacements = getWordReplacements(word, replacements);
+		const wordReplacements = getWordReplacements(word, options);
 
 		if (wordReplacements.length > 0) {
 			hasReplacements = true;

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -133,6 +133,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 		'foo.error',
 		'foo.x',
 		'let E',
+		'let ESLint',
 		'let NODE_ENV',
 
 		// Accessing banned names is allowed (as in `camelcase` rule)

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -134,6 +134,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 		'foo.x',
 		'let E',
 		'let ESLint',
+		'let isJPEG',
 		'let NODE_ENV',
 
 		// Accessing banned names is allowed (as in `camelcase` rule)


### PR DESCRIPTION
variable name `ESLint` is reported error, which should not.
