### PR TITLE
Extend fixers for `prefer-string-slice`

### DIFF
--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -52,7 +52,11 @@ const create = context => {
 				if (firstArgument === '0') {
 					slice = [firstArgument, secondArgument];
 				} else if (argumentNodes[0].type === 'Literal') {
-					slice = [firstArgument, firstArgument + ' + ' + secondArgument];
+					if (argumentNodes[1].type === 'Literal' && typeof argumentNodes[1].value === 'number' && typeof argumentNodes[0].value === 'number') {
+						slice = [argumentNodes[0].value, argumentNodes[0].value + argumentNodes[1].value];
+					} else {
+						slice = [firstArgument, firstArgument + ' + ' + secondArgument];
+					}
 				}
 			}
 

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -13,6 +13,8 @@ const substringCallTemplate = templates.template`${objectVariable}.substring(${a
 const create = context => {
 	const sourceCode = context.getSourceCode();
 
+	const getPossiblyWrappedText = (objectNode) => objectNode.type === 'LogicalExpression' ? `(${sourceCode.getText(objectNode)})` : sourceCode.getText(objectNode);
+
 	return templates.visitor({
 		[substrCallTemplate](node) {
 			const objectNode = substrCallTemplate.context.getMatch(objectVariable);
@@ -27,14 +29,14 @@ const create = context => {
 			const secondArg = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
 
 			if (argumentNodes.length === 0) {
-				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + '.slice()');
+				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + '.slice()');
 			} else if (argumentNodes.length === 1) {
-				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg})`);
+				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg})`);
 			} else if (argumentNodes.length === 2) {
 				if (firstArg === '0') {
-					problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
+					problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
 				} else if (argumentNodes[0].type === 'Literal') {
-					problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${firstArg} + ${secondArg})`);
+					problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg}, ${firstArg} + ${secondArg})`);
 				}
 			}
 
@@ -54,11 +56,11 @@ const create = context => {
 			const secondArg = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
 
 			if (argumentNodes.length === 0) {
-				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + '.slice()');
+				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + '.slice()');
 			} else if (argumentNodes.length === 1) {
-				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg})`);
+				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg})`);
 			} else if (argumentNodes.length === 2) {
-				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
+				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
 			}
 
 			context.report(problem);

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -13,7 +13,9 @@ const substringCallTemplate = templates.template`${objectVariable}.substring(${a
 const getNumericValue = node => {
 	if (node.type === 'Literal' && typeof node.value === 'number') {
 		return node.value;
-	} else if (node.type === 'UnaryExpression' && node.operator === '-') {
+	}
+
+	if (node.type === 'UnaryExpression' && node.operator === '-') {
 		return 0 - getNumericValue(node.argument);
 	}
 };
@@ -61,9 +63,9 @@ const create = context => {
 			}
 
 			if (slice) {
-				const objectText = objectNode.type === 'LogicalExpression'
-					? `(${sourceCode.getText(objectNode)})`
-					: sourceCode.getText(objectNode);
+				const objectText = objectNode.type === 'LogicalExpression' ?
+					`(${sourceCode.getText(objectNode)})` :
+					sourceCode.getText(objectNode);
 
 				problem.fix = fixer => fixer.replaceText(node, `${objectText}.slice(${slice.join(', ')})`);
 			}
@@ -101,9 +103,9 @@ const create = context => {
 				const secondNumber = argumentNodes[1] ? getNumericValue(argumentNodes[1]) : undefined;
 
 				if (firstNumber !== undefined && secondNumber !== undefined) {
-					slice = firstNumber > secondNumber
-						? [Math.max(0, secondNumber), Math.max(0, firstNumber)]
-						: [Math.max(0, firstNumber), Math.max(0, secondNumber)];
+					slice = firstNumber > secondNumber ?
+						[Math.max(0, secondNumber), Math.max(0, firstNumber)] :
+						[Math.max(0, firstNumber), Math.max(0, secondNumber)];
 				} else if (firstNumber === 0 || secondNumber === 0) {
 					slice = [0, `Math.max(0, ${firstNumber === 0 ? secondArgument : firstArgument})`];
 				} else {
@@ -117,12 +119,12 @@ const create = context => {
 			}
 
 			if (slice) {
-				const objectText = objectNode.type === 'LogicalExpression'
-					? `(${sourceCode.getText(objectNode)})`
-					: sourceCode.getText(objectNode);
+				const objectText = objectNode.type === 'LogicalExpression' ?
+					`(${sourceCode.getText(objectNode)})` :
+					sourceCode.getText(objectNode);
 
 				problem.fix = fixer => fixer.replaceText(node, `${objectText}.slice(${slice.join(', ')})`);
-				}
+			}
 
 			context.report(problem);
 		}

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -31,7 +31,9 @@ const create = context => {
 			} else if (argumentNodes.length === 1) {
 				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg})`);
 			} else if (argumentNodes.length === 2) {
-				if (argumentNodes[0].type === 'Literal') {
+				if (argumentNodes[0].type === 'Literal' && firstArg === '0') {
+					problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
+				} else if (argumentNodes[0].type === 'Literal') {
 					problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${firstArg} + ${secondArg})`);
 				}
 			}

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -31,7 +31,7 @@ const create = context => {
 			} else if (argumentNodes.length === 1) {
 				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg})`);
 			} else if (argumentNodes.length === 2) {
-				if (argumentNodes[0].type === 'Literal' && firstArg === '0') {
+				if (firstArg === '0') {
 					problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
 				} else if (argumentNodes[0].type === 'Literal') {
 					problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${firstArg} + ${secondArg})`);

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -89,12 +89,14 @@ const create = context => {
 
 			if (argumentNodes.length === 0) {
 				slice = [];
-			} else if (argumentNodes.length === 1 && firstNumber !== undefined) {
-				slice = [Math.max(0, firstNumber)];
-			} else if (argumentNodes.length === 1 && isLengthProperty(argumentNodes[0])) {
-				slice = [firstArgument];
 			} else if (argumentNodes.length === 1) {
-				slice = [`Math.max(0, ${firstArgument})`];
+				if (firstNumber !== undefined) {
+					slice = [Math.max(0, firstNumber)];
+				} else if (isLengthProperty(argumentNodes[0])) {
+					slice = [firstArgument];
+				} else {
+					slice = [`Math.max(0, ${firstArgument})`];
+				}
 			} else if (argumentNodes.length === 2) {
 				const secondNumber = argumentNodes[1] ? getNumericValue(argumentNodes[1]) : undefined;
 

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -25,18 +25,18 @@ const create = context => {
 				message: 'Prefer `String#slice()` over `String#substr()`.'
 			};
 
-			const firstArg = argumentNodes[0] ? sourceCode.getText(argumentNodes[0]) : undefined;
-			const secondArg = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
+			const firstArgument = argumentNodes[0] ? sourceCode.getText(argumentNodes[0]) : undefined;
+			const secondArgument = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
 
 			if (argumentNodes.length === 0) {
 				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + '.slice()');
 			} else if (argumentNodes.length === 1) {
-				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg})`);
+				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArgument})`);
 			} else if (argumentNodes.length === 2) {
-				if (firstArg === '0') {
-					problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
+				if (firstArgument === '0') {
+					problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArgument}, ${secondArgument})`);
 				} else if (argumentNodes[0].type === 'Literal') {
-					problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg}, ${firstArg} + ${secondArg})`);
+					problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArgument}, ${firstArgument} + ${secondArgument})`);
 				}
 			}
 
@@ -52,15 +52,15 @@ const create = context => {
 				message: 'Prefer `String#slice()` over `String#substring()`.'
 			};
 
