### PR TITLE
Fix invalid autofix with array destructuring in `no-for-loops` rule

### DIFF
--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -334,7 +334,7 @@ const create = context => {
 					let removeDeclaration = true;
 					if (
 						elementNode &&
-						elementNode.id.type === 'ObjectPattern'
+						(elementNode.id.type === 'ObjectPattern' || elementNode.id.type === 'ArrayPattern')
 					) {
 						removeDeclaration = arrayReferences.length === 1;
 

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -371,11 +371,31 @@ ruleTester.run('no-for-loop', rule, {
 		`),
 		testCase(outdent`
 			for (let i = 0; i < arr.length; i++) {
+				const [ a, b ] = arr[i];
+				console.log(a, b);
+			}
+		`, outdent`
+			for (const [ a, b ] of arr) {
+				console.log(a, b);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
 				var { a, b } = arr[i];
 				console.log(a, b);
 			}
 		`, outdent`
 			for (var { a, b } of arr) {
+				console.log(a, b);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				var [ a, b ] = arr[i];
+				console.log(a, b);
+			}
+		`, outdent`
+			for (var [ a, b ] of arr) {
 				console.log(a, b);
 			}
 		`),
@@ -391,11 +411,31 @@ ruleTester.run('no-for-loop', rule, {
 		`),
 		testCase(outdent`
 			for (let i = 0; i < arr.length; i++) {
+				let [ a, b ] = arr[i];
+				console.log(a, b);
+			}
+		`, outdent`
+			for (let [ a, b ] of arr) {
+				console.log(a, b);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
 				var { a, b } = arr[i];
 				console.log(i, a, b);
 			}
 		`, outdent`
 			for (var [i, { a, b }] of arr.entries()) {
+				console.log(i, a, b);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				var [ a, b ] = arr[i];
+				console.log(i, a, b);
+			}
+		`, outdent`
+			for (var [i, [ a, b ]] of arr.entries()) {
 				console.log(i, a, b);
 			}
 		`),
@@ -412,12 +452,34 @@ ruleTester.run('no-for-loop', rule, {
 		`),
 		testCase(outdent`
 			for (let i = 0; i < arr.length; i++) {
+				const [ a, b ] = arr[i];
+				console.log(a, b, i, arr[i]);
+			}
+		`, outdent`
+			for (const [i, element] of arr.entries()) {
+				const [ a, b ] = element;
+				console.log(a, b, i, element);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
 				const { a, b } = arr[i];
 				console.log(a, b, arr[i]);
 			}
 		`, outdent`
 			for (const element of arr) {
 				const { a, b } = element;
+				console.log(a, b, element);
+			}
+		`),
+		testCase(outdent`
+			for (let i = 0; i < arr.length; i++) {
+				const [ a, b ] = arr[i];
+				console.log(a, b, arr[i]);
+			}
+		`, outdent`
+			for (const element of arr) {
+				const [ a, b ] = element;
 				console.log(a, b, element);
 			}
 		`)


### PR DESCRIPTION
Follow up #476 , #476 only fixed object destructuring, not array destructuring

~fixes:​ #295~

~please check https://github.com/sindresorhus/eslint-plugin-unicorn/issues/295#issuecomment-569177568 first when review this PR~

sorry, this didn't fixx #295