### PR TITLE
`consistent-function-scoping`: Display function name in error message

### DIFF
--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -1,8 +1,8 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
-const MESSAGE_ID_ARROW = 'ArrowFunctionExpression';
-const MESSAGE_ID_FUNCTION = 'FunctionDeclaration';
+const MESSAGE_ID_NAMED = 'named';
+const MESSAGE_ID_ANONYMOUS = 'anonymous';
 
 const getReferences = scope => scope.references.concat(
 	...scope.childScopes.map(scope => getReferences(scope))
@@ -110,9 +110,16 @@ const create = context => {
 		},
 		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': node => {
 			if (!hasJsx && !checkNode(node, scopeManager)) {
+				const functionType = node.type === 'ArrowFunctionExpression' ? 'arrow function' : 'function';
+				const functionName = node.id && node.id.name;
+
 				context.report({
 					node,
-					messageId: node.type
+					messageId: functionName ? MESSAGE_ID_NAMED : MESSAGE_ID_ANONYMOUS,
+					data: {
+						functionType,
+						functionName
+					}
 				});
 			}
 
@@ -132,8 +139,8 @@ module.exports = {
 			url: getDocumentationUrl(__filename)
 		},
 		messages: {
-			[MESSAGE_ID_ARROW]: 'Move arrow function to the outer scope.',
-			[MESSAGE_ID_FUNCTION]: 'Move function to the outer scope.'
+			[MESSAGE_ID_NAMED]: 'Move {{functionType}} `{{functionName}}` to the outer scope.',
+			[MESSAGE_ID_ANONYMOUS]: 'Move {{functionType}} to the outer scope.'
 		}
 	}
 };

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -111,7 +111,17 @@ const create = context => {
 		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': node => {
 			if (!hasJsx && !checkNode(node, scopeManager)) {
 				const functionType = node.type === 'ArrowFunctionExpression' ? 'arrow function' : 'function';
-				const functionName = node.id && node.id.name;
+				let functionName = '';
+				if (node.id) {
+					functionName = node.id.name;
+				} else if (
+					node.parent &&
+					node.parent.type === 'VariableDeclarator' &&
+					node.parent.id &&
+					node.parent.id.type === 'Identifier'
+				) {
+					functionName = node.parent.id.name;
+				}
 
 				context.report({
 					node,

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -17,15 +17,18 @@ const typescriptRuleTester = avaRuleTester(test, {
 	parser: require.resolve('@typescript-eslint/parser')
 });
 
-const arrowError = {
-	ruleId: 'consistent-function-scoping',
-	messageId: 'ArrowFunctionExpression'
-};
+const ruleId = 'consistent-function-scoping';
+const MESSAGE_ID_NAMED = 'named';
+const MESSAGE_ID_ANONYMOUS = 'anonymous';
 
-const functionError = {
-	ruleId: 'consistent-function-scoping',
-	messageId: 'FunctionDeclaration'
-};
+const createError = ({name, arrow}) => ({
+	ruleId,
+	messageId: name ? MESSAGE_ID_NAMED : MESSAGE_ID_ANONYMOUS,
+	data: {
+		functionType: arrow ? 'arrow function' : 'function',
+		functionName: name
+	}
+});
 
 ruleTester.run('consistent-function-scoping', rule, {
 	valid: [
@@ -256,7 +259,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return foo;
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -268,7 +271,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return foo;
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -278,7 +281,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					}
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -288,13 +291,13 @@ ruleTester.run('consistent-function-scoping', rule, {
 					}
 				}
 			`,
-			errors: [arrowError]
+			errors: [createError({arrow: true})]
 		},
 		{
 			code: outdent`
 				const doFoo = () => bar => bar;
 			`,
-			errors: [arrowError]
+			errors: [createError({arrow: true})]
 		},
 		{
 			code: outdent`
@@ -305,7 +308,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return foo;
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -316,7 +319,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return doBar;
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -324,7 +327,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					function doBar() {}
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -339,7 +342,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return foo;
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -351,7 +354,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					}
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -361,7 +364,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					}
 				}
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		}
 	]
 });

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -291,7 +291,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					}
 				}
 			`,
-			errors: [createError({arrow: true})]
+			errors: [createError({name: 'doBar', arrow: true})]
 		},
 		{
 			code: outdent`


### PR DESCRIPTION
```js
const foo = () => {}
```

Should I use foo as arrow function name?