### PR TITLE
Add `stdDev -> standardDeviation` replacement

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -171,6 +171,9 @@ const defaultReplacements = {
 	src: {
 		source: true
 	},
+	stdDev: {
+		standardDeviation: true
+	},
 	str: {
 		string: true
 	},
@@ -191,8 +194,7 @@ const defaultReplacements = {
 const defaultWhitelist = {
 	propTypes: true,
 	defaultProps: true,
-	getDerivedStateFromProps: true,
-	stdDev: true
+	getDerivedStateFromProps: true
 };
 
 const prepareOptions = ({

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -286,6 +286,10 @@ ruleTester.run('prevent-abbreviations', rule, {
 			output: 'let errorCallbackOptionsObject',
 			errors: createErrors('The variable `errCbOptsObj` should be named `errorCallbackOptionsObject`. A more descriptive name will do too.')
 		},
+		{
+			code: 'let stdDev',
+			errors: createErrors('The variable `stdDev` should be named `standardDeviation`. A more descriptive name will do too.')
+		},
 		noFixingTestCase({
 			code: '({err: 1})',
 			options: checkPropertiesOptions,


### PR DESCRIPTION
Orignal mean to replace stdDev -> standardDeviation, instead of ignore it

https://github.com/sindresorhus/eslint-plugin-unicorn/pull/237#issuecomment-470940285