### PR TITLE
Allow descriptive error names by default in `catch-error-name`

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -101,7 +101,7 @@ You can set the `name` option like this:
 ]
 ```
 
-This option lets you specify a regex pattern for matches to ignore. The default is `^_$`.
+This option lets you specify a regex pattern for matches to ignore. The default allows `_` and descriptive names like `networkError`.
 
 With `^unicorn$`, this would fail:
 
@@ -122,3 +122,7 @@ try {
 	// …
 }
 ```
+
+## Tip
+
+In order to avoid shadowing in nested catch clauses the auto-fix rule appends underscores to the identifier name. Since this might be hard to read the default settings for `caughtErrorsIgnorePattern` allows to use descriptive names instead, e.g. `fsError` or `authError`.

--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -1,11 +1,10 @@
 # Enforce a specific parameter name in catch clauses
 
-Applies to both `try/catch` clauses and `promise.catch(...)` handlers.
+Applies to both `try/catch` clauses and `promise.catch(…)` handlers.
 
 The desired name is configurable, but defaults to `error`.
 
 This rule is fixable unless the reported code was destructuring an error.
-
 
 ## Fail
 
@@ -20,7 +19,6 @@ try {
 ```js
 somePromise.catch(e => {})
 ```
-
 
 ## Pass
 
@@ -74,7 +72,6 @@ somePromise.catch(_ => {
 });
 ```
 
-
 ## Options
 
 ### name
@@ -125,4 +122,4 @@ try {
 
 ## Tip
 
-In order to avoid shadowing in nested catch clauses the auto-fix rule appends underscores to the identifier name. Since this might be hard to read the default settings for `caughtErrorsIgnorePattern` allows to use descriptive names instead, e.g. `fsError` or `authError`.
+In order to avoid shadowing in nested catch clauses, the auto-fix rule appends underscores to the identifier name. Since this might be hard to read, the default setting for `caughtErrorsIgnorePattern` allows the use of descriptive names instead, for example, `fsError` or `authError`.

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -34,7 +34,7 @@ const create = context => {
 
 	const options = {
 		name: 'error',
-		caughtErrorsIgnorePattern: '^_$',
+		caughtErrorsIgnorePattern: /^_$|^[A-Za-z0-9]+(e|E)rror$/.source,
 		...context.options[0]
 	};
 

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -34,7 +34,7 @@ const create = context => {
 
 	const options = {
 		name: 'error',
-		caughtErrorsIgnorePattern: /^_$|^[A-Za-z0-9]+(e|E)rror$/.source,
+		caughtErrorsIgnorePattern: /^_$|^[\dA-Za-z]+(e|E)rror$/.source,
 		...context.options[0]
 	};
 

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -34,7 +34,8 @@ ruleTester.run('catch-error-name', rule, {
 				}
 			}
 		`),
