### PR TITLE
Update `filename-case` rule to handle complicated filename

### DIFF
--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -4,7 +4,7 @@ Enforces all linted files to have their names in a certain case style. The defau
 
 Files named `index.js` are ignored as they can't change case (Only a problem with `pascalCase`).
 
-Characters in filename except `a-z`, `A-Z`, `0-9`, `-`, `_` and `$` are ignored.
+Characters in the filename except `a-z`, `A-Z`, `0-9`, `-`, `_` and `$` are ignored.
 
 ### `kebabCase`
 

--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -4,6 +4,7 @@ Enforces all linted files to have their names in a certain case style. The defau
 
 Files named `index.js` are ignored as they can't change case (Only a problem with `pascalCase`).
 
+Characters in filename except `a-z`, `A-Z`, `0-9`, `-`, `_` and `$` are ignored.
 
 ### `kebabCase`
 

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -4,12 +4,15 @@ const camelCase = require('lodash.camelcase');
 const kebabCase = require('lodash.kebabcase');
 const snakeCase = require('lodash.snakecase');
 const upperfirst = require('lodash.upperfirst');
+
 const getDocsUrl = require('./utils/get-docs-url');
+const cartesianProductSamples = require('./utils/cartesian-product-samples');
 
 const pascalCase = string => upperfirst(camelCase(string));
 const numberRegex = /(\d+)/;
 const PLACEHOLDER = '\uFFFF\uFFFF\uFFFF';
 const PLACEHOLDER_REGEX = new RegExp(PLACEHOLDER, 'i');
