### PR TITLE
Simplify `escape-case`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"lodash.upperfirst": "^4.3.1",
 		"read-pkg-up": "^7.0.1",
 		"regexp-tree": "^0.1.17",
-		"regexpp": "^3.0.0",
 		"reserved-words": "^0.1.2",
 		"safe-regex": "^2.1.1",
 		"semver": "^7.1.2"

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -91,31 +91,34 @@ const create = context => {
 				return;
 			}
 
-			const matches = node.raw.match(escapeWithLowercase);
+			const original = node.raw;
+			const fixed = fix(original, escapeWithLowercase);
 
-			if (matches && matches.groups.data.slice(1).match(hasLowercaseCharacter)) {
+			if (fixed !== original) {
 				context.report({
 					node,
 					message,
-					fix: fixer => fixer.replaceText(node, fix(node.raw, escapeWithLowercase))
+					fix: fixer => fixer.replaceText(node, fixed)
 				});
 			}
 		},
 		'Literal[regex]'(node) {
-			const escapeNodePosition = findLowercaseEscape(node.raw);
+			const original = node.raw;
+			const fixed = fixRegExp(original);
 
-			if (escapeNodePosition) {
+			if (fixed !== original) {
 				context.report({
 					node,
 					message,
-					fix: fixer => fixer.replaceText(node, fixRegExp(node.raw))
+					fix: fixer => fixer.replaceText(node, fixed)
 				});
 			}
 		},
 		TemplateElement(node) {
-			const matches = node.value.raw.match(escapeWithLowercase);
+			const original = node.value.raw;
+			const fixed = fix(original, escapeWithLowercase);
 
-			if (matches && matches[2].slice(1).match(hasLowercaseCharacter)) {
+			if (fixed !== original) {
 				context.report({
 					node,
 					message,

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -122,11 +122,7 @@ const create = context => {
 				context.report({
 					node,
 					message,
-					fix: fixer => replaceTemplateElement(
-						fixer,
-						node,
-						fix(node.value.raw, escapeWithLowercase)
-					)
+					fix: fixer => replaceTemplateElement(fixer, node, fixed)
 				});
 			}
 		}

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -2,8 +2,8 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const replaceTemplateElement = require('./utils/replace-template-element');
 
-const escapeWithLowercase = /(?<before>(?:^|[^\\])(?:\\\\)*)\\(?<data>x[\da-f]{2}|u[\da-f]{4}|u{[\da-f]+})/;
-const escapePatternWithLowercase = /(?<before>(?:^|[^\\])(?:\\\\)*)\\(?<data>x[\da-f]{2}|u[\da-f]{4}|u{[\da-f]+}|c[a-z])/;
+const escapeWithLowercase = /(?<before>(?:^|[^\\])(?:\\\\)*)\\(?<data>x[\dA-Fa-f]{2}|u[\dA-Fa-f]{4}|u{[\dA-Fa-f]+})/;
+const escapePatternWithLowercase = /(?<before>(?:^|[^\\])(?:\\\\)*)\\(?<data>x[\dA-Fa-f]{2}|u[\dA-Fa-f]{4}|u{[\dA-Fa-f]+}|c[a-z])/;
 const message = 'Use uppercase characters for the value of the escape sequence.';
 
 const fix = (value, regexp) => {

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -66,23 +66,22 @@ Record escaped node position in regexpp ASTNode. Returns undefined if not found.
 /**
 Produce a fix if there is a lowercase escape sequence in the node.
 
-@param {ASTNode} node - The regular expression literal ASTNode to check.
-@returns {string} The fixed `node.raw` string.
+@param {string} value - The regular expression literal string to check.
+@returns {string} The fixed string.
 */
-const fixRegExp = node => {
-	const escapeNodePosition = findLowercaseEscape(node.raw);
-	const {raw} = node;
+const fixRegExp = value => {
+	const escapeNodePosition = findLowercaseEscape(value);
 
 	if (escapeNodePosition) {
 		const [start, end] = escapeNodePosition;
 		return (
-			raw.slice(0, start) +
-			fix(raw.slice(start, end), escapePatternWithLowercase) +
-			raw.slice(end, raw.length)
+			value.slice(0, start) +
+			fix(value.slice(start, end), escapePatternWithLowercase) +
+			value.slice(end, value.length)
 		);
 	}
 
-	return raw;
+	return value;
 };
 
 const create = context => {
@@ -109,7 +108,7 @@ const create = context => {
 				context.report({
 					node,
 					message,
-					fix: fixer => fixer.replaceText(node, fixRegExp(node))
+					fix: fixer => fixer.replaceText(node, fixRegExp(node.raw))
 				});
 			}
 		},

--- a/test/escape-case.js
+++ b/test/escape-case.js
@@ -73,6 +73,11 @@ ruleTester.run('escape-case', rule, {
 			output: 'const foo = "\\xA9";'
 		},
 		{
+			code: 'const foo = "\\xAb";',
+			errors,
+			output: 'const foo = "\\xAB";'
+		},
+		{
 			code: 'const foo = "\\ud834";',
 			errors,
 			output: 'const foo = "\\uD834";'


### PR DESCRIPTION
I'm not sure if I'm missing anything, but seems we don't need parse `regex` at all.
