### PR TITLE
Update `escape-case` tests

### DIFF
--- a/test/escape-case.js
+++ b/test/escape-case.js
@@ -18,9 +18,21 @@ const errors = [
 
 ruleTester.run('escape-case', rule, {
 	valid: [
+		// Literal string
 		'const foo = "\\xA9";',
 		'const foo = "\\uD834";',
 		'const foo = "\\u{1D306}";',
+		'const foo = "\\uD834foo";',
+		'const foo = "foo\\uD834";',
+		'const foo = "foo \\uD834";',
+		'const foo = "foo \\u2500";',
+		'const foo = "foo \\x46";',
+		'const foo = "foo\\\\xbar";',
+		'const foo = "foo\\\\ubarbaz";',
+		'const foo = "foo\\\\\\\\xbar";',
+		'const foo = "foo\\\\\\\\ubarbaz";',
+
+		// TemplateLiteral
 		'const foo = `\\xA9`;',
 		'const foo = `\\uD834`;',
 		'const foo = `\\u{1D306}`;',
@@ -28,31 +40,33 @@ ruleTester.run('escape-case', rule, {
 		'const foo = `foo\\uD834`;',
 		'const foo = `foo \\uD834`;',
 		'const foo = `${"\uD834 foo"} \\uD834`;',
-		'const foo = "\\uD834foo";',
-		'const foo = "foo\\uD834";',
-		'const foo = "foo \\uD834";',
-		'const foo = "foo \\u2500";',
-		'const foo = "foo \\x46";',
 		'const foo = `foo \\u2500`;',
 		'const foo = `foo \\x46`;',
-		'const foo = "foo\\\\xbar";',
-		'const foo = "foo\\\\ubarbaz";',
-		'const foo = "foo\\\\\\\\xbar";',
-		'const foo = "foo\\\\\\\\ubarbaz";',
 		'const foo = `foo\\\\xbar`;',
 		'const foo = `foo\\\\ubarbaz`;',
 		'const foo = `foo\\\\\\\\xbar`;',
 		'const foo = `foo\\\\\\\\ubarbaz`;',
-		'const foo = /\\xA9/',
-		'const foo = /\\uD834/',
-		'const foo = /\\u{1D306}/u',
-		'const foo = /\\cA/',
+
+		// Literal regex
+		'const foo = /foo\\xA9/',
+		'const foo = /foo\\uD834/',
+		'const foo = /foo\\u{1D306}/u',
+		'const foo = /foo\\cA/',
+		// Escape
+		'const foo = /foo\\\\xa9/;',
+		'const foo = /foo\\\\\\\\xa9/;',
+		'const foo = /foo\\\\uD834/',
+		'const foo = /foo\\\\u{1}/u',
+		'const foo = /foo\\\\cA/',
+
+		// RegExp
 		'const foo = new RegExp("/\\xA9")',
 		'const foo = new RegExp("/\\uD834/")',
 		'const foo = new RegExp("/\\u{1D306}/", "u")',
 		'const foo = new RegExp("/\\cA/")'
 	],
 	invalid: [
+		// Literal string
 		{
 			code: 'const foo = "\\xa9";',
 			errors,
@@ -68,6 +82,38 @@ ruleTester.run('escape-case', rule, {
 			errors,
 			output: 'const foo = "\\u{1D306}";'
 		},
+		{
+			code: 'const foo = "\\ud834foo";',
+			errors,
+			output: 'const foo = "\\uD834foo";'
+		},
+		{
+			code: 'const foo = "foo\\ud834";',
+			errors,
+			output: 'const foo = "foo\\uD834";'
+		},
+		{
+			code: 'const foo = "foo \\ud834";',
+			errors,
+			output: 'const foo = "foo \\uD834";'
+		},
+		{
+			code: 'const foo = "\\\\\\ud834foo";',
+			errors,
+			output: 'const foo = "\\\\\\uD834foo";'
+		},
+		{
+			code: 'const foo = "foo\\\\\\ud834";',
+			errors,
+			output: 'const foo = "foo\\\\\\uD834";'
+		},
+		{
+			code: 'const foo = "foo \\\\\\ud834";',
+			errors,
+			output: 'const foo = "foo \\\\\\uD834";'
+		},
+
+		// TemplateLiteral
 		{
 			code: 'const foo = `\\xa9`;',
 			errors,
@@ -109,36 +155,6 @@ ruleTester.run('escape-case', rule, {
 			output: 'const foo = `\\uD834${foo}\\uD834${foo}\\uD834`;'
 		},
 		{
-			code: 'const foo = "\\ud834foo";',
-			errors,
-			output: 'const foo = "\\uD834foo";'
-		},
-		{
-			code: 'const foo = "foo\\ud834";',
-			errors,
-			output: 'const foo = "foo\\uD834";'
-		},
-		{
-			code: 'const foo = "foo \\ud834";',
-			errors,
-			output: 'const foo = "foo \\uD834";'
-		},
-		{
-			code: 'const foo = "\\\\\\ud834foo";',
-			errors,
-			output: 'const foo = "\\\\\\uD834foo";'
-		},
-		{
-			code: 'const foo = "foo\\\\\\ud834";',
-			errors,
-			output: 'const foo = "foo\\\\\\uD834";'
-		},
-		{
-			code: 'const foo = "foo \\\\\\ud834";',
-			errors,
-			output: 'const foo = "foo \\\\\\uD834";'
-		},
-		{
 			code: 'const foo = `\\\\\\ud834foo`;',
 			errors,
 			output: 'const foo = `\\\\\\uD834foo`;'
@@ -153,6 +169,8 @@ ruleTester.run('escape-case', rule, {
 			errors,
 			output: 'const foo = `foo \\\\\\uD834`;'
 		},
+
+		// Literal regex
 		{
 			code: 'const foo = /\\xa9/;',
 			errors,
@@ -173,6 +191,18 @@ ruleTester.run('escape-case', rule, {
 			errors,
 			output: 'const foo = /\\cA/'
 		},
+		{
+			code: 'const foo = /foo\\\\\\xa9/;',
+			errors,
+			output: 'const foo = /foo\\\\\\xA9/;'
+		},
+		{
+			code: 'const foo = /foo\\\\\\\\\\xa9/;',
+			errors,
+			output: 'const foo = /foo\\\\\\\\\\xA9/;'
+		},
+
+		// RegExp
 		{
 			code: 'const foo = new RegExp("/\\xa9")',
 			errors,


### PR DESCRIPTION
Categorize fixtures.

Improve Literal regex tests.(escaped `\` is not well tested)