-			const firstArg = argumentNodes[0] ? sourceCode.getText(argumentNodes[0]) : undefined;
-			const secondArg = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
+			const firstArgument = argumentNodes[0] ? sourceCode.getText(argumentNodes[0]) : undefined;
+			const secondArgument = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
 
 			if (argumentNodes.length === 0) {
 				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + '.slice()');
 			} else if (argumentNodes.length === 1) {
-				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg})`);
+				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArgument})`);
 			} else if (argumentNodes.length === 2) {
-				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
+				problem.fix = fixer => fixer.replaceText(node, getPossiblyWrappedText(objectNode) + `.slice(${firstArgument}, ${secondArgument})`);
 			}
 
 			context.report(problem);

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -23,10 +23,17 @@ const create = context => {
 				message: 'Prefer `String#slice()` over `String#substr()`.'
 			};
 
-			const canFix = argumentNodes.length === 0;
+			const firstArg = argumentNodes[0] ? sourceCode.getText(argumentNodes[0]) : undefined;
+			const secondArg = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
 
-			if (canFix) {
+			if (argumentNodes.length === 0) {
 				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + '.slice()');
+			} else if (argumentNodes.length === 1) {
+				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg})`);
+			} else if (argumentNodes.length === 2) {
+				if (argumentNodes[0].type === 'Literal') {
+					problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${firstArg} + ${secondArg})`);
+				}
 			}
 
 			context.report(problem);
