### PR TITLE
docs: add minimum Node version requirement to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,11 @@ You might want to check out [XO](https://github.com/xojs/xo), which includes thi
 [**Propose or contribute a new rule ➡**](.github/contributing.md)
 
 
+## Requirements
+
+* [Node.js](https://nodejs.org/) `>= 8`
+
+
 ## Install
 
 ```console


### PR DESCRIPTION
Related: #481

In a separate PR, the minimum supported eslint version could also be added to this requirements section, if desired.