### PR TITLE
Refactor `prefer-node-append` to use selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-unicorn",
-	"version": "15.0.1",
+	"version": "16.0.0",
 	"description": "Various awesome ESLint rules",
 	"license": "MIT",
 	"repository": "sindresorhus/eslint-plugin-unicorn",

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -1,17 +1,11 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const isValueNotUsable = require('./utils/is-value-not-usable');
-
-const selector = [
-	'CallExpression',
-	'[callee.property.name="appendChild"]',
-	'[arguments.length=1]',
-	'[arguments.0.type!="SpreadElement"]'
-].join('')
+const methodSelector = require('./utils/method-selector');
 
 const create = context => {
 	return {
-		[selector](node) {
+		[methodSelector('appendChild', 1)](node) {
 			// TODO: exclude those cases parent/child impossible to be `Node`
 			const fix = isValueNotUsable(node) ?
 				fixer => fixer.replaceText(node.callee.property, 'append') :

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -3,7 +3,7 @@ const getDocumentationUrl = require('./utils/get-documentation-url');
 const isValueNotUsable = require('./utils/is-value-not-usable');
 const methodSelector = require('./utils/method-selector');
 
-const message = 'Prefer `Node#append()` over `Node#appendChild()`.'
+const message = 'Prefer `Node#append()` over `Node#appendChild()`.';
 const selector = methodSelector({
 	name: 'appendChild',
 	length: 1

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -5,7 +5,7 @@ const methodSelector = require('./utils/method-selector');
 
 const create = context => {
 	return {
-		[methodSelector('appendChild', 1)](node) {
+		[methodSelector("appendChild", 1)](node) {
 			// TODO: exclude those cases parent/child impossible to be `Node`
 			const fix = isValueNotUsable(node) ?
 				fixer => fixer.replaceText(node.callee.property, 'append') :

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -3,9 +3,14 @@ const getDocumentationUrl = require('./utils/get-documentation-url');
 const isValueNotUsable = require('./utils/is-value-not-usable');
 const methodSelector = require('./utils/method-selector');
 
+const selector = methodSelector({
+	name: 'appendChild',
+	length: 1
+});
+
 const create = context => {
 	return {
-		[methodSelector("appendChild", 1)](node) {
+		[selector](node) {
 			// TODO: exclude those cases parent/child impossible to be `Node`
 			const fix = isValueNotUsable(node) ?
 				fixer => fixer.replaceText(node.callee.property, 'append') :

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -2,9 +2,16 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const isValueNotUsable = require('./utils/is-value-not-usable');
 
+const selector = [
+	'CallExpression',
+	'[callee.property.name="appendChild"]',
+	'[arguments.length=1]',
+	'[arguments.0.type!="SpreadElement"]'
+].join('')
+
 const create = context => {
 	return {
-		'CallExpression[callee.property.name="appendChild"][arguments.length=1]'(node) {
+		[selector](node) {
 			// TODO: exclude those cases parent/child impossible to be `Node`
 			const fix = isValueNotUsable(node) ?
 				fixer => fixer.replaceText(node.callee.property, 'append') :

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -2,22 +2,19 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const isValueNotUsable = require('./utils/is-value-not-usable');
 
-const getMethodName = memberExpression => memberExpression.property.name;
-
 const create = context => {
 	return {
-		CallExpression(node) {
-			const {callee} = node;
+		'CallExpression[callee.property.name="appendChild"][arguments.length=1]'(node) {
+			// TODO: exclude those cases parent/child impossible to be `Node`
+			const fix = isValueNotUsable(node) ?
+				fixer => fixer.replaceText(node.callee.property, 'append') :
+				undefined;
 
-			if (callee.type === 'MemberExpression' && getMethodName(callee) === 'appendChild') {
-				const fix = isValueNotUsable(node) ? fixer => fixer.replaceText(callee.property, 'append') : undefined;
-
-				context.report({
-					node,
-					message: 'Prefer `Node#append()` over `Node#appendChild()`.',
-					fix
-				});
-			}
+			context.report({
+				node,
+				message: 'Prefer `Node#append()` over `Node#appendChild()`.',
+				fix
+			});
 		}
 	};
 };

--- a/rules/prefer-node-append.js
+++ b/rules/prefer-node-append.js
@@ -3,6 +3,7 @@ const getDocumentationUrl = require('./utils/get-documentation-url');
 const isValueNotUsable = require('./utils/is-value-not-usable');
 const methodSelector = require('./utils/method-selector');
 
+const message = 'Prefer `Node#append()` over `Node#appendChild()`.'
 const selector = methodSelector({
 	name: 'appendChild',
 	length: 1
@@ -18,7 +19,7 @@ const create = context => {
 
 			context.report({
 				node,
-				message: 'Prefer `Node#append()` over `Node#appendChild()`.',
+				message,
 				fix
 			});
 		}

--- a/rules/utils/method-selector.js
+++ b/rules/utils/method-selector.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = (method, argumentsLength) => [
+	'CallExpression',
+	'[callee.type="MemberExpression"]',
+	`[callee.property.name="${method}"]`,
+	`[arguments.length=${argumentsLength}]`,
+	...Array.from(
+		{length: argumentsLength},
+		(_, index) => `[arguments.${index}.type!="SpreadElement"]`
+	)
+].join('');

--- a/rules/utils/method-selector.js
+++ b/rules/utils/method-selector.js
@@ -3,8 +3,8 @@
 module.exports = (method, argumentsLength) => [
 	'CallExpression',
 	'[callee.type="MemberExpression"]',
-	`[callee.computed=false]`,
-	`[callee.property.type="Identifier"]`,
+	'[callee.computed=false]',
+	'[callee.property.type="Identifier"]',
 	`[callee.property.name="${method}"]`,
 	`[arguments.length=${argumentsLength}]`,
 	...Array.from(

--- a/rules/utils/method-selector.js
+++ b/rules/utils/method-selector.js
@@ -3,6 +3,8 @@
 module.exports = (method, argumentsLength) => [
 	'CallExpression',
 	'[callee.type="MemberExpression"]',
+	`[callee.computed=false]`,
+	`[callee.property.type="Identifier"]`,
 	`[callee.property.name="${method}"]`,
 	`[arguments.length=${argumentsLength}]`,
 	...Array.from(

--- a/rules/utils/method-selector.js
+++ b/rules/utils/method-selector.js
@@ -1,14 +1,25 @@
 'use strict';
 
-module.exports = (method, argumentsLength) => [
-	'CallExpression',
-	'[callee.type="MemberExpression"]',
-	'[callee.computed=false]',
-	'[callee.property.type="Identifier"]',
-	`[callee.property.name="${method}"]`,
-	`[arguments.length=${argumentsLength}]`,
-	...Array.from(
-		{length: argumentsLength},
-		(_, index) => `[arguments.${index}.type!="SpreadElement"]`
-	)
-].join('');
+module.exports = options => {
+	const {name, length, allowSpreadElement} = {
+		allowSpreadElement: false,
+		...options
+	};
+
+	return [
+		'CallExpression',
+		'[callee.type="MemberExpression"]',
+		'[callee.computed=false]',
+		'[callee.property.type="Identifier"]',
+		`[callee.property.name="${name}"]`,
+		`[arguments.length=${length}]`,
+		...(
+			allowSpreadElement ?
+				[] :
+				Array.from(
+					{length},
+					(_, index) => `[arguments.${index}.type!="SpreadElement"]`
+				)
+		)
+	].join('');
+};

--- a/test/prefer-node-append.js
+++ b/test/prefer-node-append.js
@@ -27,7 +27,7 @@ ruleTester.run('prefer-node-append', rule, {
 		'parent[appendChild](child);',
 		// Not `appendChild`
 		'parent.foo(child);',
-		// Extra/Less argument(s)
+		// More or less argument(s)
 		'parent.appendChild(one, two);',
 		'parent.appendChild();',
 		'parent.appendChild(...argumentsArray)'

--- a/test/prefer-node-append.js
+++ b/test/prefer-node-append.js
@@ -23,6 +23,8 @@ ruleTester.run('prefer-node-append', rule, {
 		'appendChild(child);',
 		// `callee.property` is not a `Identifier`
 		'parent[\'appendChild\'](child);',
+		// Computed
+		'parent[appendChild](child);',
 		// Not `appendChild`
 		'parent.foo(child);',
 		// Extra/Less argument(s)

--- a/test/prefer-node-append.js
+++ b/test/prefer-node-append.js
@@ -15,10 +15,15 @@ const error = {
 
 ruleTester.run('prefer-node-append', rule, {
 	valid: [
+		// Already using `append`
 		'parent.append(child);',
-		'document.body.append(child, \'text\');',
-		'node.append()',
-		'node.append(null)'
+		// Not `MemberExpression`
+		'appendChild(child);',
+		// Not `appendChild`
+		'parent.foo(child);',
+		// Extra/Less argument(s)
+		'parent.appendChild(one, two);',
+		'parent.appendChild();'
 	],
 	invalid: [
 		{
@@ -29,11 +34,6 @@ ruleTester.run('prefer-node-append', rule, {
 		{
 			code: 'document.body.appendChild(child);',
 			output: 'document.body.append(child);',
-			errors: [error]
-		},
-		{
-			code: 'node.appendChild()',
-			output: 'node.append()',
 			errors: [error]
 		},
 		{

--- a/test/prefer-node-append.js
+++ b/test/prefer-node-append.js
@@ -27,7 +27,8 @@ ruleTester.run('prefer-node-append', rule, {
 		'parent.foo(child);',
 		// Extra/Less argument(s)
 		'parent.appendChild(one, two);',
-		'parent.appendChild();'
+		'parent.appendChild();',
+		'parent.appendChild(...argumentsArray)'
 	],
 	invalid: [
 		{

--- a/test/prefer-node-append.js
+++ b/test/prefer-node-append.js
@@ -17,8 +17,12 @@ ruleTester.run('prefer-node-append', rule, {
 	valid: [
 		// Already using `append`
 		'parent.append(child);',
+		// Not `CallExpression`
+		'new parent.appendChild(child);',
 		// Not `MemberExpression`
 		'appendChild(child);',
+		// `callee.property` is not a `Identifier`
+		'parent[\'appendChild\'](child);',
 		// Not `appendChild`
 		'parent.foo(child);',
 		// Extra/Less argument(s)


### PR DESCRIPTION
- Simplify logic
- Add `arguments.length` check
- Exclude `SpreadElement`
- Add `TODO` on type check

At last, I add a util function `methodSelector` to do all these checks, planning to add similar checks to `prefer-node-remove` `prefer-replace-all` `prefer-starts-ends-with` `prefer-trim-start-end` 