### PR TITLE
prefer-modern-dom-apis: Only fix when expression is not used

### DIFF
--- a/rules/prefer-modern-dom-apis.js
+++ b/rules/prefer-modern-dom-apis.js
@@ -1,6 +1,6 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
-const isValueUsed = require('./utils/is-value-used');
+const isValueNotUsable = require('./utils/is-value-not-usable');
 
 const getArgumentNameForReplaceChildOrInsertBefore = nodeArguments => {
 	if (nodeArguments.type === 'Identifier') {
@@ -42,15 +42,15 @@ const checkForReplaceChildOrInsertBefore = (context, node) => {
 
 	const preferredSelector = forbiddenIdentifierNames.get(identifierName);
 
-	const fix = isValueUsed(node) ?
+	const fix = isValueNotUsable(node) ?
 		// Report error when the method is part of a variable assignment
 		// but don't offer to autofix `.replaceWith()` and `.before()`
 		// which don't have a return value.
-		undefined :
 		fixer => fixer.replaceText(
 			node,
 			`${oldChildNodeArgument}.${preferredSelector}(${newChildNodeArgument})`
-		);
+		) :
+		undefined;
 
 	return context.report({
 		node,
@@ -103,7 +103,7 @@ const checkForInsertAdjacentTextOrInsertAdjacentElement = (context, node) => {
 		nodeArguments[1]
 	);
 
-	const fix = identifierName === 'insertAdjacentElement' && isValueUsed(node) ?
+	const fix = identifierName === 'insertAdjacentElement' && !isValueNotUsable(node) ?
 		// Report error when the method is part of a variable assignment
 		// but don't offer to autofix `.insertAdjacentElement()`
 		// which doesn't have a return value.

--- a/rules/prefer-modern-dom-apis.js
+++ b/rules/prefer-modern-dom-apis.js
@@ -1,5 +1,6 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
+const isValueUsed = require('./utils/is-value-used');
 
 const getArgumentNameForReplaceChildOrInsertBefore = nodeArguments => {
 	if (nodeArguments.type === 'Identifier') {
@@ -11,14 +12,6 @@ const forbiddenIdentifierNames = new Map([
 	['replaceChild', 'replaceWith'],
 	['insertBefore', 'before']
 ]);
-
-const isPartOfVariableAssignment = nodeParentType => {
-	if (nodeParentType === 'VariableDeclarator' || nodeParentType === 'AssignmentExpression') {
-		return true;
-	}
-
-	return false;
-};
 
 const checkForReplaceChildOrInsertBefore = (context, node) => {
 	const identifierName = node.callee.property.name;
@@ -42,24 +35,22 @@ const checkForReplaceChildOrInsertBefore = (context, node) => {
 	}
 
 	const parentNode = node.callee.object.name;
-	// This check makes sure that only the first method of chained methods with same identifier name e.g: parentNode.insertBefore(alfa, beta).insertBefore(charlie, delta); gets transformed
+	// This check makes sure that only the first method of chained methods with same identifier name e.g: parentNode.insertBefore(alfa, beta).insertBefore(charlie, delta); gets reported
 	if (!parentNode) {
 		return;
 	}
 
 	const preferredSelector = forbiddenIdentifierNames.get(identifierName);
 
-	let fix = fixer => fixer.replaceText(
-		node,
-		`${oldChildNodeArgument}.${preferredSelector}(${newChildNodeArgument})`
-	);
-
-	// Report error when the method is part of a variable assignment
-	// but don't offer to autofix `.replaceWith()` and `.before()`
-	// which don't have a return value.
-	if (isPartOfVariableAssignment(node.parent.type)) {
-		fix = undefined;
-	}
+	const fix = isValueUsed(node) ?
+		// Report error when the method is part of a variable assignment
+		// but don't offer to autofix `.replaceWith()` and `.before()`
+		// which don't have a return value.
+		undefined :
+		fixer => fixer.replaceText(
+			node,
+			`${oldChildNodeArgument}.${preferredSelector}(${newChildNodeArgument})`
+		);
 
 	return context.report({
 		node,
@@ -112,18 +103,16 @@ const checkForInsertAdjacentTextOrInsertAdjacentElement = (context, node) => {
 		nodeArguments[1]
 	);
 
-	let fix = fixer =>
-		fixer.replaceText(
-			node,
-			`${referenceNode}.${preferredSelector}(${insertedTextArgument})`
-		);
-
-	// Report error when the method is part of a variable assignment
-	// but don't offer to autofix `.insertAdjacentElement()`
-	// which don't have a return value.
-	if (identifierName === 'insertAdjacentElement' && isPartOfVariableAssignment(node.parent.type)) {
-		fix = undefined;
-	}
+	const fix = identifierName === 'insertAdjacentElement' && isValueUsed(node) ?
+		// Report error when the method is part of a variable assignment
+		// but don't offer to autofix `.insertAdjacentElement()`
+		// which doesn't have a return value.
+		undefined :
+		fixer =>
+			fixer.replaceText(
+				node,
+				`${referenceNode}.${preferredSelector}(${insertedTextArgument})`
+			);
 
 	return context.report({
 		node,

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -1,6 +1,6 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
-const isValueUsed = require('./utils/is-value-used');
+const isValueNotUsable = require('./utils/is-value-not-usable');
 
 const getMethodName = memberExpression => memberExpression.property.name;
 
@@ -10,7 +10,7 @@ const create = context => {
 			const {callee} = node;
 
 			if (callee.type === 'MemberExpression' && getMethodName(callee) === 'appendChild') {
-				const fix = isValueUsed(node) ? undefined : fixer => fixer.replaceText(callee.property, 'append');
+				const fix = isValueNotUsable(node) ? fixer => fixer.replaceText(callee.property, 'append') : undefined;
 
 				context.report({
 					node,

--- a/rules/prefer-node-remove.js
+++ b/rules/prefer-node-remove.js
@@ -1,6 +1,6 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
-const isValueUsed = require('./utils/is-value-used');
+const isValueNotUsable = require('./utils/is-value-not-usable');
 
 const getMethodName = callee => {
 	const {property} = callee;
@@ -66,7 +66,7 @@ const create = context => {
 				const argumentName = getArgumentName(node.arguments);
 
 				if (argumentName) {
-					const fix = isValueUsed(node) ? undefined : fixer => fixer.replaceText(node, `${argumentName}.remove()`);
+					const fix = isValueNotUsable(node) ? fixer => fixer.replaceText(node, `${argumentName}.remove()`) : undefined;
 
 					context.report({
 						node,

--- a/rules/utils/is-value-not-usable.js
+++ b/rules/utils/is-value-not-usable.js
@@ -3,5 +3,5 @@
 module.exports = function (node) {
 	const {parent} = node;
 
-	return parent && parent.type !== 'ExpressionStatement';
+	return !parent || parent.type === 'ExpressionStatement';
 };

--- a/rules/utils/is-value-not-usable.js
+++ b/rules/utils/is-value-not-usable.js
@@ -1,7 +1,3 @@
 'use strict';
 
-module.exports = function (node) {
-	const {parent} = node;
-
-	return !parent || parent.type === 'ExpressionStatement';
-};
+module.exports = ({parent}) => !parent || parent.type === 'ExpressionStatement';

--- a/rules/utils/is-value-used.js
+++ b/rules/utils/is-value-used.js
@@ -1,25 +1,7 @@
 'use strict';
 
-const ignoredParentTypes = [
-	'ArrayExpression',
-	'AssignmentExpression',
-	'IfStatement',
-	'MemberExpression',
-	'Property',
-	'ReturnStatement',
-	'VariableDeclarator'
-];
-
-const ignoredGrandparentTypes = [
-	'ExpressionStatement'
-];
-
 module.exports = function (node) {
 	const {parent} = node;
-	const {
-		parent: grandparent
-	} = (parent || {});
 
-	return (parent && ignoredParentTypes.includes(parent.type)) ||
-		(grandparent && ignoredGrandparentTypes.includes(grandparent.type));
+	return parent && parent.type !== 'ExpressionStatement';
 };

--- a/test/prefer-modern-dom-apis.js
+++ b/test/prefer-modern-dom-apis.js
@@ -102,7 +102,7 @@ ruleTester.run('prefer-modern-dom-apis', rule, {
 						'Prefer `beta.before(alfa)` over `parentNode.insertBefore(alfa, beta)`.'
 				}
 			],
-			output: 'beta.before(alfa).insertBefore(charlie, delta);'
+			output: 'parentNode.insertBefore(alfa, beta).insertBefore(charlie, delta);'
 		},
 		{
 			code: 'const foo = parentNode.insertBefore(alfa, beta);',
@@ -123,6 +123,28 @@ ruleTester.run('prefer-modern-dom-apis', rule, {
 				}
 			],
 			output: 'foo = parentNode.insertBefore(alfa, beta);'
+		},
+		{
+			code: 'new Dom(parentNode.insertBefore(alfa, beta))',
+			errors: [
+				{
+					message:
+					'Prefer `beta.before(alfa)` over `parentNode.insertBefore(alfa, beta)`.'
+				}
+			],
+			output: 'new Dom(parentNode.insertBefore(alfa, beta))'
+		},
+		{
+			/* eslint-disable no-template-curly-in-string */
+			code: '`${parentNode.insertBefore(alfa, beta)}`',
+			errors: [
+				{
+					message:
+					'Prefer `beta.before(alfa)` over `parentNode.insertBefore(alfa, beta)`.'
+				}
+			],
+			output: '`${parentNode.insertBefore(alfa, beta)}`'
+			/* eslint-enable no-template-curly-in-string */
 		},
 		// Tests for .insertAdjacentText()
 		{
@@ -275,6 +297,56 @@ ruleTester.run('prefer-modern-dom-apis', rule, {
 				}
 			],
 			output: 'foo = referenceNode.insertAdjacentElement("beforebegin", newNode);'
+		},
+		{
+			code: 'const foo = [referenceNode.insertAdjacentElement("beforebegin", newNode)]',
+			errors: [
+				{
+					message:
+					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
+				}
+			],
+			output: 'const foo = [referenceNode.insertAdjacentElement("beforebegin", newNode)]'
+		},
+		{
+			code: 'foo(bar = referenceNode.insertAdjacentElement("beforebegin", newNode))',
+			errors: [
+				{
+					message:
+					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
+				}
+			],
+			output: 'foo(bar = referenceNode.insertAdjacentElement("beforebegin", newNode))'
+		},
+		{
+			code: 'const foo = () => { return referenceNode.insertAdjacentElement("beforebegin", newNode); }',
+			errors: [
+				{
+					message:
+					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
+				}
+			],
+			output: 'const foo = () => { return referenceNode.insertAdjacentElement("beforebegin", newNode); }'
+		},
+		{
+			code: 'if (referenceNode.insertAdjacentElement("beforebegin", newNode)) {}',
+			errors: [
+				{
+					message:
+					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
+				}
+			],
+			output: 'if (referenceNode.insertAdjacentElement("beforebegin", newNode)) {}'
+		},
+		{
+			code: 'const foo = { bar: referenceNode.insertAdjacentElement("beforebegin", newNode) }',
+			errors: [
+				{
+					message:
+					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
+				}
+			],
+			output: 'const foo = { bar: referenceNode.insertAdjacentElement("beforebegin", newNode) }'
 		}
 	]
 });


### PR DESCRIPTION
Providing a fix related to [this comment](https://github.com/sindresorhus/eslint-plugin-unicorn/pull/498#issuecomment-576365404).

~fix(`prefer-modern-dom-apis`): Ignore other cases where node return value is used~

~- Where parent is an `ArrayExpression`, `IfStatement`, `MemberExpression`,  `Property`, `ReturnStatement`~

~Fixes a test which made a fix which would break because of an inability of the replacement API to return a value.~

~Also provides minor optimization to avoid declaring fixer with value when not needed.
Also applies (and for `prefer-node-*` rules, switches from) checking `ExpressionStatement` in favor of specific parents (`BinaryExpression`, `CallExpression`, `ConditionalExpression`, `LogicalExpression`, `UnaryExpression`), since in theory, the last part of `parentNode.insertBefore(alfa, beta).insertBefore(charlie, delta);` could be checked if the rule were changed to allow such parent expressions rather than requiring a parent member to be a name only (i.e., fixing `parentNode` in `parent.insertBefore()` but ignoring `some.expression().insertBefore()`) since technically such a replacement could be made. But allowing it to be made would allow additional refactoring and potentially reporting long errors, e.g., "Prefer some.very.very.long.expression().before() over some.very.very.long.expression().insertBefore", and I'm not sure it is worth the trouble to support this strange pattern. But I did think it at least more logically clear to check the parents.~

fix(`prefer-modern-dom-apis`): Switch to whitelist for determining where node return values are expected safe not to be used.

For `prefer-modern-dom-apis`, the change will avoid fixers in more cases than just `VariableDeclarator` and `AssignmentExpression` parent types (as previously); will now avoid whenever parent is not an `ExpressionStatement` since many other parents, e.g., `ArrayExpression`, `IfStatement`, `'MemberExpression`, `Property`, `ReturnStatement`, etc. can use a return value.

For `prefer-node-*` rules, rather than blacklisting an albeit more extensive set of parents, will also switch to a whitelist, potentially avoiding fixers on other contexts not previously avoided, e.g., `AwaitExpression`.

The previous avoidance by `prefer-node-*` of fixers with `ExpressionStatement` grandparents is not currently required.

Also:
1. provides minor optimization to avoid declaring fixer with value when not needed.
2. fixes a test which made a fix which would break because of an inability of the replacement API to return a value.
3. refactors to use `isValueNotUsable` over `isValueUsed`