### PR TITLE
Add `isShadowed` check to `new-for-builtins`

### DIFF
--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -1,5 +1,6 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
+const isShadowed = require('./utils/is-shadowed');
 
 const enforceNew = new Set([
 	'Object',
@@ -39,9 +40,10 @@ const disallowNew = new Set([
 const create = context => {
 	return {
 		CallExpression: node => {
-			const {name} = node.callee;
+			const {callee} = node;
+			const {name} = callee;
 
-			if (enforceNew.has(name)) {
+			if (enforceNew.has(name) && !isShadowed(context.getScope(), callee)) {
 				context.report({
 					node,
 					message: `Use \`new ${name}()\` instead of \`${name}()\`.`,
@@ -50,9 +52,10 @@ const create = context => {
 			}
 		},
 		NewExpression: node => {
-			const {name} = node.callee;
+			const {callee} = node;
+			const {name} = callee;
 
-			if (disallowNew.has(name)) {
+			if (disallowNew.has(name) && !isShadowed(context.getScope(), callee)) {
 				context.report({
 					node,
 					message: `Use \`${name}()\` instead of \`new ${name}()\`.`,

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -1,41 +1,10 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
+const builtins = require('./utils/builtins');
 const isShadowed = require('./utils/is-shadowed');
 
-const enforceNew = new Set([
-	'Object',
-	'Array',
-	'ArrayBuffer',
-	'BigInt64Array',
-	'BigUint64Array',
-	'DataView',
-	'Date',
-	'Error',
-	'Float32Array',
-	'Float64Array',
-	'Function',
-	'Int8Array',
-	'Int16Array',
-	'Int32Array',
-	'Map',
-	'WeakMap',
-	'Set',
-	'WeakSet',
-	'Promise',
-	'RegExp',
-	'Uint8Array',
-	'Uint16Array',
-	'Uint32Array',
-	'Uint8ClampedArray'
-]);
-
-const disallowNew = new Set([
-	'BigInt',
-	'Boolean',
-	'Number',
-	'String',
-	'Symbol'
-]);
+const enforceNew = new Set(builtins.enforceNew);
+const disallowNew = new Set(builtins.disallowNew);
 
 const create = context => {
 	return {

--- a/rules/utils/builtins.js
+++ b/rules/utils/builtins.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const enforceNew = [
+	'Object',
+	'Array',
+	'ArrayBuffer',
+	'BigInt64Array',
+	'BigUint64Array',
+	'DataView',
+	'Date',
+	'Error',
+	'Float32Array',
+	'Float64Array',
+	'Function',
+	'Int8Array',
+	'Int16Array',
+	'Int32Array',
+	'Map',
+	'WeakMap',
+	'Set',
+	'WeakSet',
+	'Promise',
+	'RegExp',
+	'Uint8Array',
+	'Uint16Array',
+	'Uint32Array',
+	'Uint8ClampedArray'
+];
+
+const disallowNew = [
+	'BigInt',
+	'Boolean',
+	'Number',
+	'String',
+	'Symbol'
+];
+
+module.exports = {
+	enforceNew,
+	disallowNew
+};

--- a/rules/utils/is-shadowed.js
+++ b/rules/utils/is-shadowed.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Finds the eslint-scope reference in the given scope.
+ * @param {Object} scope The scope to search.
+ * @param {ASTNode} node The identifier node.
+ * @returns {Reference|undefined} Returns the found reference or null if none were found.
+ */
+function findReference(scope, node) {
+	const references = scope.references
+		.filter(reference =>
+			reference.identifier.range[0] === node.range[0] &&
+			reference.identifier.range[1] === node.range[1]
+		);
+
+	return references.length === 1 ? references[0] : undefined;
+}
+
+/**
+ * Checks if the given identifier node is shadowed in the given scope.
+ * @param {Object} scope The current scope.
+ * @param {string} node The identifier node to check
+ * @returns {boolean} Whether or not the name is shadowed.
+ */
+function isShadowed(scope, node) {
+	const reference = findReference(scope, node);
+
+	return (
+		reference &&
+		reference.resolved &&
+		reference.resolved.defs.length > 0
+	);
+}
+
+module.exports = isShadowed;

--- a/test/new-for-builtins.js
+++ b/test/new-for-builtins.js
@@ -8,6 +8,11 @@ const ruleTester = avaRuleTester(test, {
 	},
 	parserOptions: {
 		sourceType: 'module'
+	},
+	// Make sure globals don't effect shadowed check result
+	globals: {
+		Map: 'off',
+		String: 'off'
 	}
 });
 

--- a/test/new-for-builtins.js
+++ b/test/new-for-builtins.js
@@ -114,10 +114,6 @@ ruleTester.run('new-for-builtins', rule, {
 				const foo = new ${object}();
 			}
 		`),
-		...disallowNew.map(object => `
-			const ${object} = function() {};
-			const foo = new ${object}();
-		`),
 		// #122
 		`
 			import { Map } from 'immutable';
@@ -296,6 +292,51 @@ ruleTester.run('new-for-builtins', rule, {
 			code: 'const foo = new Symbol()',
 			errors: [disallowNewError('Symbol')],
 			output: 'const foo = Symbol()'
+		},
+		{
+			code: `
+				function varCheck() {
+					{
+						var WeakMap = function() {};
+					}
+					// This should not reported
+					return WeakMap()
+				}
+				function constCheck() {
+					{
+						const Array = function() {};
+					}
+					return Array()
+				}
+				function letCheck() {
+					{
+						let Map = function() {};
+					}
+					return Map()
+				}
+			`,
+			errors: [enforceNewError('Array'), enforceNewError('Map')],
+			output: `
+				function varCheck() {
+					{
+						var WeakMap = function() {};
+					}
+					// This should not reported
+					return WeakMap()
+				}
+				function constCheck() {
+					{
+						const Array = function() {};
+					}
+					return new Array()
+				}
+				function letCheck() {
+					{
+						let Map = function() {};
+					}
+					return new Map()
+				}
+			`
 		}
 	]
 });

--- a/test/new-for-builtins.js
+++ b/test/new-for-builtins.js
@@ -1,12 +1,13 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
 import rule from '../rules/new-for-builtins';
+import {enforceNew, disallowNew} from '../rules/utils/builtins';
 
 const ruleTester = avaRuleTester(test, {
 	parserOptions: {
 		ecmaVersion: 2020,
 		sourceType: 'module'
-	}
+	},
 	// Make sure globals don't effect shadowed check result
 	globals: {
 		Map: 'off',
@@ -23,41 +24,6 @@ const disallowNewError = builtin => ({
 	ruleId: 'new-for-builtins',
 	message: `Use \`${builtin}()\` instead of \`new ${builtin}()\`.`
 });
-
-const enforceNew = [
-	'Object',
-	'Array',
-	'ArrayBuffer',
-	'BigInt64Array',
-	'BigUint64Array',
-	'DataView',
-	'Date',
-	'Error',
-	'Float32Array',
-	'Float64Array',
-	'Function',
-	'Int8Array',
-	'Int16Array',
-	'Int32Array',
-	'Map',
-	'WeakMap',
-	'Set',
-	'WeakSet',
-	'Promise',
-	'RegExp',
-	'Uint8Array',
-	'Uint16Array',
-	'Uint32Array',
-	'Uint8ClampedArray'
-];
-
-const disallowNew = [
-	'BigInt',
-	'Boolean',
-	'Number',
-	'String',
-	'Symbol'
-];
 
 ruleTester.run('new-for-builtins', rule, {
 	valid: [

--- a/test/new-for-builtins.js
+++ b/test/new-for-builtins.js
@@ -3,12 +3,10 @@ import avaRuleTester from 'eslint-ava-rule-tester';
 import rule from '../rules/new-for-builtins';
 
 const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
-	},
 	parserOptions: {
+		ecmaVersion: 2020,
 		sourceType: 'module'
-	},
+	}
 	// Make sure globals don't effect shadowed check result
 	globals: {
 		Map: 'off',


### PR DESCRIPTION
Fixes #122

I just steal this function from https://github.com/eslint/eslint/blob/1ee6b6388305a8671c8d4c3cf30c2dbf18a1ff7e/lib/rules/no-alert.js#L48

I've tried to solve this issue before, but failed, this function use range check instead of name check is great idea.

We may need add this check in more rules, I'll check later.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#122: False positive for the `new-for-builtins` rule](https://issuehunt.io/repos/55832243/issues/122)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->