### PR TITLE
Simplify `no-unreadable-array-destructuring`

### DIFF
--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -1,22 +1,17 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
-const isCommaFollowedWithComma = (element, index, array) => {
-	return element === null && array[index + 1] === null;
-};
+const message = 'Array destructuring may not contain consecutive ignored values.';
+const isCommaFollowedWithComma = (element, index, array) =>
+	element === null && array[index + 1] === null;
 
 const create = context => {
 	return {
-		ArrayPattern(node) {
-			const {elements} = node;
-			if (!elements || elements.length === 0) {
-				return;
-			}
-
-			if (elements.some(isCommaFollowedWithComma)) {
+		'ArrayPattern[elements.length>1]': node => {
+			if (node.elements.some(isCommaFollowedWithComma)) {
 				context.report({
 					node,
-					message: 'Array destructuring may not contain consecutive ignored values.'
+					message
 				});
 			}
 		}

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -7,7 +7,7 @@ const isCommaFollowedWithComma = (element, index, array) =>
 
 const create = context => {
 	return {
-		'ArrayPattern[elements.length>1]': node => {
+		'ArrayPattern[elements.length>=3]': node => {
 			if (node.elements.some(isCommaFollowedWithComma)) {
 				context.report({
 					node,

--- a/test/no-unreadable-array-destructuring.js
+++ b/test/no-unreadable-array-destructuring.js
@@ -30,7 +30,9 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 		'function foo([bar,]) {}',
 		'function foo([bar,,]) {}',
 		'function foo([bar,, baz,, qux]) {}',
-		'const [, ...rest] = parts;'
+		'const [, ...rest] = parts;',
+		// This is stupid, but valid code
+		'const [,] = parts;'
 	],
 	invalid: [
 		{
@@ -68,6 +70,11 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 		{
 			code: 'const [,,...rest] = parts;',
 			errors
-		}
+		},
+		// This is stupid, but valid code
+		{
+			code: 'const [,,] = parts;',
+			errors
+		},
 	]
 });

--- a/test/no-unreadable-array-destructuring.js
+++ b/test/no-unreadable-array-destructuring.js
@@ -32,7 +32,7 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 		'function foo([bar,, baz,, qux]) {}',
 		'const [, ...rest] = parts;',
 		// This is stupid, but valid code
-		'const [,] = parts;'
+		'const [,,] = parts;'
 	],
 	invalid: [
 		{
@@ -73,8 +73,8 @@ ruleTester.run('no-unreadable-array-destructuring', rule, {
 		},
 		// This is stupid, but valid code
 		{
-			code: 'const [,,] = parts;',
+			code: 'const [,,,] = parts;',
 			errors
-		},
+		}
 	]
 });


### PR DESCRIPTION
~This should requires at least 2 elements, if we exclude the stupid code `const [,,] = parts;`, it should requires at least 3 elements. Should I set it to 3?~

I set length to at least 3 elements.