### PR TITLE
Fix `prefer-string-slice` typo in docs

### DIFF
--- a/docs/rules/prefer-string-slice.md
+++ b/docs/rules/prefer-string-slice.md
@@ -2,7 +2,7 @@
 
 [`String#substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [`String#substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are the two lesser known legacy ways to slice a string. It's better to use [`String#slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) as it's a more popular option with clearer behavior that has a consistent [`Array` counterpart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
 
-This rule is fixible when no arguments are passed to the method.
+This rule is fixable when no arguments are passed to the method.
 
 
 ## Fail

--- a/docs/rules/prefer-string-slice.md
+++ b/docs/rules/prefer-string-slice.md
@@ -2,7 +2,7 @@
 
 [`String#substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [`String#substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are the two lesser known legacy ways to slice a string. It's better to use [`String#slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) as it's a more popular option with clearer behavior that has a consistent [`Array` counterpart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
 
-This rule is fixable when no arguments are passed to the method.
+This rule is partly fixable.
 
 
 ## Fail


### PR DESCRIPTION
This fixes a small typo in "fixible".
