### PR TITLE
Extract `isSameNode` to utils

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -6,6 +6,7 @@ const {defaultsDeep, upperFirst, lowerFirst} = require('lodash');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const avoidCapture = require('./utils/avoid-capture');
 const cartesianProductSamples = require('./utils/cartesian-product-samples');
+const isSameNode = require('./utils/is-same-node');
 
 const isUpperCase = string => string === string.toUpperCase();
 const isUpperFirst = string => isUpperCase(string[0]);
@@ -397,20 +398,11 @@ const shouldFix = variable => {
 	return !variableIdentifiers(variable).some(isExportedIdentifier);
 };
 
-const isIdentifierKeyOfNode = (identifier, node) =>
-	node.key === identifier ||
-	// In `babel-eslint` parent.key is not reference of identifier
-	// https://github.com/babel/babel-eslint/issues/809
-	(
-		node.key.type === identifier.type &&
-		node.key.name === identifier.name
-	);
-
 const isShorthandPropertyIdentifier = identifier => {
 	return (
 		identifier.parent.type === 'Property' &&
 		identifier.parent.shorthand &&
-		isIdentifierKeyOfNode(identifier, identifier.parent)
+		isSameNode(identifier, identifier.parent.key)
 	);
 };
 
@@ -419,7 +411,7 @@ const isAssignmentPatternShorthandPropertyIdentifier = identifier => {
 		identifier.parent.type === 'AssignmentPattern' &&
 		identifier.parent.left === identifier &&
 		identifier.parent.parent.type === 'Property' &&
-		isIdentifierKeyOfNode(identifier, identifier.parent.parent) &&
+		isSameNode(identifier, identifier.parent.parent.key) &&
 		identifier.parent.parent.value === identifier.parent &&
 		identifier.parent.parent.shorthand
 	);

--- a/rules/utils/is-same-node.js
+++ b/rules/utils/is-same-node.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = (node1, node2) =>
 	node1 &&

--- a/rules/utils/is-same-node.js
+++ b/rules/utils/is-same-node.js
@@ -1,0 +1,10 @@
+
+module.exports = (node1, node2) =>
+	node1 &&
+	node2 &&
+	(
+		node1 === node2 ||
+		// In `babel-eslint` parent.key is not reference of identifier, #444
+		// issue https://github.com/babel/babel-eslint/issues/809
+		(node1.range[0] === node2.range[0] && node1.range[1] === node2.range[1])
+	);

--- a/rules/utils/is-shadowed.js
+++ b/rules/utils/is-shadowed.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const isSameNode = require('./is-same-node');
+
 /**
  * Finds the eslint-scope reference in the given scope.
  * @param {Object} scope The scope to search.
@@ -8,10 +10,7 @@
  */
 function findReference(scope, node) {
 	const references = scope.references
-		.filter(reference =>
-			reference.identifier.range[0] === node.range[0] &&
-			reference.identifier.range[1] === node.range[1]
-		);
+		.filter(reference => isSameNode(reference.identifier, node));
 
 	if (references.length === 1) {
 		return references[0];


### PR DESCRIPTION
I add this `isIdentifierKeyOfNode` workaround in #444, now I think compare range of two nodes should be more safe, if they has same range, there is no reason they are not the same node, inspiration by #540.
