### PR TITLE
`string-content`: Ignore some `TaggedTemplateExpression`

### DIFF
--- a/docs/rules/string-content.md
+++ b/docs/rules/string-content.md
@@ -6,6 +6,13 @@ This rule is fixable.
 
 *It only reports one pattern per AST node at the time.*
 
+Ignored tagged templates:
+
+- ``gql`...` ``
+- ``html`...` ``
+- ``svg`...` ``
+- ``styled.*`...` ``
+
 ## Fail
 
 ```js

--- a/docs/rules/string-content.md
+++ b/docs/rules/string-content.md
@@ -6,12 +6,12 @@ This rule is fixable.
 
 *It only reports one pattern per AST node at the time.*
 
-Ignored tagged templates:
+This rule ignores the following tagged template literals as they're known to contain code:
 
-- ``gql`...` ``
-- ``html`...` ``
-- ``svg`...` ``
-- ``styled.*`...` ``
+- ``gql`…` ``
+- ``html`…` ``
+- ``svg`…` ``
+- ``styled.*`…` ``
 
 ## Fail
 

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -8,6 +8,38 @@ const defaultPatterns = {
 	'\'': '’'
 };
 
+const ignoredIdentifier = new Set([
+	'gql'
+]);
+
+const ignoredMemberExpressionObject = new Set([
+	'styled'
+]);
+
+const isIgnoredTag = node => {
+	if (!node.parent || !node.parent.parent || !node.parent.parent.tag) {
+		return false;
+	}
+
+	const {tag} = node.parent.parent;
+
+	if (tag.type === 'Identifier' && ignoredIdentifier.has(tag.name)) {
+		return true;
+	}
+
+	if (tag.type === 'MemberExpression') {
+		const {object} = tag;
+		if (
+			object.type === 'Identifier' &&
+			ignoredMemberExpressionObject.has(object.name)
+		) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
 const defaultMessage = 'Prefer `{{suggest}}` over `{{match}}`.';
 
 function getReplacements(patterns) {
@@ -53,7 +85,7 @@ const create = context => {
 				if (typeof string !== 'string') {
 					return;
 				}
-			} else {
+			} else if (!isIgnoredTag(node)) {
 				string = node.value.raw;
 			}
 

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -9,7 +9,9 @@ const defaultPatterns = {
 };
 
 const ignoredIdentifier = new Set([
-	'gql'
+	'gql',
+	'html',
+	'svg'
 ]);
 
 const ignoredMemberExpressionObject = new Set([

--- a/test/string-content.js
+++ b/test/string-content.js
@@ -41,7 +41,10 @@ ruleTester.run('string-content', rule, {
 		// `TemplateLiteral`
 		'const foo = `🦄`',
 		// Should not escape
-		'const foo = `\\`\\${1}`'
+		'const foo = `\\`\\${1}`',
+		// Ignored
+		'const foo = gql`\'`',
+		'const foo = styled.div`\'`'
 		/* eslint-enable no-template-curly-in-string */
 	],
 	invalid: [
@@ -198,7 +201,14 @@ ruleTester.run('string-content', rule, {
 			output: 'const foo = `\\\\\\${bar}`',
 			options: [{patterns: {foo: '{bar}'}}],
 			errors: createError('foo', '{bar}')
+		},
+		// Not ignored tag
+		{
+			code: 'const foo = notIgnoredTag`\'`',
+			output: 'const foo = notIgnoredTag`’`',
+			errors: createError('\'', '’')
 		}
+
 		/* eslint-enable no-template-curly-in-string */
 	]
 });

--- a/test/string-content.js
+++ b/test/string-content.js
@@ -43,8 +43,26 @@ ruleTester.run('string-content', rule, {
 		// Should not escape
 		'const foo = `\\`\\${1}`',
 		// Ignored
-		'const foo = gql`\'`',
-		'const foo = styled.div`\'`'
+		`
+			const foo = gql\`{
+				field(input: '...')
+			}\`;
+		`,
+		`
+			const foo = styled.div\`
+				background: url('...')
+			\`;
+		`,
+		`
+			const foo = html\`
+				<div class='test'>...</div>
+			\`;
+		`,
+		`
+			const foo = svg\`
+				<svg xmlns="http://www.w3.org/2000/svg"><path fill='#00CD9F'/></svg>
+			\`;
+		`
 		/* eslint-enable no-template-curly-in-string */
 	],
 	invalid: [
@@ -208,7 +226,6 @@ ruleTester.run('string-content', rule, {
 			output: 'const foo = notIgnoredTag`’`',
 			errors: createError('\'', '’')
 		}
-
 		/* eslint-enable no-template-curly-in-string */
 	]
 });


### PR DESCRIPTION
Ignored `` gql`...` `` (requested in https://github.com/xojs/xo/pull/439#issuecomment-596375822) and  `` styled.*`...` ``, anything else?

Edit: add `` html`...` `` and `` svg`...` ``