### PR TITLE
`catch-error-name`: Keep `typeAnnotation` when replacing `identifier`

### DIFF
--- a/rules/no-keyword-prefix.js
+++ b/rules/no-keyword-prefix.js
@@ -194,7 +194,6 @@ module.exports = {
 		docs: {
 			url: getDocumentationUrl(__filename)
 		},
-		fixable: 'code',
 		schema,
 		messages: {
 			[MESSAGE_ID]: 'Do not prefix identifiers with keyword `{{keyword}}`.'

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -9,6 +9,10 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
+const typescriptRuleTester = avaRuleTester(test, {
+	parser: require.resolve('@typescript-eslint/parser')
+});
+
 function invalidTestCase(options) {
 	if (typeof options === 'string') {
 		options = {code: options};
@@ -414,5 +418,15 @@ ruleTester.run('catch-error-name', rule, {
 				}
 			]
 		}
+	]
+});
+
+typescriptRuleTester.run('catch-error-name', rule, {
+	valid: [],
+	invalid: [
+		invalidTestCase({
+			code: 'promise.catch(function (err: Error) { console.log(err) })',
+			output: 'promise.catch(function (error: Error) { console.log(error) })'
+		})
 	]
 });


### PR DESCRIPTION
- [x] catch-error-name
- [x] prevent-abbreviation #608

Close #438
