### PR TITLE
Improve `prefer-includes` rule

### DIFF
--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -5,7 +5,7 @@ const isMethodNamed = require('./utils/is-method-named');
 // Ignore {_,lodash,underscore}.indexOf
 const ignoredVariables = new Set(['_', 'lodash', 'underscore']);
 const isNegativeOne = (operator, value) => operator === '-' && value === 1;
-const isIgnoredTarget = node => node.type === 'Identifier' && ignoredVariables.has(node.name)
+const isIgnoredTarget = node => node.type === 'Identifier' && ignoredVariables.has(node.name);
 
 const report = (context, node, target, argumentsNodes) => {
 	const sourceCode = context.getSourceCode();

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -2,7 +2,10 @@
 const getDocsUrl = require('./utils/get-docs-url');
 const isMethodNamed = require('./utils/is-method-named');
 
+// Ignore {_,lodash,underscore}.indexOf
+const ignoredVariables = new Set(['_', 'lodash', 'underscore']);
 const isNegativeOne = (operator, value) => operator === '-' && value === 1;
+const isIgnoredTarget = node => node.type === 'Identifier' && ignoredVariables.has(node.name)
 
 const report = (context, node, target, argumentsNodes) => {
 	const sourceCode = context.getSourceCode();
@@ -38,8 +41,7 @@ const create = context => ({
 
 		const target = left.callee.object;
 
-		// Ignore {_,lodash,underscore}.indexOf
-		if (target.type === 'Identifier' && ['_', 'lodash', 'underscore'].includes(target.name)) {
+		if (isIgnoredTarget(target)) {
 			return;
 		}
 

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -38,14 +38,14 @@ const create = context => ({
 
 		const target = left.callee.object;
 
-		// ignore _.indexOf(foo)
+		// Ignore _.indexOf(foo)
 		if (target.type === 'Identifier' && target.name === '_') {
 			return;
 		}
 
 		const {arguments: argumentsNodes} = left;
 
-		// ignore something.indexOf(foo, 0, another)
+		// Ignore something.indexOf(foo, 0, another)
 		if (argumentsNodes.length > 2) {
 			return;
 		}

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -4,19 +4,25 @@ const isMethodNamed = require('./utils/is-method-named');
 
 const isNegativeOne = (operator, value) => operator === '-' && value === 1;
 
-const report = (context, node, target, pattern) => {
+const report = (context, node, target, argumentsNodes) => {
 	const sourceCode = context.getSourceCode();
 	const memberExpressionNode = target.parent;
 	const dotToken = sourceCode.getTokenBefore(memberExpressionNode.property);
 	const targetSource = sourceCode.getText().slice(memberExpressionNode.range[0], dotToken.range[0]);
-	const patternSource = sourceCode.getText(pattern);
+
+	// Strip default `fromIndex`
+	if (argumentsNodes.length === 2 && argumentsNodes[1].type === 'Literal' && argumentsNodes[1].value === 0) {
+		argumentsNodes = argumentsNodes.slice(0, 1);
+	}
+
+	const argumentsSource = argumentsNodes.map(argument => sourceCode.getText(argument));
 
 	context.report({
 		node,
 		message: 'Use `.includes()`, rather than `.indexOf()`, when checking for existence.',
 		fix: fixer => {
 			const isNot = node => ['===', '==', '<'].includes(node.operator) ? '!' : '';
-			const replacement = `${isNot(node)}${targetSource}.includes(${patternSource})`;
+			const replacement = `${isNot(node)}${targetSource}.includes(${argumentsSource.join(', ')})`;
 			return fixer.replaceText(node, replacement);
 		}
 	});
@@ -26,29 +32,40 @@ const create = context => ({
 	BinaryExpression: node => {
 		const {left, right} = node;
 
-		if (isMethodNamed(left, 'indexOf')) {
-			const target = left.callee.object;
-			const pattern = left.arguments[0];
+		if (!isMethodNamed(left, 'indexOf')) {
+			return;
+		}
 
-			if (right.type === 'UnaryExpression') {
-				const {argument} = right;
+		const target = left.callee.object;
 
-				if (argument.type !== 'Literal') {
-					return false;
-				}
+		// ignore _.indexOf(foo)
+		if (target.type === 'Identifier' && target.name === '_') {
+			return;
+		}
 
-				const {value} = argument;
+		const {arguments: argumentsNodes} = left;
 
-				if (['!==', '!=', '>', '===', '=='].includes(node.operator) && isNegativeOne(right.operator, value)) {
-					report(context, node, target, pattern);
-				}
+		// ignore something.indexOf(foo, 0, another)
+		if (argumentsNodes.length > 2) {
+			return;
+		}
+
+		if (right.type === 'UnaryExpression') {
+			const {argument} = right;
+
+			if (argument.type !== 'Literal') {
+				return;
 			}
 
-			if (right.type === 'Literal' && ['>=', '<'].includes(node.operator) && right.value === 0) {
-				report(context, node, target, pattern);
-			}
+			const {value} = argument;
 
-			return false;
+			if (['!==', '!=', '>', '===', '=='].includes(node.operator) && isNegativeOne(right.operator, value)) {
+				report(context, node, target, argumentsNodes);
+			}
+		}
+
+		if (right.type === 'Literal' && ['>=', '<'].includes(node.operator) && right.value === 0) {
+			report(context, node, target, argumentsNodes);
 		}
 	}
 });

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -38,8 +38,8 @@ const create = context => ({
 
 		const target = left.callee.object;
 
-		// Ignore _.indexOf(foo)
-		if (target.type === 'Identifier' && target.name === '_') {
+		// Ignore {_,lodash,underscore}.indexOf
+		if (target.type === 'Identifier' && ['_', 'lodash', 'underscore'].includes(target.name)) {
 			return;
 		}
 

--- a/test/prefer-includes.js
+++ b/test/prefer-includes.js
@@ -25,7 +25,9 @@ ruleTester.run('prefer-includes', rule, {
 		'null.indexOf(\'foo\') !== 1',
 		'f(0) < 0',
 		'[].indexOf(foo, \'bar\', 0) !== -1',
-		'_.indexOf(foo, bar) !== -1'
+		'_.indexOf(foo, bar) !== -1',
+		'lodash.indexOf(foo, bar) !== -1',
+		'underscore.indexOf(foo, bar) !== -1'
 	],
 	invalid: [
 		{

--- a/test/prefer-includes.js
+++ b/test/prefer-includes.js
@@ -17,6 +17,7 @@ ruleTester.run('prefer-includes', rule, {
 	valid: [
 		'str.indexOf(\'foo\') !== -n',
 		'str.indexOf(\'foo\') !== 1',
+		'str.indexOf(\'foo\') === -2',
 		'!str.indexOf(\'foo\') === 1',
 		'!str.indexOf(\'foo\') === -n',
 		'str.includes(\'foo\')',

--- a/test/prefer-includes.js
+++ b/test/prefer-includes.js
@@ -46,6 +46,11 @@ ruleTester.run('prefer-includes', rule, {
 			errors
 		},
 		{
+			code: 'str.indexOf(\'foo\') == -1',
+			output: '!str.includes(\'foo\')',
+			errors
+		},
+		{
 			code: '\'foobar\'.indexOf(\'foo\') >= 0',
 			output: '\'foobar\'.includes(\'foo\')',
 			errors

--- a/test/prefer-includes.js
+++ b/test/prefer-includes.js
@@ -23,7 +23,9 @@ ruleTester.run('prefer-includes', rule, {
 		'\'foobar\'.includes(\'foo\')',
 		'[1,2,3].includes(4)',
 		'null.indexOf(\'foo\') !== 1',
-		'f(0) < 0'
+		'f(0) < 0',
+		'[].indexOf(foo, \'bar\', 0) !== -1',
+		'_.indexOf(foo, bar) !== -1'
 	],
 	invalid: [
 		{
@@ -64,6 +66,16 @@ ruleTester.run('prefer-includes', rule, {
 		{
 			code: '(a || b).indexOf(\'foo\') === -1',
 			output: '!(a || b).includes(\'foo\')',
+			errors
+		},
+		{
+			code: 'foo.indexOf(bar, 0) !== -1',
+			output: 'foo.includes(bar)',
+			errors
+		},
+		{
+			code: 'foo.indexOf(bar, 1) !== -1',
+			output: 'foo.includes(bar, 1)',
 			errors
 		}
 	]

--- a/test/prefer-includes.js
+++ b/test/prefer-includes.js
@@ -24,7 +24,7 @@ ruleTester.run('prefer-includes', rule, {
 		'[1,2,3].includes(4)',
 		'null.indexOf(\'foo\') !== 1',
 		'f(0) < 0',
-		'[].indexOf(foo, \'bar\', 0) !== -1',
+		'something.indexOf(foo, 0, another) !== -1',
 		'_.indexOf(foo, bar) !== -1',
 		'lodash.indexOf(foo, bar) !== -1',
 		'underscore.indexOf(foo, bar) !== -1'


### PR DESCRIPTION
1. Ignore `indexOf` more than 2 arguments
2. Ignore `_.indexOf`, fixes #410
3. keep `Array/String.indexOf` method second argument [`fromIndex`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf#Parameters)
4. strip `fromIndex` that is literal `0`