### PR TITLE
Generate docs url automaticly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,22 @@
 'use strict';
 const path = require('path');
 const importModules = require('import-modules');
+const mapObject = require('map-obj');
+const getDocs = require('./rules/utils/get-docs-url');
+
+const rules = mapObject(
+	importModules(path.resolve(__dirname, 'rules'), {camelize: false}),
+	(ruleId, rule) => {
+		rule.meta = rule.meta || {};
+		rule.meta.docs = rule.meta.docs || {};
+		rule.meta.docs.url = rule.meta.docs.url || getDocs(ruleId);
+
+		return [ruleId, rule];
+	}
+);
 
 module.exports = {
-	rules: importModules(path.resolve(__dirname, 'rules'), {camelize: false}),
+	rules,
 	configs: {
 		recommended: {
 			env: {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
 		"lodash.snakecase": "^4.1.1",
 		"lodash.topairs": "^4.3.0",
 		"lodash.upperfirst": "^4.3.1",
-		"regexpp": "^3.0.0",
+		"map-obj": "^4.1.0",
 		"read-pkg": "^5.2.0",
+		"regexpp": "^3.0.0",
 		"reserved-words": "^0.1.2",
 		"safe-regex": "^2.0.2",
 		"semver": "^6.3.0"

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -1,7 +1,6 @@
 'use strict';
 const astUtils = require('eslint-ast-utils');
 const avoidCapture = require('./utils/avoid-capture');
-const getDocsUrl = require('./utils/get-docs-url');
 
 // Matches `someObj.then([FunctionExpression | ArrowFunctionExpression])`
 function isLintablePromiseCatch(node) {
@@ -143,9 +142,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code',
 		schema
 	}

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const MESSAGE_ID_ARROW = 'ArrowFunctionExpression';
 const MESSAGE_ID_FUNCTION = 'FunctionDeclaration';
 
@@ -171,9 +169,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		messages: {
 			[MESSAGE_ID_ARROW]: 'Move arrow function to the outer scope.',
 			[MESSAGE_ID_FUNCTION]: 'Move function to the outer scope.'

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -1,6 +1,5 @@
 'use strict';
 const upperfirst = require('lodash.upperfirst');
-const getDocsUrl = require('./utils/get-docs-url');
 
 const MESSAGE_ID_INVALID_EXPORT = 'invalidExport';
 
@@ -177,9 +176,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'problem',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code',
 		messages: {
 			[MESSAGE_ID_INVALID_EXPORT]: 'Exported error name should match error class'

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const errorConstructors = new Set([
 	'Error',
 	'EvalError',
@@ -92,9 +90,6 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
-		type: 'problem',
-		docs: {
-			url: getDocsUrl(__filename)
-		}
+		type: 'problem'
 	}
 };

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -4,8 +4,6 @@ const {
 	parseRegExpLiteral
 } = require('regexpp');
 
-const getDocsUrl = require('./utils/get-docs-url');
-
 const escapeWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u{(?:[a-f\d]+)})/;
 const escapePatternWithLowercase = /((?:^|[^\\])(?:\\\\)*)\\(x[a-f\d]{2}|u[a-f\d]{4}|u{(?:[a-f\d]+)}|c[a-z])/;
 const hasLowercaseCharacter = /[a-z]+/;
@@ -126,9 +124,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -3,7 +3,6 @@ const readPkg = require('read-pkg');
 const semver = require('semver');
 const ci = require('ci-info');
 const baseRule = require('eslint/lib/rules/no-warning-comments');
-const getDocsUrl = require('./utils/get-docs-url');
 
 const MESSAGE_ID_AVOID_MULTIPLE_DATES = 'avoidMultipleDates';
 const MESSAGE_ID_EXPIRED_TODO = 'expiredTodo';
@@ -468,9 +467,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		messages: {
 			[MESSAGE_ID_AVOID_MULTIPLE_DATES]:
 				'Avoid using multiple expiration dates in TODO: {{expirationDates}}. {{message}}',

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const operatorTypes = {
 	gt: ['>'],
 	gte: ['>='],
@@ -163,9 +161,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'problem',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code',
 		schema
 	}

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -4,7 +4,6 @@ const camelCase = require('lodash.camelcase');
 const kebabCase = require('lodash.kebabcase');
 const snakeCase = require('lodash.snakecase');
 const upperfirst = require('lodash.upperfirst');
-const getDocsUrl = require('./utils/get-docs-url');
 const cartesianProductSamples = require('./utils/cartesian-product-samples');
 
 const pascalCase = string => upperfirst(camelCase(string));
@@ -232,9 +231,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		schema,
 		messages: {
 			renameToCase: 'Filename is not in {{chosenCases}}. Rename it to {{renamedFilenames}}.',

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const regexp = /^(@.*?\/.*?|[./]+?.*?)(?:\/(\.|(?:index(?:\.js)?))?)$/;
 const isImportingIndex = value => regexp.test(value);
 const normalize = value => value.replace(regexp, '$1');
@@ -26,9 +24,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const enforceNew = new Set([
 	'Object',
 	'Array',
@@ -70,9 +68,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const disableRegex = /^eslint-disable(-next-line|-line)?($|(\s+(@[\w-]+\/(?:[\w-]+\/)?)?[\w-]+)?)/;
 
 const create = context => ({
@@ -31,9 +29,6 @@ const create = context => ({
 module.exports = {
 	create,
 	meta: {
-		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		}
+		type: 'suggestion'
 	}
 };

--- a/rules/no-array-instanceof.js
+++ b/rules/no-array-instanceof.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const create = context => ({
 	BinaryExpression: node => {
 		if (node.operator === 'instanceof' && node.right.type === 'Identifier' && node.right.name === 'Array') {
@@ -20,9 +18,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-console-spaces.js
+++ b/rules/no-console-spaces.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const getConsoleMethod = node => {
 	const methods = [
 		'log',
@@ -134,9 +132,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const iteratorMethods = new Map([
 	['map', 1],
 	['forEach', 1],
@@ -65,9 +63,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'problem',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const defaultElementName = 'element';
 const isLiteralValue = value => node => node && node.type === 'Literal' && node.value === value;
 const isLiteralZero = isLiteralValue(0);
@@ -359,9 +357,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 function checkEscape(context, node, value) {
 	const fixedValue = typeof value === 'string' ? value.replace(/((?:^|[^\\])(?:\\\\)*)\\x/g, '$1\\u00') : value;
 
@@ -28,9 +26,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-keyword-prefix.js
+++ b/rules/no-keyword-prefix.js
@@ -1,7 +1,4 @@
 'use strict';
-
-const getDocsUrl = require('./utils/get-docs-url');
-
 const MESSAGE_ID = 'noKeywordPrefix';
 
 const prepareOptions = ({
@@ -183,9 +180,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code',
 		schema,
 		messages: {

--- a/rules/no-nested-ternary.js
+++ b/rules/no-nested-ternary.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const isParethesized = (sourceCode, node) => {
 	const previousToken = sourceCode.getTokenBefore(node);
 	const nextToken = sourceCode.getTokenAfter(node);
@@ -49,9 +47,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const inferMethod = args => (args.length > 0 && typeof args[0].value === 'number') ? 'alloc' : 'from';
 
 const create = context => {
@@ -25,9 +23,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'problem',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const create = context => {
 	const startsWithHashBang = context.getSourceCode().lines[0].indexOf('#!') === 0;
 
@@ -39,9 +37,6 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
-		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		}
+		type: 'suggestion'
 	}
 };

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const isCommaFollowedWithComma = (element, index, array) => {
 	return element === null && array[index + 1] === null;
 };
@@ -26,9 +24,6 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
-		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		}
+		type: 'suggestion'
 	}
 };

--- a/rules/no-unsafe-regex.js
+++ b/rules/no-unsafe-regex.js
@@ -1,6 +1,5 @@
 'use strict';
 const safeRegex = require('safe-regex');
-const getDocsUrl = require('./utils/get-docs-url');
 
 const message = 'Unsafe regular expression.';
 
@@ -51,9 +50,6 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
-		type: 'problem',
-		docs: {
-			url: getDocsUrl(__filename)
-		}
+		type: 'problem'
 	}
 };

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const getDeclaratorOrPropertyValue = declaratorOrProperty => {
 	return declaratorOrProperty.init || declaratorOrProperty.value;
 };
@@ -232,9 +230,6 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
-		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		}
+		type: 'suggestion'
 	}
 };

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const MESSAGE_ZERO_FRACTION = 'Don\'t use a zero fraction in the number.';
 const MESSAGE_DANGLING_DOT = 'Don\'t use a dangling dot in the number.';
 
@@ -47,9 +45,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const fix = value => {
 	if (!/^0[a-zA-Z]/.test(value)) {
 		return value;
@@ -33,9 +31,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -1,5 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
 const domEventsJson = require('./utils/dom-events.json');
 
 const nestedEvents = Object.keys(domEventsJson).map(key => domEventsJson[key]);
@@ -158,9 +157,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code',
 		schema
 	}

--- a/rules/prefer-dataset.js
+++ b/rules/prefer-dataset.js
@@ -1,5 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
 const {isValidVariableName} = require('./utils');
 
 const getMethodName = memberExpression => memberExpression.property.name;
@@ -71,9 +70,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-event-key.js
+++ b/rules/prefer-event-key.js
@@ -1,5 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
 const quoteString = require('./utils/quote-string');
 
 const keys = [
@@ -218,9 +217,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-exponentiation-operator.js
+++ b/rules/prefer-exponentiation-operator.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const isMathPow = node => {
 	const {callee} = node;
 	return (
@@ -62,9 +60,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -1,5 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
 const isMethodNamed = require('./utils/is-method-named');
 
 const MESSAGE_ID_FLATMAP = 'flat-map';
@@ -150,9 +149,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code',
 		messages: {
 			[MESSAGE_ID_FLATMAP]: 'Prefer `.flatMap(…)` over `.map(…).flat()`.',

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -1,5 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
 const isMethodNamed = require('./utils/is-method-named');
 
 const isNegativeOne = (operator, value) => operator === '-' && value === 1;
@@ -57,9 +56,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const getMethodName = memberExpression => memberExpression.property.name;
 
 const ignoredParentTypes = [
@@ -53,9 +51,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-node-remove.js
+++ b/rules/prefer-node-remove.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const getMethodName = callee => {
 	const {property} = callee;
 
@@ -80,9 +78,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-query-selector.js
+++ b/rules/prefer-query-selector.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const forbiddenIdentifierNames = new Map([
 	['getElementById', 'querySelector'],
 	['getElementsByClassName', 'querySelectorAll'],
@@ -111,9 +109,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -1,6 +1,5 @@
 'use strict';
 const astUtils = require('eslint-ast-utils');
-const getDocsUrl = require('./utils/get-docs-url');
 
 const isApplySignature = (argument1, argument2) => (
 	((argument1.type === 'Literal' && argument1.raw === 'null') ||
@@ -78,9 +77,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const isArrayFrom = node => {
 	const {callee} = node;
 	return (
@@ -53,9 +51,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const doesNotContain = (string, characters) => characters.every(character => !string.includes(character));
 
 const isSimpleString = string => doesNotContain(
@@ -52,9 +50,6 @@ const create = context => {
 module.exports = {
 	create,
 	meta: {
-		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		}
+		type: 'suggestion'
 	}
 };

--- a/rules/prefer-text-content.js
+++ b/rules/prefer-text-content.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const message = 'Prefer `.textContent` over `.innerText`.';
 
 const create = context => {
@@ -23,9 +21,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const tcIdentifiers = new Set([
 	'isArguments',
 	'isArray',
@@ -121,9 +119,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -4,7 +4,6 @@ const astUtils = require('eslint-ast-utils');
 const defaultsDeep = require('lodash.defaultsdeep');
 const toPairs = require('lodash.topairs');
 
-const getDocsUrl = require('./utils/get-docs-url');
 const avoidCapture = require('./utils/avoid-capture');
 const cartesianProductSamples = require('./utils/cartesian-product-samples');
 
@@ -720,9 +719,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code',
 		schema
 	}

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -1,6 +1,5 @@
 'use strict';
 const cleanRegexp = require('clean-regexp');
-const getDocsUrl = require('./utils/get-docs-url');
 const quoteString = require('./utils/quote-string');
 
 const message = 'Use regex shorthands to improve readability.';
@@ -71,9 +70,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -1,6 +1,4 @@
 'use strict';
-const getDocsUrl = require('./utils/get-docs-url');
-
 const customError = /^(?:[A-Z][a-z\d]*)*Error$/;
 
 const create = context => ({
@@ -22,9 +20,6 @@ module.exports = {
 	create,
 	meta: {
 		type: 'suggestion',
-		docs: {
-			url: getDocsUrl(__filename)
-		},
 		fixable: 'code'
 	}
 };

--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -4,7 +4,6 @@ const packageJson = require('../../package');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
 
-module.exports = filename => {
-	const ruleName = path.basename(filename, '.js');
+module.exports = ruleName => {
 	return `${repoUrl}/blob/v${packageJson.version}/docs/rules/${ruleName}.md`;
 };

--- a/rules/utils/get-docs-url.js
+++ b/rules/utils/get-docs-url.js
@@ -1,5 +1,4 @@
 'use strict';
-const path = require('path');
 const packageJson = require('../../package');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';

--- a/test/get-docs-url.js
+++ b/test/get-docs-url.js
@@ -4,10 +4,5 @@ import getDocsUrl from '../rules/utils/get-docs-url';
 
 test('returns the URL of the a named rule\'s documentation', t => {
 	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${pkg.version}/docs/rules/foo.md`;
-	t.is(getDocsUrl('foo.js'), url);
-});
-
-test('determines the rule name from the file', t => {
-	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${pkg.version}/docs/rules/get-docs-url.md`;
-	t.is(getDocsUrl(__filename), url);
+	t.is(getDocsUrl('foo'), url);
 });


### PR DESCRIPTION
This will makes new rules a little easier to write, but may breaks direct import from `rules` dir

Motivation to do this is `get-docs-url.js` filename is against our `prevent-abbreviations` rule(#387), to fix this we have to change the path in every rules file