+const isIgnoredChar = char => !/^[a-z0-9-_$]$/i.test(char);
 
 function ignoreNumbers(fn) {
 	return string => {
@@ -74,19 +77,50 @@ function getChosenCases(context) {
 	return ['kebabCase'];
 }
 
-function fixFilename(chosenCase, filename) {
-	return filename
-		.split('.')
-		.map(ignoreNumbers(cases[chosenCase].fn))
-		.join('.');
+function validateFilename(words, caseFunctions) {
+	return words
+		.filter(({ignored}) => !ignored)
+		.every(({word}) => caseFunctions.some(fn => fn(word) === word));
+}
+
+function fixFilename(words, caseFunctions) {
+	const replacements = words
+		.map(({word, ignored}) => ignored ? [word] : caseFunctions.map(fn => fn(word)));
+
+	const {
+		samples
+	} = cartesianProductSamples(replacements);
+
+	return samples.map(words => words.join(''));
 }
 
 const leadingUnserscoresRegex = /^(_+)(.*)$/;
 function splitFilename(filename) {
 	const res = leadingUnserscoresRegex.exec(filename);
+
+	const leading = (res && res[1]) || '';
+	const tailing = (res && res[2]) || filename;
+
+	const words = [];
+
+	let lastWord;
+	for (const char of tailing) {
+		const isIgnored = isIgnoredChar(char);
+
+		if (lastWord && lastWord.ignored === isIgnored) {
+			lastWord.word += char;
+		} else {
+			lastWord = {
+				word: char,
+				ignored: isIgnored
+			};
+			words.push(lastWord);
+		}
+	}
+
 	return {
-		leading: (res && res[1]) || '',
-		trailing: (res && res[2]) || filename
+		leading,
+		words
 	};
 }
 
@@ -112,6 +146,7 @@ function englishishJoinWords(words) {
 
 const create = context => {
 	const chosenCases = getChosenCases(context);
+	const chosenCasesFunctions = chosenCases.map(case_ => ignoreNumbers(cases[case_].fn));
 	const filenameWithExtension = context.getFilename();
 
 	if (filenameWithExtension === '<input>' || filenameWithExtension === '<text>') {
@@ -127,11 +162,15 @@ const create = context => {
 				return;
 			}
 
-			const splitName = splitFilename(filename);
-			const fixedFilenames = chosenCases.map(case_ => fixFilename(case_, splitName.trailing));
-			const renamedFilenames = fixedFilenames.map(x => splitName.leading + x + extension);
+			const {
+				leading,
+				words
+			} = splitFilename(filename);
+			const isValid = validateFilename(words, chosenCasesFunctions);
 
-			if (!fixedFilenames.includes(splitName.trailing)) {
+			if (!isValid) {
+				const renamedFilenames = fixFilename(words, chosenCasesFunctions).map(filename => `${leading}${filename}${extension}`);
+
 				context.report({
 					node,
 					messageId: chosenCases.length > 1 ? 'renameToCases' : 'renameToCase',

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -6,6 +6,7 @@ const toPairs = require('lodash.topairs');
 
 const getDocsUrl = require('./utils/get-docs-url');
 const avoidCapture = require('./utils/avoid-capture');
+const cartesianProductSamples = require('./utils/cartesian-product-samples');
 
 const isUpperCase = string => string === string.toUpperCase();
 const isUpperFirst = string => isUpperCase(string[0]);
@@ -248,26 +249,6 @@ const getWordReplacements = (word, replacements) => {
 	return wordReplacement.length > 0 ? wordReplacement.sort() : [];
 };
 
-const getReplacementsFromCombinations = (combinations, length = Infinity) => {
-	const total = combinations.reduce((total, {length}) => total * length, 1);
-
-	const samples = Array.from({length: Math.min(total, length)}, (_, sampleIndex) => {
-		let indexLeft = sampleIndex;
-		return combinations.reduceRight((words, replacements) => {
-			const {length} = replacements;
-			const replacementIndex = indexLeft % length;
-			indexLeft -= replacementIndex;
-			indexLeft /= length;
-			return [replacements[replacementIndex], ...words];
-		}, []).join('');
-	});
-
-	return {
-		total,
-		samples
-	};
-};
-
 const getNameReplacements = (name, {replacements, whitelist}, limit = 3) => {
 	// Skip constants and whitelist
 	if (isUpperCase(name) || whitelist.get(name)) {
@@ -304,7 +285,15 @@ const getNameReplacements = (name, {replacements, whitelist}, limit = 3) => {
 		return {total: 0};
 	}
 
-	return getReplacementsFromCombinations(combinations, limit);
+	const {
+		total,
+		samples
+	} = cartesianProductSamples(combinations, limit);
+
+	return {
+		total,
+		samples: samples.map(words => words.join(''))
+	};
 };
 
 const anotherNameMessage = 'A more descriptive name will do too.';

--- a/rules/utils/cartesian-product-samples.js
+++ b/rules/utils/cartesian-product-samples.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = (combinations, length = Infinity) => {
 	const total = combinations.reduce((total, {length}) => total * length, 1);
 

--- a/rules/utils/cartesian-product-samples.js
+++ b/rules/utils/cartesian-product-samples.js
@@ -1,0 +1,18 @@
+module.exports = (combinations, length = Infinity) => {
+	const total = combinations.reduce((total, {length}) => total * length, 1);
+
+	const samples = Array.from({length: Math.min(total, length)}, (_, sampleIndex) => {
+		let indexRemaining = sampleIndex;
+		return combinations.reduceRight((words, items) => {
+			const {length} = items;
+			const index = indexRemaining % length;
+			indexRemaining = (indexRemaining - index) / length;
+			return [items[index], ...words];
+		}, []);
+	});
+
+	return {
+		total,
+		samples
+	};
+};

--- a/rules/utils/cartesian-product-samples.js
+++ b/rules/utils/cartesian-product-samples.js
@@ -3,11 +3,11 @@ module.exports = (combinations, length = Infinity) => {
 
 	const samples = Array.from({length: Math.min(total, length)}, (_, sampleIndex) => {
 		let indexRemaining = sampleIndex;
-		return combinations.reduceRight((words, items) => {
+		return combinations.reduceRight((combination, items) => {
 			const {length} = items;
 			const index = indexRemaining % length;
 			indexRemaining = (indexRemaining - index) / length;
-			return [items[index], ...words];
+			return [items[index], ...combination];
 		}, []);
 	});
 

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -91,7 +91,8 @@ ruleTester.run('filename-case', rule, {
 		testManyCases('src/foo/FooBar.js', {kebabCase: true, pascalCase: true}),
 		testManyCases('src/foo/___foo_bar.js', {snakeCase: true, pascalCase: true}),
 		testCaseWithOptions('src/foo/bar.js'),
-		testCase('src/foo/[bar].js', 'camelCase')
+		testCase('src/foo/[fooBar].js', 'camelCase'),
+		testCase('src/foo/{foo_bar}.js', 'snakeCase')
 	],
 	invalid: [
 		testCase(
@@ -232,6 +233,15 @@ ruleTester.run('filename-case', rule, {
 			'src/foo/[foo_bar].js',
 			undefined,
 			'Filename is not in kebab case. Rename it to `[foo-bar].js`.'
+		),
+		testManyCases(
+			'src/foo/{foo_bar}.js',
+			{
+				camelCase: true,
+				pascalCase: true,
+				kebabCase: true
+			},
+			'Filename is not in camel case, pascal case, or kebab case. Rename it to `{fooBar}.js`, `{FooBar}.js`, or `{foo-bar}.js`.'
 		)
 	]
 });

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -90,7 +90,8 @@ ruleTester.run('filename-case', rule, {
 		testManyCases('src/foo/fooBar.js', {camelCase: true}),
 		testManyCases('src/foo/FooBar.js', {kebabCase: true, pascalCase: true}),
 		testManyCases('src/foo/___foo_bar.js', {snakeCase: true, pascalCase: true}),
-		testCaseWithOptions('src/foo/bar.js')
+		testCaseWithOptions('src/foo/bar.js'),
+		testCase('src/foo/[bar].js', 'camelCase')
 	],
 	invalid: [
 		testCase(
@@ -226,6 +227,11 @@ ruleTester.run('filename-case', rule, {
 				snakeCase: true
 			},
 			'Filename is not in snake case. Rename it to `_foo_bar.js`.'
+		),
+		testCase(
+			'src/foo/[foo_bar].js',
+			undefined,
+			'Filename is not in kebab case. Rename it to `[foo-bar].js`.'
 		)
 	]
 });


### PR DESCRIPTION
Update `filename-case` to validate only `a-z`, `0-9`, `-`, `_` and `$`.

fixes #343
