### PR TITLE
`consistent-function-scoping`: Fix uninitialized variable check

### DIFF
--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -256,7 +256,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 
 				inner();
 			}
-		`,
+		`
 	],
 	invalid: [
 		{

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -244,7 +244,19 @@ ruleTester.run('consistent-function-scoping', rule, {
 
 				eventEmitter.once('error', onError2);
 			};
-		`
+		`,
+		// #586
+		outdent`
+			function outer(stream) {
+				let content;
+
+				function inner() {
+					process.stdout.write(content);
+				}
+
+				inner();
+			}
+		`,
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Fixes #586