### PR TITLE
Remove invalid `eslint-disable` comment

### DIFF
--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/expiring-todo-comments */
 'use strict';
 const readPkgUp = require('read-pkg-up');
 const semver = require('semver');


### PR DESCRIPTION
This has to be `eslint-plugin-unicorn` version problem

The file `rules/expiring-todo-comments.js` is not reporting `unicorn/expiring-todo-comments` any more, after new version of `eslint-plugin-unicorn` released