### PR TITLE
Fix `no-new-buffer` crash on `TypeScript-ESLint`

### DIFF
--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -1,7 +1,19 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
-const inferMethod = arguments_ => (arguments_.length > 0 && typeof arguments_[0].value === 'number') ? 'alloc' : 'from';
+const inferMethod = arguments_ => {
+	if (arguments_.length > 0) {
+		const [firstArgument] = arguments_;
+		if (
+			firstArgument.type === 'Literal' &&
+			typeof firstArgument.value === 'number'
+		) {
+			return 'alloc';
+		}
+	}
+
+	return 'from';
+};
 
 const create = context => {
 	return {
@@ -9,7 +21,7 @@ const create = context => {
 			const method = inferMethod(node.arguments);
 			const range = [
 				node.range[0],
-				node.callee.end
+				node.callee.range[1]
 			];
 
 			context.report({

--- a/test/no-new-buffer.js
+++ b/test/no-new-buffer.js
@@ -12,6 +12,10 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
+const typescriptRuleTester = avaRuleTester(test, {
+	parser: require.resolve('@typescript-eslint/parser')
+});
+
 const allocError = {
 	ruleId: 'no-new-buffer',
 	message: '`new Buffer()` is deprecated, use `Buffer.alloc()` instead.'
@@ -76,6 +80,17 @@ ruleTester.run('no-new-buffer', rule, {
 				const buf1 = Buffer.from('buf');
 				const buf2 = Buffer.from(buf1);
 			`
+		}
+	]
+});
+
+typescriptRuleTester.run('no-new-buffer', rule, {
+	valid: [],
+	invalid: [
+		{
+			code: 'new Buffer(input, encoding);',
+			errors: [fromError],
+			output: 'Buffer.from(input, encoding);'
 		}
 	]
 });


### PR DESCRIPTION
Use `.range[1]` insteadof `.end`, left from #519