### PR TITLE
Fix `prevent-abbreviations` fixer bug

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -364,26 +364,25 @@ const shouldFix = variable => {
 	return !variableIdentifiers(variable).some(isExportedIdentifier);
 };
 
+const isIdentifierKeyOfNode = (identifier, node) =>
+	node.key === identifier ||
+	// In `babel-eslint` parent.key is not reference of identifier
+	(
+		node.key.type === identifier.type &&
+		node.key.name === identifier.name
+	);
+
 const isShorthandPropertyIdentifier = identifier => {
 	return identifier.parent.type === 'Property' &&
 		identifier.parent.shorthand &&
-		(
-			identifier.parent.key === identifier ||
-			// In `babel-eslint` parent.key is not reference of identifier
-			(
-				identifier.parent.key.type === identifier.type &&
-				identifier.parent.key.name === identifier.name &&
-				identifier.parent.key.start === identifier.start &&
-				identifier.parent.key.end === identifier.end
-			)
-		);
+		isIdentifierKeyOfNode(identifier, identifier.parent);
 };
 
 const isAssignmentPatternShorthandPropertyIdentifier = identifier => {
 	return identifier.parent.type === 'AssignmentPattern' &&
 		identifier.parent.left === identifier &&
 		identifier.parent.parent.type === 'Property' &&
-		identifier.parent.parent.key === identifier &&
+		isIdentifierKeyOfNode(identifier, identifier.parent.parent) &&
 		identifier.parent.parent.value === identifier.parent &&
 		identifier.parent.parent.shorthand;
 };

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -366,8 +366,17 @@ const shouldFix = variable => {
 
 const isShorthandPropertyIdentifier = identifier => {
 	return identifier.parent.type === 'Property' &&
-		identifier.parent.key === identifier &&
-		identifier.parent.shorthand;
+		identifier.parent.shorthand &&
+		(
+			identifier.parent.key === identifier ||
+			// In `babel-eslint` parent.key is not reference of identifier
+			(
+				identifier.parent.key.type === identifier.type &&
+				identifier.parent.key.name === identifier.name &&
+				identifier.parent.key.start === identifier.start &&
+				identifier.parent.key.end === identifier.end
+			)
+		);
 };
 
 const isAssignmentPatternShorthandPropertyIdentifier = identifier => {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -367,6 +367,7 @@ const shouldFix = variable => {
 const isIdentifierKeyOfNode = (identifier, node) =>
 	node.key === identifier ||
 	// In `babel-eslint` parent.key is not reference of identifier
+	// https://github.com/babel/babel-eslint/issues/809
 	(
 		node.key.type === identifier.type &&
 		node.key.name === identifier.name

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -644,6 +644,12 @@ ruleTester.run('prevent-abbreviations', rule, {
 			errors: createErrors()
 		},
 		{
+			code: 'err => ({err})',
+			output: 'error => ({err: error})',
+			options: customOptions,
+			errors: createErrors()
+		},
+		{
 			code: 'const {err} = foo;',
 			output: 'const {err: error} = foo;',
 			options: customOptions,
@@ -1389,8 +1395,19 @@ babelRuleTester.run('prevent-abbreviations', rule, {
 			}
 		`
 	],
-
 	invalid: [
+		{
+			code: '({err}) => err',
+			output: '({err: error}) => error',
+			options: customOptions,
+			errors: createErrors()
+		},
+		{
+			code: 'err => ({err})',
+			output: 'error => ({err: error})',
+			options: customOptions,
+			errors: createErrors()
+		},
 		{
 			code: 'Foo.customProps = {}',
 			options: checkPropertiesOptions,

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1397,6 +1397,21 @@ babelRuleTester.run('prevent-abbreviations', rule, {
 	],
 	invalid: [
 		{
+			code: outdent`
+				function unicorn(unicorn) {
+					const {prop = {}} = unicorn;
+					return property;
+				}
+			`,
+			output: outdent`
+				function unicorn(unicorn) {
+					const {prop: property = {}} = unicorn;
+					return property;
+				}
+			`,
+			errors: createErrors()
+		},
+		{
 			code: '({err}) => err',
 			output: '({err: error}) => error',
 			options: customOptions,


### PR DESCRIPTION
fixes: #443 and fixes #330

I've located the problem, in `isShorthandPropertyIdentifier` check function, In `babel-eslint` parent.key is not reference of identifier, add a extra check to make it pass