### PR TITLE
Fix `lint` script

### DIFF
--- a/test/lint/lint.js
+++ b/test/lint/lint.js
@@ -35,7 +35,7 @@ const {
 
 const hasFixable = fixableErrorCount || fixableWarningCount;
 
-if (fix && hasFixable) {
+if (fix) {
 	CLIEngine.outputFixes(report);
 }
 


### PR DESCRIPTION
Can't run `npm run lint --fix` to fix code in some case before.