### PR TITLE
Don't report `no-process-exit` rule in worker threads

### DIFF
--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -25,16 +25,12 @@ process.on('SIGINT', () => {
 ```
 
 ```js
-import {workerData, parentPort} from 'worker_threads'
+import workerThreads from 'worker_threads'
 
-const {data, seq} = workerData
-
-doSomething()
-  .then(() => {
-    const response = `modified ${data}`
-    parentPort.postMessage(`Data processed - ${seq}: ${response}`)
-  })
-  .catch(error => {
-    process.exit(1)
-  })
+try {
+	// do something...
+	process.exit(0)
+} catch(e) {
+	process.exit(1)
+}
 ```

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -1,6 +1,6 @@
 # Disallow `process.exit()`
 
-This rule is an extension to ESLint's [`no-process-exit` rule](http://eslint.org/docs/rules/no-process-exit), that allows `process.exit()` to be called in files that start with a [hashbang](https://en.wikipedia.org/wiki/Shebang_(Unix)) → `#!/usr/bin/env node`. It also allows `process.exit()` to be called in `process.on('<event>', func)` event handlers.
+This rule is an extension to ESLint's [`no-process-exit` rule](http://eslint.org/docs/rules/no-process-exit), that allows `process.exit()` to be called in files that start with a [hashbang](https://en.wikipedia.org/wiki/Shebang_(Unix)) → `#!/usr/bin/env node`. It also allows `process.exit()` to be called in `process.on('<event>', func)` event handlers and files with `worker_threads` modules required.
 
 
 ## Fail
@@ -22,4 +22,19 @@ process.on('SIGINT', () => {
     console.log('Got SIGINT');
     process.exit(1);
 });
+```
+
+```js
+import {workerData, parentPort} from 'worker_threads'
+
+const {data, seq} = workerData
+
+doSomething()
+  .then(() => {
+    const response = `modified ${data}`
+    parentPort.postMessage(`Data processed - ${seq}: ${response}`)
+  })
+  .catch(error => {
+    process.exit(1)
+  })
 ```

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -1,6 +1,6 @@
 # Disallow `process.exit()`
 
-This rule is an extension to ESLint's [`no-process-exit` rule](http://eslint.org/docs/rules/no-process-exit), that allows `process.exit()` to be called in files that start with a [hashbang](https://en.wikipedia.org/wiki/Shebang_(Unix)) → `#!/usr/bin/env node`. It also allows `process.exit()` to be called in `process.on('<event>', func)` event handlers and files with `worker_threads` modules required.
+This rule is an extension to ESLint's [`no-process-exit` rule](http://eslint.org/docs/rules/no-process-exit), that allows `process.exit()` to be called in files that start with a [hashbang](https://en.wikipedia.org/wiki/Shebang_(Unix)) → `#!/usr/bin/env node`. It also allows `process.exit()` to be called in `process.on('<event>', func)` event handlers and in files that imports `worker_threads`.
 
 
 ## Fail
@@ -25,12 +25,12 @@ process.on('SIGINT', () => {
 ```
 
 ```js
-import workerThreads from 'worker_threads'
+import workerThreads from 'worker_threads';
 
 try {
-	// do something...
-	process.exit(0)
-} catch(e) {
-	process.exit(1)
+	// Do something…
+	process.exit(0);
+} catch (_) {
+	process.exit(1);
 }
 ```

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -17,7 +17,6 @@ const create = context => {
 	return {
 		CallExpression: node => {
 			const {callee} = node;
-			// Console.log(requiredWorkerThreadsModule, callee.type, callee.name)
 
 			if (callee.type === 'Identifier' && callee.name === 'require') {
 				const args = node.arguments;

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -10,9 +10,29 @@ const create = context => {
 
 	let processEventHandler;
 
+	// Only report if it's outside an worker thread context. See #328.
+	let requiredWorkerThreadsModule = false;
+	const reports = [];
+
 	return {
 		CallExpression: node => {
 			const {callee} = node;
+			// Console.log(requiredWorkerThreadsModule, callee.type, callee.name)
+
+			if (callee.type === 'Identifier' && callee.name === 'require') {
+				const args = node.arguments;
+
+				if (args.length === 0) {
+					return;
+				}
+
+				const [argument] = args;
+
+				if (argument.type === 'Literal' && argument.value === 'worker_threads') {
+					requiredWorkerThreadsModule = true;
+					return;
+				}
+			}
 
 			if (callee.type === 'MemberExpression' && callee.object.name === 'process') {
 				if (callee.property.name === 'on' || callee.property.name === 'once') {
@@ -21,16 +41,35 @@ const create = context => {
 				}
 
 				if (callee.property.name === 'exit' && !processEventHandler) {
-					context.report({
-						node,
-						message: 'Only use `process.exit()` in CLI apps. Throw an error instead.'
-					});
+					reports.push(
+						() =>
+							context.report({
+								node,
+								message: 'Only use `process.exit()` in CLI apps. Throw an error instead.'
+							})
+					);
 				}
 			}
 		},
 		'CallExpression:exit': node => {
 			if (node === processEventHandler) {
 				processEventHandler = undefined;
+			}
+		},
+
+		ImportDeclaration: node => {
+			const {source} = node;
+
+			if (source.type === 'Literal' && source.value === 'worker_threads') {
+				requiredWorkerThreadsModule = true;
+			}
+		},
+
+		'Program:exit': () => {
+			if (!requiredWorkerThreadsModule) {
+				for (const report of reports) {
+					report();
+				}
 			}
 		}
 	};

--- a/test/no-process-exit.js
+++ b/test/no-process-exit.js
@@ -5,6 +5,9 @@ import rule from '../rules/no-process-exit';
 const ruleTester = avaRuleTester(test, {
 	env: {
 		es6: true
+	},
+	parserOptions: {
+		sourceType: 'module'
 	}
 });
 
@@ -29,6 +32,9 @@ ruleTester.run('no-process-exit', rule, {
 		'process.once("SIGINT", () => { process.exit(1); })',
 		'process.once("SIGINT", () => process.exit(1))',
 		'process.once("SIGINT", () => { if (true) { process.exit(1); } })',
+		'const {workerData, parentPort} = require(\'worker_threads\')\n\nprocess.exit(1);',
+		'import {workerData, parentPort} from \'worker_threads\'\n\nprocess.exit(1);',
+		'import foo from \'worker_threads\'\n\nprocess.exit(1);',
 		''
 	],
 	invalid: [
@@ -42,6 +48,14 @@ ruleTester.run('no-process-exit', rule, {
 		},
 		{
 			code: 'x(process.exit(1));',
+			errors
+		},
+		{
+			code: 'const mod = require(\'not_worker_threads\');\n\nprocess.exit(1);',
+			errors
+		},
+		{
+			code: 'import mod from \'not_worker_threads\';\n\nprocess.exit(1);',
 			errors
 		}
 	]

--- a/test/no-process-exit.js
+++ b/test/no-process-exit.js
@@ -34,8 +34,7 @@ ruleTester.run('no-process-exit', rule, {
 		'process.once("SIGINT", () => { if (true) { process.exit(1); } })',
 		'const {workerData, parentPort} = require(\'worker_threads\')\n\nprocess.exit(1);',
 		'import {workerData, parentPort} from \'worker_threads\'\n\nprocess.exit(1);',
-		'import foo from \'worker_threads\'\n\nprocess.exit(1);',
-		''
+		'import foo from \'worker_threads\'\n\nprocess.exit(1);'
 	],
 	invalid: [
 		{

--- a/test/no-process-exit.js
+++ b/test/no-process-exit.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
-import { outdent } from 'outdent';
+import {outdent} from 'outdent';
 import rule from '../rules/no-process-exit';
 
 const ruleTester = avaRuleTester(test, {

--- a/test/no-process-exit.js
+++ b/test/no-process-exit.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
+import { outdent } from 'outdent';
 import rule from '../rules/no-process-exit';
 
 const ruleTester = avaRuleTester(test, {
@@ -32,9 +33,18 @@ ruleTester.run('no-process-exit', rule, {
 		'process.once("SIGINT", () => { process.exit(1); })',
 		'process.once("SIGINT", () => process.exit(1))',
 		'process.once("SIGINT", () => { if (true) { process.exit(1); } })',
-		'const {workerData, parentPort} = require(\'worker_threads\')\n\nprocess.exit(1);',
-		'import {workerData, parentPort} from \'worker_threads\'\n\nprocess.exit(1);',
-		'import foo from \'worker_threads\'\n\nprocess.exit(1);'
+		outdent`
+			const {workerData, parentPort} = require('worker_threads');
+			process.exit(1);
+		`,
+		outdent`
+			import {workerData, parentPort} from 'worker_threads';
+			process.exit(1);
+		`,
+		outdent`
+			import foo from 'worker_threads';
+			process.exit(1);
+		`
 	],
 	invalid: [
 		{
@@ -50,11 +60,17 @@ ruleTester.run('no-process-exit', rule, {
 			errors
 		},
 		{
-			code: 'const mod = require(\'not_worker_threads\');\n\nprocess.exit(1);',
+			code: outdent`
+				const mod = require('not_worker_threads');
+				process.exit(1);
+			`,
 			errors
 		},
 		{
-			code: 'import mod from \'not_worker_threads\';\n\nprocess.exit(1);',
+			code: outdent`
+				import mod from 'not_worker_threads';
+				process.exit(1);
+			`,
 			errors
 		}
 	]


### PR DESCRIPTION
Rule no-process-exit should enable process.exit()
when worker_threads module is required.

Fixes #328

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#328: no-process-exit in worker_threads](https://issuehunt.io/repos/55832243/issues/328)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->