### PR TITLE
Support pre-release versions in `expiring-todo-comments` rule

### DIFF
--- a/docs/rules/expiring-todo-comments.md
+++ b/docs/rules/expiring-todo-comments.md
@@ -99,7 +99,7 @@ Supported comparisons are `>` and `>=`. Comparison must have a `@` before such a
 
 ### Pre-releases
 
-TODO comments with rules for package.json and dependency versions support the semver pre-release format, such as `1.0.0-my.pre.release.1.2.3`. This means that if your TODO asks for version `>=1.0.0` and you're in `1.0.0-beta`, your TODO will **not** trigger as a pre-release comes first. Conversely, when you land version at least `1.0.0`, it will properly trigger.
+TODO comments with rules for package.json and dependency versions support the semver pre-release format, such as `1.0.0-my.pre.release.1.2.3`. This means that if your TODO asks for version `>=1.0.0` and you're in `1.0.0-beta`, your TODO will **not** trigger as a pre-release comes first. When the version is at least `1.0.0`, it will properly trigger.
 
 Keep in mind that pre-releases compare by number and alphabetical order. Example: `1.0.0-alpha` < `1.0.0-alpha.1` < `1.0.0-alpha.beta` < `1.0.0-beta` < `1.0.0-beta.2` < `1.0.0-beta.11` < `1.0.0-rc.1` < `1.0.0`.
 

