### PR TITLE
Add `ignoreImports` option to `import-index` rule

### DIFF
--- a/docs/rules/import-index.md
+++ b/docs/rules/import-index.md
@@ -63,14 +63,23 @@ import m from '.';
 ```
 
 
-### `ignoreImports`
+## Options
 
-The default behavior is to check for imports. If you want to disable this (for example, you are moving to nodejs esm), set `ignoreImports` to `true`:
+### ignoreImports
+
+Type: `boolean`\
+Default: `false`
+
+Don't check `import` statements.
+
+Can be useful if you're using native `import` in Node.js where the filename and extension is required.
 
 ```js
 // eslint unicorn/import-index: ["error", {"ignoreImports": true}]
-import m from './index'; // pass
+import m from './index'; // Passes
+```
 
+```js
 // eslint unicorn/import-index: ["error", {"ignoreImports": false}]
-import m from './index'; // fails
+import m from './index'; // Fails
 ```

--- a/docs/rules/import-index.md
+++ b/docs/rules/import-index.md
@@ -61,3 +61,16 @@ const m = require('@foo/bar');
 ```js
 import m from '.';
 ```
+
+
+### `ignoreImports`
+
+The default behavior is to check for imports. If you want to disable this (for example, you are moving to nodejs esm), set `ignoreImports` to `true`:
+
+```js
+// eslint unicorn/import-index: ["error", {"ignoreImports": true}]
+import m from './index'; // pass
+
+// eslint unicorn/import-index: ["error", {"ignoreImports": false}]
+import m from './index'; // fails
+```

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -16,11 +16,28 @@ const importIndex = (context, node, argument) => {
 };
 
 const create = context => {
-	return {
-		'CallExpression[callee.name="require"]': node => importIndex(context, node, node.arguments[0]),
-		ImportDeclaration: node => importIndex(context, node, node.source)
+	const options = context.options[0] || {};
+
+	const rules = {
+		'CallExpression[callee.name="require"]': node => importIndex(context, node, node.arguments[0])
 	};
+
+	if (!options.ignoreImports) {
+		rules.ImportDeclaration = node => importIndex(context, node, node.source);
+	}
+
+	return rules;
 };
+
+const schema = [{
+	type: 'object',
+	properties: {
+		ignoreImports: {
+			type: 'boolean'
+		}
+	},
+	additionalProperties: false
+}];
 
 module.exports = {
 	create,
@@ -29,6 +46,7 @@ module.exports = {
 		docs: {
 			url: getDocumentationUrl(__filename)
 		},
+		schema,
 		fixable: 'code'
 	}
 };

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -33,7 +33,8 @@ const schema = [{
 	type: 'object',
 	properties: {
 		ignoreImports: {
-			type: 'boolean'
+			type: 'boolean',
+			default: false
 		}
 	},
 	additionalProperties: false

--- a/test/import-index.js
+++ b/test/import-index.js
@@ -16,9 +16,17 @@ const error = {
 	message: 'Do not reference the index file directly.'
 };
 
+const ignoreImportsOptions = [{
+	ignoreImports: true
+}];
+
 ruleTester.run('import-index', rule, {
 	valid: [
 		'const m = require(\'.\')',
+		{
+			code: 'const m = require(\'.\')',
+			options: ignoreImportsOptions
+		},
 		'const m = require(\'..\')',
 		'const m = require(\'../..\')',
 		'const m = require(\'./foobar\')',
@@ -37,11 +45,47 @@ ruleTester.run('import-index', rule, {
 		'import m from \'foobar\'',
 		'import m from \'index\'',
 		'import m from \'index.js\'',
+		{
+			code: 'import m from \'index.js\'',
+			options: ignoreImportsOptions
+		},
 		'import m from \'indexbar\'',
 		'import m from \'fooindex\'',
 		'import m from \'@index/foo\'',
 		'import m from \'@foo/index\'',
-		'import m from \'@foo/index.js\''
+		'import m from \'@foo/index.js\'',
+		{
+			code: 'import m from \'./\'',
+			options: ignoreImportsOptions
+		},
+		{
+			code: 'import m from \'./index\'',
+			options: ignoreImportsOptions
+		},
+		{
+			code: 'import m from \'./index.js\'',
+			options: ignoreImportsOptions
+		},
+		{
+			code: 'import m from \'../../index\'',
+			options: ignoreImportsOptions
+		},
+		{
+			code: 'import m from \'./foo/index.js\'',
+			options: ignoreImportsOptions
+		},
+		{
+			code: 'import m from \'./foobar/\'',
+			options: ignoreImportsOptions
+		},
+		{
+			code: 'import m from \'@foo/index/index\'',
+			options: ignoreImportsOptions
+		},
+		{
+			code: 'import m from \'@foo/index/index.js\'',
+			options: ignoreImportsOptions
+		}
 	],
 	invalid: [
 		{

--- a/test/import-index.js
+++ b/test/import-index.js
@@ -104,9 +104,21 @@ ruleTester.run('import-index', rule, {
 			output: 'const m = require(\'.\')'
 		},
 		{
+			code: 'const m = require(\'./index\')',
+			errors: [error],
+			output: 'const m = require(\'.\')',
+			options: ignoreImportsOptions
+		},
+		{
 			code: 'const m = require(\'./index.js\')',
 			errors: [error],
 			output: 'const m = require(\'.\')'
+		},
+		{
+			code: 'const m = require(\'./index.js\')',
+			errors: [error],
+			output: 'const m = require(\'.\')',
+			options: ignoreImportsOptions
 		},
 		{
 			code: 'const m = require(\'../../index.js\')',


### PR DESCRIPTION
closes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/307


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#307: import-index: Option to ignore import/export statements](https://issuehunt.io/repos/55832243/issues/307)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->