### PR TITLE
Handle currying arrow function in `consistent-function-scoping`

### DIFF
--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -124,46 +124,26 @@ const create = context => {
 	const sourceCode = context.getSourceCode();
 	const {scopeManager} = sourceCode;
 
-	const reports = [];
+	const functions = [];
 	let hasJsx = false;
 
 	return {
-		ArrowFunctionExpression: node => {
-			const valid = checkNode(node, scopeManager);
-
-			if (valid) {
-				reports.push(null);
-			} else {
-				reports.push({
-					node,
-					messageId: MESSAGE_ID_ARROW
-				});
-			}
-		},
-		FunctionDeclaration: node => {
-			const valid = checkNode(node, scopeManager);
-
-			if (valid) {
-				reports.push(null);
-			} else {
-				reports.push({
-					node,
-					messageId: MESSAGE_ID_FUNCTION
-				});
-			}
-		},
+		'ArrowFunctionExpression, FunctionDeclaration': node => functions.push(node),
 		JSXElement: () => {
 			// Turn off this rule if we see a JSX element because scope
 			// references does not include JSXElement nodes.
 			hasJsx = true;
 		},
-		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': () => {
-			const report = reports.pop();
-			if (report && !hasJsx) {
-				context.report(report);
+		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': node => {
+			if (!hasJsx && !checkNode(node, scopeManager)) {
+				context.report({
+					node,
+					messageId: node.type
+				});
 			}
 
-			if (reports.length === 0) {
+			functions.pop();
+			if (functions.length === 0) {
 				hasJsx = false;
 			}
 		}

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -97,6 +97,13 @@ function checkNode(node, scopeManager) {
 		return true;
 	}
 
+	if (
+		parentNode.type === 'ArrowFunctionExpression' &&
+		parentNode.body === node
+	) {
+		return true;
+	}
+
 	// Skip over junk like the block statement inside of a function declaration
 	// or the various pieces of an arrow function.
 

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -188,6 +188,14 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 				return Bar;
 			};
+		`,
+		// #391
+		outdent`
+			const enrichErrors = (packageName, cliArgs, f) => async (...args) => {
+				try {
+					return await f(...args);
+				} catch (error) {}
+			};
 		`
 	],
 	invalid: [

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -196,6 +196,14 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return await f(...args);
 				} catch (error) {}
 			};
+		`,
+		// Another case from #391 comment
+		outdent`
+			const canStepForward = ([X, Y]) => {
+				return ([x, y]) => direction => {
+					switch (direction) { }
+				}
+			}
 		`
 	],
 	invalid: [
@@ -239,12 +247,6 @@ ruleTester.run('consistent-function-scoping', rule, {
 						return bar;
 					}
 				}
-			`,
-			errors: [arrowError]
-		},
-		{
-			code: outdent`
-				const doFoo = () => bar => bar;
 			`,
 			errors: [arrowError]
 		},

--- a/test/lint/lint.js
+++ b/test/lint/lint.js
@@ -11,10 +11,6 @@ const unicornRules = new Map(Object.entries(unicorn.rules));
 
 const cli = new CLIEngine({
 	baseConfig: recommended,
-	rules: {
-		// TODO: remove this override, when #391 is fixed
-		'unicorn/consistent-function-scoping': 'off'
-	},
 	useEslintrc: false,
 	fix
 });


### PR DESCRIPTION
Fixes #391