### PR TITLE
Fix invalid autofix with destructuring assignment in no-for-loops rule

### DIFF
--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -326,12 +326,18 @@ const create = context => {
 					const shouldGenerateIndex = isIndexVariableUsedElsewhereInTheLoopBody(indexVariable, bodyScope, arrayIdentifierName);
 
 					const index = indexIdentifierName;
-					const element = elementIdentifierName || defaultElementName;
 					const array = arrayIdentifierName;
 
+					let element = elementIdentifierName || defaultElementName;
+					let declarationType = 'const';
+					if (elementNode && elementNode.id.type === 'ObjectPattern') {
+						declarationType = elementNode.parent.kind;
+						element = sourceCode.getText(elementNode.id);
+					}
+
 					const replacement = shouldGenerateIndex ?
-						`const [${index}, ${element}] of ${array}.entries()` :
-						`const ${element} of ${array}`;
+						`${declarationType} [${index}, ${element}] of ${array}.entries()` :
+						`${declarationType} ${element} of ${array}`;
 
 					return [
 						fixer.replaceTextRange([

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -356,6 +356,48 @@ ruleTester.run('no-for-loop', rule, {
 					use(element);
 				}
 			}
+		`),
+
+		// Destructuring assignment in usage:
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				const { a, b } = arr[i];
+				console.log(a, b);
+			}
+		`, outdent`
+			for (const { a, b } of arr) {
+				console.log(a, b);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				var { a, b } = arr[i];
+				console.log(a, b);
+			}
+		`, outdent`
+			for (var { a, b } of arr) {
+				console.log(a, b);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				let { a, b } = arr[i];
+				console.log(a, b);
+			}
+		`, outdent`
+			for (let { a, b } of arr) {
+				console.log(a, b);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				var { a, b } = arr[i];
+				console.log(i, a, b);
+			}
+		`, outdent`
+			for (var [i, { a, b }] of arr.entries()) {
+				console.log(i, a, b);
+			}
 		`)
 	]
 });

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -409,6 +409,17 @@ ruleTester.run('no-for-loop', rule, {
 				const { a, b } = element;
 				console.log(a, b, i, element);
 			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				const { a, b } = arr[i];
+				console.log(a, b, arr[i]);
+			}
+		`, outdent`
+			for (const element of arr) {
+				const { a, b } = element;
+				console.log(a, b, element);
+			}
 		`)
 	]
 });

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -398,6 +398,17 @@ ruleTester.run('no-for-loop', rule, {
 			for (var [i, { a, b }] of arr.entries()) {
 				console.log(i, a, b);
 			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				const { a, b } = arr[i];
+				console.log(a, b, i, arr[i]);
+			}
+		`, outdent`
+			for (const [i, element] of arr.entries()) {
+				const { a, b } = element;
+				console.log(a, b, i, element);
+			}
 		`)
 	]
 });


### PR DESCRIPTION
Example (original):
```js
for (let i = 0; i < arr.length; i++) {
  const { a, b } = arr[i];
  console.log(a, b);
}
```

Autofix (before this fix):
```js
for (const element of arr) {
  console.log(a, b);
}
```

Autofix (after this fix):
```js
for (const element of arr) {
  const { a, b } = element;
  console.log(a, b);
}
```

When `arr[i]` is used in a destructuring assignment, the entire assignment should not be removed (previous behavior), only `arr[i]` should be replaced with `element` (new behavior).