### PR TITLE
import-index: Fix for `require()`

### DIFF
--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -6,7 +6,7 @@ const isImportingIndex = value => regexp.test(value);
 const normalize = value => value.replace(regexp, '$1');
 
 const importIndex = (context, node, argument) => {
-	if (isImportingIndex(argument.value)) {
+	if (argument && isImportingIndex(argument.value)) {
 		context.report({
 			node,
 			message: 'Do not reference the index file directly.',

--- a/test/import-index.js
+++ b/test/import-index.js
@@ -18,6 +18,7 @@ const error = {
 
 ruleTester.run('import-index', rule, {
 	valid: [
+		'const m = require()',
 		'const m = require(\'.\')',
 		'const m = require(\'..\')',
 		'const m = require(\'../..\')',


### PR DESCRIPTION
When using ESLint to lint code while typing, if you type `require()` with the `import-index` rule enabled, then it will throw an error.

This fixes that. 