### PR TITLE
Add empty `create` function to deprecated rules

### DIFF
--- a/rules/prefer-exponentiation-operator.js
+++ b/rules/prefer-exponentiation-operator.js
@@ -2,6 +2,7 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
 module.exports = {
+	create() {},
 	meta: {
 		type: 'suggestion',
 		docs: {

--- a/rules/prefer-exponentiation-operator.js
+++ b/rules/prefer-exponentiation-operator.js
@@ -1,8 +1,9 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
+const create = () => ({});
 
 module.exports = {
-	create() {},
+	create,
 	meta: {
 		type: 'suggestion',
 		docs: {

--- a/rules/prefer-exponentiation-operator.js
+++ b/rules/prefer-exponentiation-operator.js
@@ -1,5 +1,6 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
+
 const create = () => ({});
 
 module.exports = {

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -2,6 +2,7 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
 module.exports = {
+	create() {},
 	meta: {
 		type: 'suggestion',
 		docs: {

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -1,8 +1,9 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
+const create = () => ({});
 
 module.exports = {
-	create() {},
+	create,
 	meta: {
 		type: 'suggestion',
 		docs: {

--- a/rules/regex-shorthand.js
+++ b/rules/regex-shorthand.js
@@ -1,5 +1,6 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
+
 const create = () => ({});
 
 module.exports = {


### PR DESCRIPTION
Not sure how it works, but seems `create` is required. https://github.com/fisker/shared-configs/pull/865/checks?check_run_id=493628377#step:5:14


```text
TypeError: Error while loading rule 'unicorn/regex-shorthand': rule.create is not a function
```