--- a/docs/rules/expiring-todo-comments.md
+++ b/docs/rules/expiring-todo-comments.md
@@ -97,6 +97,14 @@ Argument versions should be [semver](https://semver.org/) compatible such as: `1
 
 Supported comparisons are `>` and `>=`. Comparison must have a `@` before such as `@>` and `@>=`.
 
+### Pre-releases
+
+TODOS with rules for package.json and dependency versions support semver pre-release format (such as `1.0.0-my.pre.release.1.2.3`). This means if your TODO asks for version `>=1.0.0` and you're in `1.0.0-beta` your TODO will **not** trigger as a pre-release comes first. Conversely, when you land version at least `1.0.0` it'll properly trigger.
+
+Keep in mind that pre-releases compare by number and alphabetical order. Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+
+You can read more about [pre-release format here](https://semver.org/#spec-item-9) or [semver precedence rules here](https://semver.org/#spec-item-11).
+
 ### Combinations
 
 Any combination of rules is possible as long as you separate them by commas. Each condition **triggers an individual report.**

--- a/docs/rules/expiring-todo-comments.md
+++ b/docs/rules/expiring-todo-comments.md
@@ -99,11 +99,11 @@ Supported comparisons are `>` and `>=`. Comparison must have a `@` before such a
 
 ### Pre-releases
 
-TODOS with rules for package.json and dependency versions support semver pre-release format (such as `1.0.0-my.pre.release.1.2.3`). This means if your TODO asks for version `>=1.0.0` and you're in `1.0.0-beta` your TODO will **not** trigger as a pre-release comes first. Conversely, when you land version at least `1.0.0` it'll properly trigger.
+TODO comments with rules for package.json and dependency versions support the semver pre-release format, such as `1.0.0-my.pre.release.1.2.3`. This means that if your TODO asks for version `>=1.0.0` and you're in `1.0.0-beta`, your TODO will **not** trigger as a pre-release comes first. Conversely, when you land version at least `1.0.0`, it will properly trigger.
 
-Keep in mind that pre-releases compare by number and alphabetical order. Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+Keep in mind that pre-releases compare by number and alphabetical order. Example: `1.0.0-alpha` < `1.0.0-alpha.1` < `1.0.0-alpha.beta` < `1.0.0-beta` < `1.0.0-beta.2` < `1.0.0-beta.11` < `1.0.0-rc.1` < `1.0.0`.
 
-You can read more about [pre-release format here](https://semver.org/#spec-item-9) or [semver precedence rules here](https://semver.org/#spec-item-11).
+You can read more about the semver pre-release format [here](https://semver.org/#spec-item-9) and semver precedence rules [here](https://semver.org/#spec-item-11).
 
 ### Combinations
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"semver": "^6.3.0"
 	},
 	"devDependencies": {
+		"@lubien/fixture-beta-package": "^1.0.0-beta.1",
 		"ava": "^2.4.0",
 		"babel-eslint": "^10.0.3",
 		"chalk": "^2.4.2",

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -27,8 +27,8 @@ const packageDependencies = {
 };
 
 const DEPENDENCY_INCLUSION_RE = /^[+|-]\s*@?[\S+]\/?\S+/;
-const VERSION_COMPARISON_RE = /^(@?[\S+]\/?\S+)@(>|>=)([\d]+(\.\d+){0,2})/;
-const PKG_VERSION_RE = /^(>|>=)([\d]+(\.\d+){0,2})\s*$/;
+const VERSION_COMPARISON_RE = /^(@?[\S+]\/?\S+)@(>|>=)([\d]+(\.\d+){0,2}(-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9a-z-]+(\.[0-9a-z-]+)*)?)/i;
+const PKG_VERSION_RE = /^(>|>=)([\d]+(\.\d+){0,2}(-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9a-z-]+(\.[0-9a-z-]+)*)?)\s*$/;
 const ISO8601_DATE = /(\d{4})-(\d{2})-(\d{2})/;
 
 function parseTodoWithArguments(string, {terms}) {
@@ -158,13 +158,37 @@ function reachedDate(past) {
 	return Date.parse(past) < Date.parse(now);
 }
 
-function tryToCoerceVersion(version) {
+function tryToCoerceVersion(rawVersion) {
+	let version = rawVersion;
+
+	// Remove leading things like `^1.0.0`, `>1.0.0`
+	const leadingNoises = [
+		'>=',
+		'<=',
+		'>',
+		'<',
+		'~',
+		'^'
+	];
+	const foundTrailingNoise = leadingNoises.find(noise => version.startsWith(noise));
+	if (foundTrailingNoise) {
+		version = version.slice(foundTrailingNoise.length);
+	}
+
+	// Get only the first member for cases such as `1.0.0 - 2.9999.9999`
+	const parts = version.split(' ');
+	if (parts.length > 1) {
+		version = parts[0];
+	}
+
 	if (semver.valid(version)) {
 		return version;
 	}
 
 	try {
-		return semver.coerce(version);
+		// Try to semver.parse a perfect match while semver.coerce tries to fix errors
+		// But coerce can't parse pre-releases.
+		return semver.parse(version) || semver.coerce(version);
 	} catch (_) {
 		return false;
 	}

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -27,8 +27,8 @@ const packageDependencies = {
 };
 
 const DEPENDENCY_INCLUSION_RE = /^[+|-]\s*@?[\S+]\/?\S+/;
-const VERSION_COMPARISON_RE = /^(@?[\S+]\/?\S+)@(>|>=)([\d]+(\.\d+){0,2}(-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9a-z-]+(\.[0-9a-z-]+)*)?)/i;
-const PKG_VERSION_RE = /^(>|>=)([\d]+(\.\d+){0,2}(-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9a-z-]+(\.[0-9a-z-]+)*)?)\s*$/;
+const VERSION_COMPARISON_RE = /^(@?[\S+]\/?\S+)@(>|>=)([\d]+(\.\d+){0,2}(-[\da-z-]+(\.[\da-z-]+)*)?(\+[\da-z-]+(\.[\da-z-]+)*)?)/i;
+const PKG_VERSION_RE = /^(>|>=)([\d]+(\.\d+){0,2}(-[\da-z-]+(\.[\da-z-]+)*)?(\+[\da-z-]+(\.[\da-z-]+)*)?)\s*$/;
 const ISO8601_DATE = /(\d{4})-(\d{2})-(\d{2})/;
 
 function parseTodoWithArguments(string, {terms}) {

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -159,6 +159,10 @@ function reachedDate(past) {
 }
 
 function tryToCoerceVersion(version) {
+	if (semver.valid(version)) {
+		return version;
+	}
+
 	try {
 		return semver.coerce(version);
 	} catch (_) {

--- a/test/expiring-todo-comments.js
+++ b/test/expiring-todo-comments.js
@@ -81,6 +81,9 @@ ruleTester.run('expiring-todo-comments', rule, {
 		'// TODO [+popura]: I think we wont need a broken package.',
 		'// TODO [semver@>1000]: Welp hopefully we wont get at that.',
 		'// TODO [semver@>=1000]: Welp hopefully we wont get at that.',
+		'// TODO [@lubien/fixture-beta-package@>=1.0.0]: we are using a pre-release',
+		'// TODO [@lubien/fixture-beta-package@>=1.0.0-gamma.1]: beta comes first from gamma',
+		'// TODO [@lubien/fixture-beta-package@>=1.0.0-beta.2]: we are in beta.1',
 		'// TODO [2200-12-12, -read-pkg-up]: Combo',
 		'// TODO [2200-12-12, -read-pkg-up, +popura]: Combo',
 		'// TODO [2200-12-12, -read-pkg-up, +popura, semver@>=1000]: Combo',
@@ -222,6 +225,18 @@ ruleTester.run('expiring-todo-comments', rule, {
 		{
 			code: '// TODO [read-pkg-up@>=5.1.1]: when `read-pkg-up` version is >= 5.1.1',
 			errors: [versionMatchesError('read-pkg-up >= 5.1.1', 'when `read-pkg-up` version is >= 5.1.1')]
+		},
+		{
+			code: '// TODO [@lubien/fixture-beta-package@>=1.0.0-alfa.1]: when `@lubien/fixture-beta-package` version is >= 1.0.0-alfa.1',
+			errors: [versionMatchesError('@lubien/fixture-beta-package >= 1.0.0-alfa.1', 'when `@lubien/fixture-beta-package` version is >= 1.0.0-alfa.1')]
+		},
+		{
+			code: '// TODO [@lubien/fixture-beta-package@>=1.0.0-beta.1]: when `@lubien/fixture-beta-package` version is >= 1.0.0-beta.1',
+			errors: [versionMatchesError('@lubien/fixture-beta-package >= 1.0.0-beta.1', 'when `@lubien/fixture-beta-package` version is >= 1.0.0-beta.1')]
+		},
+		{
+			code: '// TODO [@lubien/fixture-beta-package@>=1.0.0-beta.0]: when `@lubien/fixture-beta-package` version is >= 1.0.0-beta.0',
+			errors: [versionMatchesError('@lubien/fixture-beta-package >= 1.0.0-beta.0', 'when `@lubien/fixture-beta-package` version is >= 1.0.0-beta.0')]
 		},
 		{
 			code: '// TODO [semver>1]: Missing @.',


### PR DESCRIPTION
Fixes #432

Refactor tryToCoerceVersion

Don't coerce valid semver tags on expiring-todo-comments.

I'm not sure **where** to test this. Should I export (`exports.tryToCoerceVersion`) the function and test along with the rule itself (test/expiring-todo-comments.js)? @sindresorhus any idea?