### PR TITLE
Fix `prefer-string-slice` missing parentheses

### DIFF
--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -35,6 +35,19 @@ const isLikelyNumeric = node => isLiteralNumber(node) || isLengthProperty(node);
 
 const create = context => {
 	const sourceCode = context.getSourceCode();
+	const getNodeText = node => {
+		const text = sourceCode.getText(node);
+		const before = sourceCode.getTokenBefore(node);
+		const after = sourceCode.getTokenAfter(node);
+		if (
+			(before && before.type === 'Punctuator' && before.value === '(') &&
+			(after && after.type === 'Punctuator' && after.value === ')')
+		) {
+			return '(' + text + ')';
+		}
+
+		return text;
+	};
 
 	return templates.visitor({
 		[substrCallTemplate](node) {
@@ -75,9 +88,7 @@ const create = context => {
 			}
 
 			if (slice) {
-				const objectText = objectNode.type === 'LogicalExpression' ?
-					`(${sourceCode.getText(objectNode)})` :
-					sourceCode.getText(objectNode);
+				const objectText = getNodeText(objectNode);
 
 				problem.fix = fixer => fixer.replaceText(node, `${objectText}.slice(${slice.join(', ')})`);
 			}
@@ -131,10 +142,7 @@ const create = context => {
 			}
 
 			if (slice) {
-				const objectText = objectNode.type === 'LogicalExpression' ?
-					`(${sourceCode.getText(objectNode)})` :
-					sourceCode.getText(objectNode);
-
+				const objectText = getNodeText(objectNode);
 				problem.fix = fixer => fixer.replaceText(node, `${objectText}.slice(${slice.join(', ')})`);
 			}
 

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -35,6 +35,7 @@ const isLikelyNumeric = node => isLiteralNumber(node) || isLengthProperty(node);
 
 const create = context => {
 	const sourceCode = context.getSourceCode();
+
 	const getNodeText = node => {
 		const text = sourceCode.getText(node);
 		const before = sourceCode.getTokenBefore(node);
@@ -43,7 +44,7 @@ const create = context => {
 			(before && before.type === 'Punctuator' && before.value === '(') &&
 			(after && after.type === 'Punctuator' && after.value === ')')
 		) {
-			return '(' + text + ')';
+			return `(${text})`;
 		}
 
 		return text;

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -9,6 +9,10 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
+const typescriptRuleTester = avaRuleTester(test, {
+	parser: require.resolve('@typescript-eslint/parser')
+});
+
 const errors = [
 	{
 		ruleId: 'prefer-string-slice'
@@ -205,6 +209,38 @@ ruleTester.run('prefer-string-slice', rule, {
 		},
 		{
 			code: '"foo".substring(1, 3)',
+			errors
+		}
+	]
+});
+
+typescriptRuleTester.run('prefer-string-slice', rule, {
+	valid: [],
+	invalid: [
+		{
+			code: outdent`
+				function foo() {
+					return (bar as string).substr(3);
+				}
+			`,
+			output: outdent`
+				function foo() {
+					return (bar as string).slice(3);
+				}
+			`,
+			errors
+		},
+		{
+			code: outdent`
+				function foo() {
+					return (bar as string).substring(3);
+				}
+			`,
+			output: outdent`
+				function foo() {
+					return (bar as string).slice(3);
+				}
+			`,
 			errors
 		}
 	]


### PR DESCRIPTION
```ts
function foo() {
	return (bar as string).substr(3);
}
```

was fixed to 

```ts
function foo() {
	return bar as string.slice(3);
}
```