### PR TITLE
`consistent-function-scoping`: Check use of `this` and `arguments`

### DIFF
--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -77,7 +77,7 @@ function checkReferences(scope, parent, scopeManager) {
 
 function checkNode(node, scopeManager) {
 	const scope = scopeManager.acquire(node);
-	if (!scope) {
+	if (!scope || (node.type === 'ArrowFunctionExpression' && scope.thisFound)) {
 		return true;
 	}
 

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -79,7 +79,7 @@ const isArrowFunctionWithThis = scope =>
 	scope.type === 'function' &&
 	scope.block &&
 	scope.block.type === 'ArrowFunctionExpression' &&
-	scope.thisFound
+	scope.thisFound;
 
 function checkNode(node, scopeManager) {
 	const scope = scopeManager.acquire(node);

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -79,12 +79,12 @@ const isArrowFunctionWithThis = scope =>
 	scope.type === 'function' &&
 	scope.block &&
 	scope.block.type === 'ArrowFunctionExpression' &&
-	scope.thisFound;
+	(scope.thisFound || scope.childScopes.some(scope => isArrowFunctionWithThis(scope)));
 
 function checkNode(node, scopeManager) {
 	const scope = scopeManager.acquire(node);
 
-	if (!scope || isArrowFunctionWithThis(scope) || scope.childScopes.some(scope => isArrowFunctionWithThis(scope))) {
+	if (!scope || isArrowFunctionWithThis(scope)) {
 		return true;
 	}
 

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -74,6 +74,7 @@ function checkReferences(scope, parent, scopeManager) {
 			hitIdentifier(variable.identifiers)
 		);
 }
+
 // https://reactjs.org/docs/hooks-reference.html
 const reactHooks = new Set([
 	'useState',

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -75,9 +75,16 @@ function checkReferences(scope, parent, scopeManager) {
 		);
 }
 
+const isArrowFunctionWithThis = scope =>
+	scope.type === 'function' &&
+	scope.block &&
+	scope.block.type === 'ArrowFunctionExpression' &&
+	scope.thisFound
+
 function checkNode(node, scopeManager) {
 	const scope = scopeManager.acquire(node);
-	if (!scope || (node.type === 'ArrowFunctionExpression' && scope.thisFound)) {
+
+	if (!scope || isArrowFunctionWithThis(scope) || scope.childScopes.some(scope => isArrowFunctionWithThis(scope))) {
 		return true;
 	}
 

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -204,6 +204,12 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return doBar();
 			};
 		`,
+		outdent`
+			function doFoo(Foo) {
+				const doBar = () => () => () => this;
+				return doBar();
+			};
+		`,
 		// `arguments`
 		outdent`
 			function doFoo(Foo) {

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -198,6 +198,12 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return doBar();
 			};
 		`,
+		outdent`
+			function doFoo(Foo) {
+				const doBar = () => () => this;
+				return doBar();
+			};
+		`,
 		// `arguments`
 		outdent`
 			function doFoo(Foo) {
@@ -338,6 +344,15 @@ ruleTester.run('consistent-function-scoping', rule, {
 			code: outdent`
 				function doFoo(Foo) {
 					const doBar = () => (function() {return this})();
+					return doBar();
+				};
+			`,
+			errors: [arrowError]
+		},
+		{
+			code: outdent`
+				function doFoo(Foo) {
+					const doBar = () => (function() {return () => this})();
 					return doBar();
 				};
 			`,

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -334,6 +334,15 @@ ruleTester.run('consistent-function-scoping', rule, {
 			`,
 			errors: [functionError]
 		},
+		{
+			code: outdent`
+				function doFoo(Foo) {
+					const doBar = () => (function() {return this})();
+					return doBar();
+				};
+			`,
+			errors: [arrowError]
+		},
 		// `arguments`
 		{
 			code: outdent`
@@ -345,6 +354,15 @@ ruleTester.run('consistent-function-scoping', rule, {
 				};
 			`,
 			errors: [functionError]
+		},
+		{
+			code: outdent`
+				function doFoo(Foo) {
+					const doBar = () => (function() {return arguments})();
+					return doBar();
+				};
+			`,
+			errors: [arrowError]
 		},
 		{
 			code: outdent`

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -191,6 +191,13 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return Bar;
 			};
 		`,
+		// `this`
+		outdent`
+			function doFoo(Foo) {
+				const doBar = () => this;
+				return doBar();
+			};
+		`,
 		// #391
 		outdent`
 			const enrichErrors = (packageName, cliArgs, f) => async (...args) => {
@@ -307,6 +314,18 @@ ruleTester.run('consistent-function-scoping', rule, {
 				const doFoo = () => bar => bar;
 			`,
 			errors: [arrowError]
+		},
+		// `this`
+		{
+			code: outdent`
+				function doFoo(Foo) {
+					function doBar() {
+						return this;
+					}
+					return doBar();
+				};
+			`,
+			errors: [functionError]
 		},
 		{
 			code: outdent`

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -198,6 +198,13 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return doBar();
 			};
 		`,
+		// `arguments`
+		outdent`
+			function doFoo(Foo) {
+				const doBar = () => arguments;
+				return doBar();
+			};
+		`,
 		// #391
 		outdent`
 			const enrichErrors = (packageName, cliArgs, f) => async (...args) => {
@@ -321,6 +328,18 @@ ruleTester.run('consistent-function-scoping', rule, {
 				function doFoo(Foo) {
 					function doBar() {
 						return this;
+					}
+					return doBar();
+				};
+			`,
+			errors: [functionError]
+		},
+		// `arguments`
+		{
+			code: outdent`
+				function doFoo(Foo) {
+					function doBar() {
+						return arguments;
 					}
 					return doBar();
 				};

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -347,7 +347,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return doBar();
 				};
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -356,7 +356,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return doBar();
 				};
 			`,
-			errors: [arrowError]
+			errors: [createError({name: 'doBar', arrow: true})]
 		},
 		{
 			code: outdent`
@@ -365,7 +365,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return doBar();
 				};
 			`,
-			errors: [arrowError]
+			errors: [createError({name: 'doBar', arrow: true})]
 		},
 		// `arguments`
 		{
@@ -377,7 +377,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return doBar();
 				};
 			`,
-			errors: [functionError]
+			errors: [createError({name: 'doBar'})]
 		},
 		{
 			code: outdent`
@@ -386,7 +386,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return doBar();
 				};
 			`,
-			errors: [arrowError]
+			errors: [createError({name: 'doBar', arrow: true})]
 		},
 		{
 			code: outdent`


### PR DESCRIPTION
`this` is not considered in arrow function before, now fixed.
Also add `arguments` tests.