### PR TITLE
Ignore `regexp-tree` parse error on `regex-shorthand` rule

### DIFF
--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -18,16 +18,7 @@ const create = context => {
 			let parsedSource;
 			try {
 				parsedSource = parse(value);
-			} catch (error) {
-				context.report({
-					node,
-					message: '{{original}} can\'t be parsed: {{message}}',
-					data: {
-						original: value,
-						message: error.message
-					}
-				});
-
+			} catch (_) {
 				return;
 			}
 


### PR DESCRIPTION
If a regex can be parsed by ESLint, but can't parse by `regexp-tree`, we don't know if this regex can be optimized, we should just ignore it