### PR TITLE
Update `regex-shorthand`

### DIFF
--- a/test/regex-shorthand.js
+++ b/test/regex-shorthand.js
@@ -3,11 +3,8 @@ import avaRuleTester from 'eslint-ava-rule-tester';
 import rule from '../rules/regex-shorthand';
 
 const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
-	},
 	parserOptions: {
-		sourceType: 'module'
+		ecmaVersion: 2020
 	}
 });
 
@@ -20,20 +17,36 @@ ruleTester.run('regex-shorthand', rule, {
 	valid: [
 		'const foo = /\\d/',
 		'const foo = /\\W/i',
-		'const foo = /\\w/ig',
-		'const foo = /[a-z]/ig',
-		'const foo = /\\d*?/ig',
+		'const foo = /\\w/gi',
+		'const foo = /[a-z]/gi',
+		'const foo = /\\d*?/gi',
 		'const foo = new RegExp(\'\\d\')',
 		'const foo = new RegExp(\'\\d\', \'ig\')',
 		'const foo = new RegExp(\'\\d*?\')',
 		'const foo = new RegExp(\'[a-z]\', \'i\')',
 		'const foo = new RegExp(/\\d/)',
-		'const foo = new RegExp(/\\d/ig)',
+		'const foo = new RegExp(/\\d/gi)',
 		'const foo = new RegExp(/\\d/, \'ig\')',
 		'const foo = new RegExp(/\\d*?/)',
-		'const foo = new RegExp(/[a-z]/, \'i\')'
+		'const foo = new RegExp(/[a-z]/, \'i\')',
+
+		// Should not crash ESLint (#446 and #448)
+		'/\\{\\{verificationUrl\\}\\}/gu',
+		'/^test-(?<name>[a-zA-Z-\\d]+)$/u',
+
+		// Should not suggest wrong regex (#447)
+		'/(\\s|\\.|@|_|-)/u',
+		'/[\\s.@_-]/u'
 	],
 	invalid: [
+		{
+			code: 'const foo = /\\w/ig',
+			errors: [{
+				...error,
+				message: '/\\w/ig can be optimized to /\\w/gi'
+			}],
+			output: 'const foo = /\\w/gi'
+		},
 		{
 			code: 'const foo = /[0-9]/',
 			errors: [{


### PR DESCRIPTION
what I've done:

1. simplify logic
2. sort flags, `regexp-tree` do this by default, but missed in previous version
3. ignore regex `regexp-tree` can't parse, can't find a case to test
4. ignore regex with `u` flag that `regexp-tree` can't handle well, avoid crashing ESLint and suggestting wrong code

related PRs:
#452 was tring to ignore parse error
#451 after simplify logic, we caught a crash issue when running integration test, so move the fix into this one

fixes #446
fixes #447
fixes #448