### PR TITLE
Fix scope compare in `consistent-function-scoping`

### DIFF
--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -9,7 +9,7 @@ const getReferences = scope => scope.references.concat(
 );
 
 const isSameScope = (scope1, scope2) =>
-	scope1 === scope2 || scope1.block === scope2.block
+	scope1 === scope2 || scope1.block === scope2.block;
 
 function checkReferences(scope, parent, scopeManager) {
 	if (!scope) {
@@ -38,7 +38,7 @@ function checkReferences(scope, parent, scopeManager) {
 
 		const hitDefinitions = variable.defs.some(definition => {
 			const scope = scopeManager.acquire(definition.node);
-			return parent === scope;
+			return isSameScope(parent, scope);
 		});
 
 		if (hitDefinitions) {
@@ -74,7 +74,7 @@ function checkReferences(scope, parent, scopeManager) {
 
 			// Look at the scope above the function definition to see if lives
 			// next to the reference being checked
-			return parent === identifierParentScope.upper;
+			return isSameScope(parent, identifierParentScope.upper);
 		});
 
 		if (hitIdentifier) {

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -8,6 +8,9 @@ const getReferences = scope => scope.references.concat(
 	...scope.childScopes.map(scope => getReferences(scope))
 );
 
+const isSameScope = (scope1, scope2) =>
+	scope1 === scope2 || scope1.block === scope2.block
+
 function checkReferences(scope, parent, scopeManager) {
 	if (!scope) {
 		return false;
@@ -26,7 +29,7 @@ function checkReferences(scope, parent, scopeManager) {
 		}
 
 		const hitReference = variable.references.some(reference => {
-			return parent === reference.from;
+			return isSameScope(parent, reference.from);
 		});
 
 		if (hitReference) {

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -9,7 +9,7 @@ const getReferences = scope => scope.references.concat(
 );
 
 const isSameScope = (scope1, scope2) =>
-	scope1 === scope2 || scope1.block === scope2.block;
+	scope1 && scope2 && (scope1 === scope2 || scope1.block === scope2.block);
 
 function checkReferences(scope, parent, scopeManager) {
 	if (!scope) {

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -219,6 +219,18 @@ ruleTester.run('consistent-function-scoping', rule, {
 						throw new Error('unknown direction')
 				}
 			}
+		`,
+		// #374
+		outdent`
+			'use strict';
+
+			module.exports = function recordErrors(eventEmitter, stateArgument) {
+				const stateVariable = stateArgument;
+				function onError(error) {
+					stateVariable.inputError = error;
+				}
+				eventEmitter.once('error', onError);
+			};
 		`
 	],
 	invalid: [

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -231,7 +231,20 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 				eventEmitter.once('error', onError);
 			};
-		`
+		`,
+		// #375
+		outdent`
+			module.exports = function recordErrors(eventEmitter, stateArgument) {
+				function onError(error) {
+					stateArgument.inputError = error;
+				}
+				function onError2(error) {
+					onError(error);
+				}
+
+				eventEmitter.once('error', onError2);
+			};
+		`,
 	],
 	invalid: [
 		{

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -244,7 +244,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 
 				eventEmitter.once('error', onError2);
 			};
-		`,
+		`
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Seems `FunctionExpression` and `FunctionDeclaration` has different scope, but they has the same block.

Fixes #374
Fixes #375