@@ -41,10 +48,15 @@ const create = context => {
 				message: 'Prefer `String#slice()` over `String#substring()`.'
 			};
 
-			const canFix = argumentNodes.length === 0;
+			const firstArg = argumentNodes[0] ? sourceCode.getText(argumentNodes[0]) : undefined;
+			const secondArg = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
 
-			if (canFix) {
+			if (argumentNodes.length === 0) {
 				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + '.slice()');
+			} else if (argumentNodes.length === 1) {
+				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg})`);
+			} else if (argumentNodes.length === 2) {
+				problem.fix = fixer => fixer.replaceText(node, sourceCode.getText(objectNode) + `.slice(${firstArg}, ${secondArg})`);
 			}
 
 			context.report(problem);

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -13,7 +13,7 @@ const substringCallTemplate = templates.template`${objectVariable}.substring(${a
 const create = context => {
 	const sourceCode = context.getSourceCode();
 
-	const getPossiblyWrappedText = (objectNode) => objectNode.type === 'LogicalExpression' ? `(${sourceCode.getText(objectNode)})` : sourceCode.getText(objectNode);
+	const getPossiblyWrappedText = objectNode => objectNode.type === 'LogicalExpression' ? `(${sourceCode.getText(objectNode)})` : sourceCode.getText(objectNode);
 
 	return templates.visitor({
 		[substrCallTemplate](node) {

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -18,11 +18,11 @@ const getNumericValue = node => {
 	}
 
 	if (node.type === 'UnaryExpression' && node.operator === '-') {
-		return 0 - getNumericValue(node.argument);
+		return -getNumericValue(node.argument);
 	}
 };
 
-// This handles cases where the argument is very likely to be a number, such as .substring('foo'.length)
+// This handles cases where the argument is very likely to be a number, such as `.substring('foo'.length)`.
 const isLengthProperty = node => (
 	node &&
 	node.type === 'MemberExpression' &&

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -78,6 +78,17 @@ ruleTester.run('prefer-string-slice', rule, {
 			`,
 			errors
 		},
+		{
+			code: outdent`
+				const uri = 'foo';
+				(uri || '').substr(1)
+			`,
+			output: outdent`
+				const uri = 'foo';
+				(uri || '').slice(1)
+			`,
+			errors
+		},
 
 		{
 			code: 'foo.substr(start)',

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -42,7 +42,12 @@ ruleTester.run('prefer-string-slice', rule, {
 		},
 		{
 			code: '"foo".substr(1, 2)',
-			output: '"foo".slice(1, 1 + 2)',
+			output: '"foo".slice(1, 3)',
+			errors
+		},
+		{
+			code: '"foo".substr(1, length)',
+			output: '"foo".slice(1, 1 + length)',
 			errors
 		},
 		{

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
+import {outdent} from 'outdent';
 import rule from '../rules/prefer-string-slice';
 
 const ruleTester = avaRuleTester(test, {
@@ -34,6 +35,38 @@ ruleTester.run('prefer-string-slice', rule, {
 			output: '"foo".slice()',
 			errors
 		},
+		{
+			code: '"foo".substr(1)',
+			output: '"foo".slice(1)',
+			errors
+		},
+		{
+			code: '"foo".substr(1, 2)',
+			output: '"foo".slice(1, 1 + 2)',
+			errors
+		},
+		{
+			code: outdent`
+				const length = 123;
+				"foo".substr(1, length)
+			`,
+			output: outdent`
+				const length = 123;
+				"foo".slice(1, 1 + length)
+			`,
+			errors
+		},
+		{
+			code: outdent`
+				const length = 123;
+				"foo".substr(1, length - 4)
+			`,
+			output: outdent`
+				const length = 123;
+				"foo".slice(1, 1 + length - 4)
+			`,
+			errors
+		},
 
 		{
 			code: 'foo.substr(start)',
@@ -60,6 +93,16 @@ ruleTester.run('prefer-string-slice', rule, {
 		{
 			code: '"foo".substring()',
 			output: '"foo".slice()',
+			errors
+		},
+		{
+			code: '"foo".substring(1)',
+			output: '"foo".slice(1)',
+			errors
+		},
+		{
+			code: '"foo".substring(1, 2)',
+			output: '"foo".slice(1, 2)',
 			errors
 		},
 

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -127,6 +127,41 @@ ruleTester.run('prefer-string-slice', rule, {
 			output: '"foo".slice(1, 2)',
 			errors
 		},
+		{
+			code: '"foo".substring(2, 1)',
+			output: '"foo".slice(1, 2)',
+			errors
+		},
+		{
+			code: '"foo".substring(-1, -5)',
+			output: '"foo".slice(0, 0)',
+			errors
+		},
+		{
+			code: '"foo".substring(-1, 2)',
+			output: '"foo".slice(0, 2)',
+			errors
+		},
+		{
+			code: '"foo".substring(length)',
+			output: '"foo".slice(Math.max(0, length))',
+			errors
+		},
+		{
+			code: '"foo".substring("fo".length)',
+			output: '"foo".slice("fo".length)',
+			errors
+		},
+		{
+			code: '"foo".substring(0, length)',
+			output: '"foo".slice(0, Math.max(0, length))',
+			errors
+		},
+		{
+			code: '"foo".substring(length, 0)',
+			output: '"foo".slice(0, Math.max(0, length))',
+			errors
+		},
 
 		{
 			code: 'foo.substring(start)',

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -59,6 +59,17 @@ ruleTester.run('prefer-string-slice', rule, {
 		{
 			code: outdent`
 				const length = 123;
+				"foo".substr(0, length)
+			`,
+			output: outdent`
+				const length = 123;
+				"foo".slice(0, length)
+			`,
+			errors
+		},
+		{
+			code: outdent`
+				const length = 123;
 				"foo".substr(1, length - 4)
 			`,
 			output: outdent`

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -47,7 +47,17 @@ ruleTester.run('prefer-string-slice', rule, {
 		},
 		{
 			code: '"foo".substr(1, length)',
-			output: '"foo".slice(1, 1 + length)',
+			output: '"foo".substr(1, length)',
+			errors
+		},
+		{
+			code: '"foo".substr(1, "abc".length)',
+			output: '"foo".slice(1, 1 + "abc".length)',
+			errors
+		},
+		{
+			code: '"foo".substr("1", 2)',
+			output: '"foo".substr("1", 2)',
 			errors
 		},
 		{
@@ -57,7 +67,7 @@ ruleTester.run('prefer-string-slice', rule, {
 			`,
 			output: outdent`
 				const length = 123;
-				"foo".slice(1, 1 + length)
+				"foo".substr(1, length)
 			`,
 			errors
 		},
@@ -75,11 +85,22 @@ ruleTester.run('prefer-string-slice', rule, {
 		{
 			code: outdent`
 				const length = 123;
+				"foo".substr('0', length)
+			`,
+			output: outdent`
+				const length = 123;
+				"foo".substr('0', length)
+			`,
+			errors
+		},
+		{
+			code: outdent`
+				const length = 123;
 				"foo".substr(1, length - 4)
 			`,
 			output: outdent`
 				const length = 123;
-				"foo".slice(1, 1 + length - 4)
+				"foo".substr(1, length - 4)
 			`,
 			errors
 		},


### PR DESCRIPTION
Currently barely any `substr()` or `substring()` calls can be automatically fixed.

This PR makes pretty much all `substring()` calls fixable and makes many `substr()` fixable.