### PR TITLE
Change some options for `prevent-abbreviations` rule

### DIFF
--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -203,7 +203,7 @@ Default: `'internal'`
 By default, the following code will be reported:
 
 ```js
-import {prop} from './ramda';
+import {prop} from './foo';
 ```
 
 With this set to `true`, the following code will be reported:

--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -156,14 +156,14 @@ Pass `"extendDefaultWhitelist": false` to override the default `whitelist` compl
 
 ### checkDefaultAndNamespaceImports
 
-Type: `"internal"` | `boolean`<br>
-Default: `"internal"`
+Type: `'internal' | boolean`<br>
+Default: `'internal'`
 
-- `"internal"` check variables declared in default or namespace import, **but only internal module**.
-- `true` check variables declared in default or namespace import.
-- `false` disable check variables declared in default or namespace import.
+- `'internal'` - Check variables declared in default or namespace import, **but only for internal modules**.
+- `true` - Check variables declared in default or namespace import.
+- `false` - Don't check variables declared in default or namespace import.
 
-The following code will be reported.
+By default, the following code will be reported:
 
 ```js
 import * as err from './err';
@@ -177,7 +177,7 @@ import err from '/err';
 const err = require('@/err');
 ```
 
-With this set to `true` the following code will be reported.
+With this set to `true`, the following code will be reported:
 
 ```js
 import tempWrite from 'temp-write';
@@ -193,21 +193,20 @@ const err = require('err');
 
 ### checkShorthandImports
 
-Type: `"internal"` | `boolean`<br>
-Default: `"internal"`
+Type: `'internal'` | `boolean`<br>
+Default: `'internal'`
 
+- `'internal'` - Check variables declared in shorthand import, **but only for internal modules**.
+- `true` - Check variables declared in shorthand import.
+- `false` - Don't check variables declared in default shorthand import.
 
-- `"internal"` check variables declared in shorthand import, **but only internal module**.
-- `true` check variables declared in shorthand import.
-- `false` disable check variables declared in default shorthand import.
-
-The following code will be reported.
+By default, the following code will be reported:
 
 ```js
 import {prop} from './ramda';
 ```
 
-With this set to `true` the following code will be reported.
+With this set to `true`, the following code will be reported:
 
 ```js
 import {prop} from 'ramda';

--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -173,10 +173,6 @@ import * as err from './err';
 import err from '/err';
 ```
 
-```js
-const err = require('@/err');
-```
-
 With this set to `true`, the following code will be reported:
 
 ```js

--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -156,7 +156,7 @@ Pass `"extendDefaultWhitelist": false` to override the default `whitelist` compl
 
 ### checkDefaultAndNamespaceImports
 
-Type: `"internal"` || `boolean`<br>
+Type: `"internal"` | `boolean`<br>
 Default: `"internal"`
 
 - `"internal"` check variables declared in default or namespace import, **but only internal module**.
@@ -193,7 +193,7 @@ const err = require('err');
 
 ### checkShorthandImports
 
-Type: `"internal"` || `boolean`<br>
+Type: `"internal"` | `boolean`<br>
 Default: `"internal"`
 
 

--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -156,10 +156,26 @@ Pass `"extendDefaultWhitelist": false` to override the default `whitelist` compl
 
 ### checkDefaultAndNamespaceImports
 
-Type: `boolean`<br>
-Default: `false`
+Type: `"internal"` || `boolean`<br>
+Default: `"internal"`
 
-Pass `"checkDefaultAndNamespaceImports": true` to check variables declared in default or namespace import.
+- `"internal"` check variables declared in default or namespace import, **but only internal module**.
+- `true` check variables declared in default or namespace import.
+- `false` disable check variables declared in default or namespace import.
+
+The following code will be reported.
+
+```js
+import * as err from './err';
+```
+
+```js
+import err from '/err';
+```
+
+```js
+const err = require('@/err');
+```
 
 With this set to `true` the following code will be reported.
 
@@ -177,10 +193,19 @@ const err = require('err');
 
 ### checkShorthandImports
 
-Type: `boolean`<br>
-Default: `false`
+Type: `"internal"` || `boolean`<br>
+Default: `"internal"`
 
-Pass `"checkShorthandImports": true` to check variables declared in shorthand import.
+
+- `"internal"` check variables declared in shorthand import, **but only internal module**.
+- `true` check variables declared in shorthand import.
+- `false` disable check variables declared in default shorthand import.
+
+The following code will be reported.
+
+```js
+import {prop} from './ramda';
+```
 
 With this set to `true` the following code will be reported.
 

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -499,7 +499,7 @@ const isInternalImport = node => {
 		source = node.parent.source.value;
 	}
 