-		testCase(outdent`
+		testCase(
+			outdent`
 			const handleError = err => {
 				try {
 					doSomething();
@@ -42,7 +43,9 @@ ruleTester.run('catch-error-name', rule, {
 					console.log(err_);
 				}
 			}
-		`, 'err'),
+		`,
+			'err'
+		),
 		testCase(outdent`
 			const handleError = error => {
 				const error_ = new Error('🦄');
@@ -60,11 +63,14 @@ ruleTester.run('catch-error-name', rule, {
 				obj.catch(error_ => { });
 			}
 		`),
-		testCase(outdent`
+		testCase(
+			outdent`
 			const handleError = err => {
 				obj.catch(err_ => { });
 			}
-		`, 'err'),
+		`,
+			'err'
+		),
 		testCase(outdent`
 			const handleError = error => {
 				const error_ = new Error('foo bar');
@@ -91,11 +97,15 @@ ruleTester.run('catch-error-name', rule, {
 		testCase('obj.catch((_) => {})'),
 		testCase('obj.catch((_) => { console.log(foo); })'),
 		testCase('obj.catch(err => {})', 'err'),
-		testCase('obj.catch(outerError => { return obj2.catch(innerError => {}) })'),
+		testCase(
+			'obj.catch(outerError => { return obj2.catch(innerError => {}) })'
+		),
 		testCase('obj.catch(function (error) {})'),
 		testCase('obj.catch(function () {})'),
 		testCase('obj.catch(function (err) {})', 'err'),
-		testCase('obj.catch(function (outerError) { return obj2.catch(function (innerError) {}) })'),
+		testCase(
+			'obj.catch(function (outerError) { return obj2.catch(function (innerError) {}) })'
+		),
 		testCase('obj.catch()'),
 		testCase('obj.catch(_ => { console.log(_); })'),
 		testCase('obj.catch(function (_) { console.log(_); })'),
@@ -129,21 +139,76 @@ ruleTester.run('catch-error-name', rule, {
 			} catch {
 				console.log('failed');
 			}
-		`)
+		`),
+		testCase('try {} catch (descriptiveError) {}'),
+		testCase('try {} catch (descriptiveerror) {}')
 	],
 
 	invalid: [
-		testCase('try {} catch (err) { console.log(err) }', null, true, 'try {} catch (error) { console.log(error) }'),
-		testCase('try {} catch (error) { console.log(error) }', 'err', true, 'try {} catch (err) { console.log(err) }'),
+		testCase(
+			'try {} catch (err) { console.log(err) }',
+			null,
+			true,
+			'try {} catch (error) { console.log(error) }'
+		),
+		testCase(
+			'try {} catch (error) { console.log(error) }',
+			'err',
+			true,
+			'try {} catch (err) { console.log(err) }'
+		),
 		testCase('try {} catch ({message}) {}', null, true),
-		testCase('try {} catch (outerError) {}', null, true, 'try {} catch (error) {}'),
-		testCase('try {} catch (innerError) {}', null, true, 'try {} catch (error) {}'),
+		{
+			code: 'try {} catch (outerError) {}',
+			output: 'try {} catch (error) {}',
+			errors: [
+				{
+					ruleId: 'catch-error-message',
+					message: 'The catch parameter should be named `error`.'
+				}
+			],
+			options: [
+				{
+					caughtErrorsIgnorePattern: '^_$'
+				}
+			]
+		},
+		{
+			code: 'try {} catch (innerError) {}',
+			output: 'try {} catch (error) {}',
+			errors: [
+				{
+					ruleId: 'catch-error-name',
+					message: 'The catch parameter should be named `error`.'
+				}
+			],
+			options: [
+				{
+					caughtErrorsIgnorePattern: '^_$'
+				}
+			]
+		},
 		testCase('obj.catch(err => err)', null, true, 'obj.catch(error => error)'),
-		testCase('obj.catch(error => error.stack)', 'err', true, 'obj.catch(err => err.stack)'),
+		testCase(
+			'obj.catch(error => error.stack)',
+			'err',
+			true,
+			'obj.catch(err => err.stack)'
+		),
 		testCase('obj.catch(({message}) => {})', null, true),
-		testCase('obj.catch(function (err) { console.log(err) })', null, true, 'obj.catch(function (error) { console.log(error) })'),
+		testCase(
+			'obj.catch(function (err) { console.log(err) })',
+			null,
+			true,
+			'obj.catch(function (error) { console.log(error) })'
+		),
 		testCase('obj.catch(function ({message}) {})', null, true),
-		testCase('obj.catch(function (error) { console.log(error) })', 'err', true, 'obj.catch(function (err) { console.log(err) })'),
+		testCase(
+			'obj.catch(function (error) { console.log(error) })',
+			'err',
+			true,
+			'obj.catch(function (err) { console.log(err) })'
+		),
 		// Failing tests for #107
 		// testCase(outdent`
 		// 	foo.then(() => {
@@ -204,6 +269,11 @@ ruleTester.run('catch-error-name', rule, {
 				{
 					ruleId: 'catch-error-name',
 					message: 'The catch parameter should be named `error_`.'
+				}
+			],
+			options: [
+				{
+					caughtErrorsIgnorePattern: '^_$'
 				}
 			]
 		},
@@ -295,10 +365,7 @@ ruleTester.run('catch-error-name', rule, {
 				obj.catch(error => {});
 				obj.catch(error => {});
 			`,
-			errors: [
-				{ruleId: 'catch-error-name'},
-				{ruleId: 'catch-error-name'}
-			]
+			errors: [{ruleId: 'catch-error-name'}, {ruleId: 'catch-error-name'}]
 		},
 		{
 			code: 'try {} catch (_error) {}',
@@ -332,6 +399,11 @@ ruleTester.run('catch-error-name', rule, {
 				{
 					ruleId: 'catch-error-message',
 					message: 'The catch parameter should be named `error`.'
+				}
+			],
+			options: [
+				{
+					caughtErrorsIgnorePattern: '^_$'
 				}
 			]
 		}


### PR DESCRIPTION
Fixes #192.