### PR TITLE
Minor tweak to `new-for-builtins`

### DIFF
--- a/rules/utils/is-shadowed.js
+++ b/rules/utils/is-shadowed.js
@@ -13,7 +13,9 @@ function findReference(scope, node) {
 			reference.identifier.range[1] === node.range[1]
 		);
 
-	return references.length === 1 ? references[0] : undefined;
+	if (references.length === 1) {
+		return references[0];
+	}
 }
 
 /**


### PR DESCRIPTION
`outer > inner` test, more `globals` values