-	return !source.includes('node_modules') && (source.startsWith('.') || source.startsWith('/') || source.startsWith('@/'));
+	return !source.includes('node_modules') && (source.startsWith('.') || source.startsWith('/')));
 };
 
 const create = context => {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -499,7 +499,7 @@ const isInternalImport = node => {
 		source = node.parent.source.value;
 	}
 
-	return !source.includes('node_modules') && (source.startsWith('.') || source.startsWith('/')));
+	return !source.includes('node_modules') && (source.startsWith('.') || source.startsWith('/'));
 };
 
 const create = context => {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -565,25 +565,21 @@ const create = context => {
 		const [definition] = variable.defs;
 
 		if (isDefaultOrNamespaceImportName(definition.name)) {
-			if (
-				!options.checkDefaultAndNamespaceImports ||
-				(
-					options.checkDefaultAndNamespaceImports === 'internal' &&
-					!isInternalImport(definition)
-				)
-			) {
+			if (!options.checkDefaultAndNamespaceImports) {
+				return;
+			}
+
+			if (options.checkDefaultAndNamespaceImports === 'internal' && !isInternalImport(definition)) {
 				return;
 			}
 		}
 
 		if (isShorthandImportIdentifier(definition.name)) {
-			if (
-				!options.checkShorthandImports ||
-				(
-					options.checkShorthandImports === 'internal' &&
-					!isInternalImport(definition)
-				)
-			) {
+			if (!options.checkShorthandImports) {
+				return;
+			}
+
+			if (options.checkShorthandImports === 'internal' && !isInternalImport(definition)) {
 				return;
 			}
 		}

--- a/test/get-documentation-url.js
+++ b/test/get-documentation-url.js
@@ -1,13 +1,13 @@
 import test from 'ava';
-import pkg from '../package.json';
+import packageJson from '../package.json';
 import getDocumentationUrl from '../rules/utils/get-documentation-url';
 
 test('returns the URL of the a named rule\'s documentation', t => {
-	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${pkg.version}/docs/rules/foo.md`;
+	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${packageJson.version}/docs/rules/foo.md`;
 	t.is(getDocumentationUrl('foo.js'), url);
 });
 
 test('determines the rule name from the file', t => {
-	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${pkg.version}/docs/rules/get-documentation-url.md`;
+	const url = `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v${packageJson.version}/docs/rules/get-documentation-url.md`;
 	t.is(getDocumentationUrl(__filename), url);
 });

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -56,8 +56,8 @@ const extendedOptions = [{
 	}
 }];
 
-const noCheckShorthandImportsOptions = [{ checkShorthandImports: false }]
-const noCheckDefaultAndNamespaceImports = [{ checkDefaultAndNamespaceImports: false }]
+const noCheckShorthandImportsOptions = [{checkShorthandImports: false}];
+const noCheckDefaultAndNamespaceImports = [{checkDefaultAndNamespaceImports: false}];
 
 const customOptions = [{
 	checkProperties: true,
@@ -238,7 +238,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 		{
 			code: 'foo();',
 			filename: 'err/http-error.js'
-		},
+		}
 	],
 
 	invalid: [
@@ -1101,8 +1101,6 @@ moduleRuleTester.run('prevent-abbreviations', rule, {
 		'const {err} = foo',
 		'function f({err}) {}',
 
-
-
 		// Option checkDefaultAndNamespaceImports: false
 		{
 			code: 'const err = require("err")',
@@ -1169,7 +1167,7 @@ moduleRuleTester.run('prevent-abbreviations', rule, {
 		{
 			code: 'import { default as foo, err } from "./err"',
 			options: noCheckShorthandImportsOptions
-		},
+		}
 	],
 
 	invalid: [

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -56,6 +56,9 @@ const extendedOptions = [{
 	}
 }];
 
+const noCheckShorthandImportsOptions = [{ checkShorthandImports: false }]
+const noCheckDefaultAndNamespaceImports = [{ checkDefaultAndNamespaceImports: false }]
+
 const customOptions = [{
 	checkProperties: true,
 
@@ -235,7 +238,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 		{
 			code: 'foo();',
 			filename: 'err/http-error.js'
-		}
+		},
 	],
 
 	invalid: [
@@ -1096,7 +1099,77 @@ moduleRuleTester.run('prevent-abbreviations', rule, {
 		// Names from object destructuring are allowed
 		'const {err} = require("err")',
 		'const {err} = foo',
-		'function f({err}) {}'
+		'function f({err}) {}',
+
+
+
+		// Option checkDefaultAndNamespaceImports: false
+		{
+			code: 'const err = require("err")',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'const err = require("./err")',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import foo, * as err from "err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import foo, * as err from "./err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import { default as err, foo as bar } from "err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import { default as err, foo as bar } from "./err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import err, { foo as bar } from "err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import err, { foo as bar } from "./err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import * as err from "err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import * as err from "./err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import err from "err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+		{
+			code: 'import err from "./err"',
+			options: noCheckDefaultAndNamespaceImports
+		},
+
+		// Option checkShorthandImports: false
+		{
+			code: 'import { err } from "err"',
+			options: noCheckShorthandImportsOptions
+		},
+		{
+			code: 'import { err } from "./err"',
+			options: noCheckShorthandImportsOptions
+		},
+		{
+			code: 'import { default as foo, err } from "err"',
+			options: noCheckShorthandImportsOptions
+		},
+		{
+			code: 'import { default as foo, err } from "./err"',
+			options: noCheckShorthandImportsOptions
+		},
 	],
 
 	invalid: [

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1075,6 +1075,9 @@ moduleRuleTester.run('prevent-abbreviations', rule, {
 			export {foo as err};
 		`,
 
+		// Path includes `node_modules`
+		'import err from "./node_modules/err"',
+
 		// Default import names are allowed
 		'import err from "err"',
 		'import err, {foo as bar} from "err"',
@@ -1169,11 +1172,6 @@ moduleRuleTester.run('prevent-abbreviations', rule, {
 		{
 			code: 'const err = require("@/err")',
 			output: 'const error = require("@/err")',
-			errors: createErrors()
-		},
-		{
-			code: 'const {err} = require("./err")',
-			output: 'const {err as error} = require("./err")',
 			errors: createErrors()
 		},
 		{

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1155,6 +1155,63 @@ moduleRuleTester.run('prevent-abbreviations', rule, {
 			errors: createErrors()
 		},
 
+		// Internal import
+		{
+			code: 'const err = require("./err")',
+			output: 'const error = require("./err")',
+			errors: createErrors()
+		},
+		{
+			code: 'const err = require("/err")',
+			output: 'const error = require("/err")',
+			errors: createErrors()
+		},
+		{
+			code: 'const err = require("@/err")',
+			output: 'const error = require("@/err")',
+			errors: createErrors()
+		},
+		{
+			code: 'const {err} = require("./err")',
+			output: 'const {err as error} = require("./err")',
+			errors: createErrors()
+		},
+		{
+			code: 'import err from "./err"',
+			output: 'import error from "./err"',
+			errors: createErrors()
+		},
+		{
+			code: 'import err, {foo as bar} from "./err"',
+			output: 'import error, {foo as bar} from "./err"',
+			errors: createErrors()
+		},
+		{
+			code: 'import {default as err, foo as bar} from "./err"',
+			output: 'import {default as error, foo as bar} from "./err"',
+			errors: createErrors()
+		},
+		{
+			code: 'import * as err from "./err"',
+			output: 'import * as error from "./err"',
+			errors: createErrors()
+		},
+		{
+			code: 'import foo, * as err from "./err"',
+			output: 'import foo, * as error from "./err"',
+			errors: createErrors()
+		},
+		{
+			code: 'import {err} from "./err"',
+			output: 'import {err as error} from "./err"',
+			errors: createErrors()
+		},
+		{
+			code: 'import {default as foo, err} from "./err"',
+			output: 'import {default as foo, err as error} from "./err"',
+			errors: createErrors()
+		},
+
 		{
 			code: outdent`
 				let err;

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1160,18 +1160,13 @@ moduleRuleTester.run('prevent-abbreviations', rule, {
 
 		// Internal import
 		{
-			code: 'const err = require("./err")',
-			output: 'const error = require("./err")',
+			code: 'const err = require("../err")',
+			output: 'const error = require("../err")',
 			errors: createErrors()
 		},
 		{
 			code: 'const err = require("/err")',
 			output: 'const error = require("/err")',
-			errors: createErrors()
-		},
-		{
-			code: 'const err = require("@/err")',
-			output: 'const error = require("@/err")',
 			errors: createErrors()
 		},
 		{


### PR DESCRIPTION
The PR will make this code bellow report an error by default

```js
const getDocsUrl = require('./utils/get-docs-url');
```

without breaking https://github.com/sindresorhus/eslint-plugin-unicorn/pull/237#issuecomment-470942156

```js
import tempWrite from 'temp-write';
```

and

```js
import tempWrite from './node_modules/temp-write';
```

moduleId starts with `.`  `/` ~`@/`~ and without `node_modules` is considered `internal-module`.


The `internal` naming and `internal-module` logic may need discuss.

//cc @futpib @sindresorhus 