### PR TITLE
Change `prefer-query-selector` rule description to avoid confusion

### DIFF
--- a/docs/rules/prefer-query-selector.md
+++ b/docs/rules/prefer-query-selector.md
@@ -1,6 +1,6 @@
 # Prefer `.querySelector()` over `.getElementById()`, `.querySelectorAll()` over `.getElementsByClassName()` and `.getElementsByTagName()`
 
-It's better to be use one method to query DOM elements.
+It's better to use a single method to query DOM elements.
 
 This rule is partly fixable.
 

--- a/docs/rules/prefer-query-selector.md
+++ b/docs/rules/prefer-query-selector.md
@@ -1,6 +1,6 @@
 # Prefer `.querySelector()` over `.getElementById()`, `.querySelectorAll()` over `.getElementsByClassName()` and `.getElementsByTagName()`
 
-It's better to use a single method to query DOM elements.
+It's better to use the same method to query DOM elements.
 
 This rule is partly fixable.
 

--- a/docs/rules/prefer-query-selector.md
+++ b/docs/rules/prefer-query-selector.md
@@ -1,6 +1,6 @@
 # Prefer `.querySelector()` over `.getElementById()`, `.querySelectorAll()` over `.getElementsByClassName()` and `.getElementsByTagName()`
 
-It's better to be consistent.
+It's better to be use one method to query DOM elements.
 
 This rule is partly fixable.
 


### PR DESCRIPTION
Removed the word consistent, which seemed to cause confusion.

Fix #342

