### PR TITLE
Fix `custom-error-definition` to support constructors without a body

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 	},
 	"devDependencies": {
 		"@lubien/fixture-beta-package": "^1.0.0-beta.1",
+		"@typescript-eslint/parser": "^2.9.0",
 		"ava": "^2.4.0",
 		"babel-eslint": "^10.0.3",
 		"chalk": "^2.4.2",
@@ -66,6 +67,7 @@
 		"outdent": "^0.7.0",
 		"pify": "^4.0.1",
 		"tempy": "^0.3.0",
+		"typescript": "^3.7.2",
 		"xo": "^0.25.3"
 	},
 	"peerDependencies": {

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -80,6 +80,12 @@ const customErrorDefinition = (context, node) => {
 	}
 
 	const constructorBodyNode = constructor.value.body;
+
+	// Verify the constructor has a body
+	if (!constructorBodyNode) {
+		return;
+	}
+
 	const constructorBody = constructorBodyNode.body;
 
 	const superExpression = constructorBody.find(isSuperExpression);

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -81,7 +81,7 @@ const customErrorDefinition = (context, node) => {
 
 	const constructorBodyNode = constructor.value.body;
 
-	// Verify the constructor has a body
+	// Verify the constructor has a body (TypeScript)
 	if (!constructorBodyNode) {
 		return;
 	}

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -12,6 +12,10 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
+const typescriptRuleTester = avaRuleTester(test, {
+	parser: require.resolve('@typescript-eslint/parser')
+});
+
 const invalidClassNameError = {ruleId: 'custom-error-definition', message: 'Invalid class name, use `FooError`.'};
 const constructorError = {ruleId: 'custom-error-definition', message: 'Add a constructor to your error.'};
 const noSuperCallError = {ruleId: 'custom-error-definition', message: 'Missing call to `super()` in constructor.'};
@@ -431,5 +435,17 @@ ruleTester.run('custom-error-definition', rule, {
 				invalidNameError('FooError')
 			]
 		}
+	]
+});
+
+typescriptRuleTester.run('custom-error-definition', rule, {
+	valid: [
+		outdent`
+			class CustomError extends Error {
+				constructor(type: string, text: string, reply?: any);
+			}
+		`
+	],
+	invalid: [
 	]
 });

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -446,6 +446,5 @@ typescriptRuleTester.run('custom-error-definition', rule, {
 			}
 		`
 	],
-	invalid: [
-	]
+	invalid: []
 });


### PR DESCRIPTION
Using this example:

```typescript
export class CustomError extends Error {
  type: string;
  text: string;
  reply?: any;
  constructor(type: string, text: string, reply?: any);
}
```

The error `TypeError: Cannot read property 'body' of null` gets thrown for the line `const constructorBody = constructorBodyNode.body;`.

We can fix this by returning early if no constructor body is available.