### PR TITLE
Add `prefer-default-parameters` rule

### DIFF
--- a/docs/rules/prefer-default-parameters.md
+++ b/docs/rules/prefer-default-parameters.md
@@ -1,0 +1,27 @@
+# Prefer default parameters over reassignment
+
+Instead of reassigning a function parameter, default parameters should be used. The `foo = foo || 123` statement evaluates to `123` when `foo` is falsy, possibly leading to confusing behavior, whereas default parameters only apply when passed an `undefined` value. This rule only reports reassignments to literal values.
+
+This rule is fixable.
+
+
+## Fail
+
+```js
+function abc(foo) { foo = foo || 'bar'; }
+```
+
+```js
+function abc(foo) { const bar = foo || \'bar\'; }
+```
+
+
+## Pass
+
+```js
+function abc(foo = 'bar') { }
+```
+
+```js
+function abc(foo) { foo = foo || bar(); }
+```

--- a/docs/rules/prefer-default-parameters.md
+++ b/docs/rules/prefer-default-parameters.md
@@ -4,24 +4,28 @@ Instead of reassigning a function parameter, default parameters should be used. 
 
 This rule is fixable.
 
-
 ## Fail
 
 ```js
-function abc(foo) { foo = foo || 'bar'; }
+function abc(foo) {
+	foo = foo || 'bar';
+}
 ```
 
 ```js
-function abc(foo) { const bar = foo || \'bar\'; }
+function abc(foo) {
+	const bar = foo || 'bar';
+}
 ```
-
 
 ## Pass
 
 ```js
-function abc(foo = 'bar') { }
+function abc(foo = 'bar') {}
 ```
 
 ```js
-function abc(foo) { foo = foo || bar(); }
+function abc(foo) {
+	foo = foo || bar();
+}
 ```

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = {
 				'unicorn/prefer-array-find': 'error',
 				'unicorn/prefer-dataset': 'error',
 				'unicorn/prefer-date-now': 'error',
+				'unicorn/prefer-default-parameters': 'error',
 				'unicorn/prefer-event-key': 'error',
 				// TODO: Enable this by default when targeting Node.js 12.
 				'unicorn/prefer-flat-map': 'off',

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ Configure it in `package.json`.
 			"unicorn/prefer-array-find": "error",
 			"unicorn/prefer-dataset": "error",
 			"unicorn/prefer-date-now": "error",
+			"unicorn/prefer-default-parameters": "error",
 			"unicorn/prefer-event-key": "error",
 			"unicorn/prefer-flat-map": "error",
 			"unicorn/prefer-includes": "error",
@@ -141,6 +142,7 @@ Configure it in `package.json`.
 - [prefer-array-find](docs/rules/prefer-array-find.md) - Prefer `.find(…)` over the first element from `.filter(…)`. *(partly fixable)*
 - [prefer-dataset](docs/rules/prefer-dataset.md) - Prefer using `.dataset` on DOM elements over `.setAttribute(…)`. *(fixable)*
 - [prefer-date-now](docs/rules/prefer-date-now.md) - Prefer `Date.now()` to get the number of milliseconds since the Unix Epoch. *(fixable)*
+- [prefer-default-parameters](docs/rules/prefer-default-parameters.md) - Prefer default parameters over reassignment. *(fixable)*
 - [prefer-event-key](docs/rules/prefer-event-key.md) - Prefer `KeyboardEvent#key` over `KeyboardEvent#keyCode`. *(partly fixable)*
 - [prefer-flat-map](docs/rules/prefer-flat-map.md) - Prefer `.flatMap(…)` over `.map(…).flat()`. *(fixable)*
 - [prefer-includes](docs/rules/prefer-includes.md) - Prefer `.includes()` over `.indexOf()` when checking for existence or non-existence. *(fixable)*

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -78,16 +78,20 @@ const create = context => {
 			right: {raw: literal}
 		} = right;
 
-		// Check if literal is assigned to the same identifier
+		// Parameter is reassigned to a different identifier
 		if (assignment && firstId !== secondId) {
 			return;
 		}
 
 		const variable = findVariable(context.getScope(), secondId);
-		const maxReferences = assignment ? 2 : 1;
 
-		// Check if identifier is referenced elsewhere
-		if (variable.references.length > maxReferences) {
+		// Parameter is referenced prior to default-assignment
+		if (assignment && variable.references[0].identifier !== left) {
+			return;
+		}
+
+		// Old parameter is still referenced somewhere else
+		if (!assignment && variable.references.length > 1) {
 			return;
 		}
 

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -88,17 +88,8 @@ const create = context => {
 		);
 		const lastParameter = currentFunction.params[currentFunction.params.length - 1];
 
-		if (!parameter) {
-			return;
-		}
-
 		// See 'default-param-last' rule
-		if (parameter !== lastParameter) {
-			context.report({
-				node,
-				messageId: MESSAGE_ID
-			});
-
+		if (!parameter || parameter !== lastParameter) {
 			return;
 		}
 

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -120,16 +120,10 @@ const create = context => {
 	};
 
 	return {
-		FunctionDeclaration: node => {
+		':function': node => {
 			functionStack.push(node);
 		},
-		ArrowFunctionExpression: node => {
-			functionStack.push(node);
-		},
-		'FunctionDeclaration:exit': () => {
-			functionStack.pop();
-		},
-		'ArrowFunctionExpression:exit': () => {
+		':function:exit': () => {
 			functionStack.pop();
 		},
 		[assignmentSelector]: node => {

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -86,8 +86,19 @@ const create = context => {
 			parameter.type === 'Identifier' &&
 			parameter.name === secondId
 		);
+		const lastParameter = currentFunction.params[currentFunction.params.length - 1];
 
 		if (!parameter) {
+			return;
+		}
+
+		// See 'default-param-last' rule
+		if (parameter !== lastParameter) {
+			context.report({
+				node,
+				messageId: MESSAGE_ID
+			});
+
 			return;
 		}
 

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -1,0 +1,142 @@
+'use strict';
+const getDocumentationUrl = require('./utils/get-documentation-url');
+
+const MESSAGE_ID = 'preferDefaultParameters';
+
+const assignmentSelector = [
+	'ExpressionStatement',
+	'[expression.type="AssignmentExpression"]'
+].join('');
+
+const declarationSelector = [
+	'VariableDeclaration',
+	'[declarations.0.type="VariableDeclarator"]'
+].join('');
+
+const isDefaultExpression = (left, right) =>
+	left &&
+	right &&
+	left.type === 'Identifier' &&
+	right.type === 'LogicalExpression' &&
+	right.left.type === 'Identifier' &&
+	right.right.type === 'Literal';
+
+const needsParentheses = (source, func) => {
+	if (func.type !== 'ArrowFunctionExpression' || func.params.length > 1) {
+		return false;
+	}
+
+	const [parameter] = func.params;
+	const before = source.getTokenBefore(parameter);
+	const after = source.getTokenAfter(parameter);
+
+	return !after || !before || before.value !== '(' || after.value !== ')';
+};
+
+const fixDefaultExpression = (fixer, source, node) => {
+	const {line} = source.getLocFromIndex(node.range[0]);
+	const {column} = source.getLocFromIndex(node.range[1]);
+	const nodeText = source.getText(node);
+	const lineText = source.lines[line - 1];
+	const isOnlyNodeOnLine = lineText.trim() === nodeText;
+	const endsWithWhitespace = lineText[column] === ' ';
+
+	if (isOnlyNodeOnLine) {
+		return fixer.removeRange([
+			source.getIndexFromLoc({line, column: 0}),
+			source.getIndexFromLoc({line: line + 1, column: 0})
+		]);
+	}
+
+	if (endsWithWhitespace) {
+		return fixer.removeRange([
+			node.range[0],
+			node.range[1] + 1
+		]);
+	}
+
+	return fixer.removeRange(node.range);
+};
+
+const create = context => {
+	const source = context.getSourceCode();
+	let currentFunction;
+
+	const checkExpression = (node, left, right, assignment) => {
+		if (!currentFunction || !isDefaultExpression(left, right)) {
+			return;
+		}
+
+		const {name: firstId} = left;
+		const {
+			left: {name: secondId},
+			right: {raw: literal}
+		} = right;
+
+		// Check if literal is assigned to the same identifier
+		if (assignment && firstId !== secondId) {
+			return;
+		}
+
+		const parameter = currentFunction.params.find(parameter =>
+			parameter.type === 'Identifier' &&
+			parameter.name === secondId
+		);
+
+		if (!parameter) {
+			return;
+		}
+
+		const replacement = needsParentheses(source, currentFunction) ?
+			`(${firstId} = ${literal})` :
+			`${firstId} = ${literal}`;
+
+		context.report({
+			node,
+			messageId: MESSAGE_ID,
+			fix: fixer => [
+				fixer.replaceText(parameter, replacement),
+				fixDefaultExpression(fixer, source, node)
+			]
+		});
+	};
+
+	return {
+		FunctionDeclaration: node => {
+			currentFunction = node;
+		},
+		ArrowFunctionExpression: node => {
+			currentFunction = node;
+		},
+		'FunctionDeclaration:exit': () => {
+			currentFunction = undefined;
+		},
+		'ArrowFunctionExpression:exit': () => {
+			currentFunction = undefined;
+		},
+		[assignmentSelector]: node => {
+			const {left, right} = node.expression;
+
+			checkExpression(node, left, right, true);
+		},
+		[declarationSelector]: node => {
+			const {id, init} = node.declarations[0];
+
+			checkExpression(node, id, init, false);
+		}
+	};
+};
+
+module.exports = {
+	create,
+	meta: {
+		type: 'suggestion',
+		docs: {
+			url: getDocumentationUrl(__filename)
+		},
+		fixable: 'code',
+		messages: {
+			[MESSAGE_ID]: 'Prefer default parameters over reassignment.'
+		}
+	}
+};

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -24,12 +24,12 @@ const isDefaultExpression = (left, right) =>
 	right.left.type === 'Identifier' &&
 	right.right.type === 'Literal';
 
-const needsParentheses = (source, func) => {
-	if (func.type !== 'ArrowFunctionExpression' || func.params.length > 1) {
+const needsParentheses = (source, function_) => {
+	if (function_.type !== 'ArrowFunctionExpression' || function_.params.length > 1) {
 		return false;
 	}
 
-	const [parameter] = func.params;
+	const [parameter] = function_.params;
 	const before = source.getTokenBefore(parameter);
 	const after = source.getTokenAfter(parameter);
 

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -23,7 +23,7 @@ const isDefaultExpression = (left, right) =>
 	right &&
 	left.type === 'Identifier' &&
 	right.type === 'LogicalExpression' &&
-	right.operator === '||' &&
+	(right.operator === '||' || right.operator === '??') &&
 	right.left.type === 'Identifier' &&
 	right.right.type === 'Literal';
 

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -18,6 +18,7 @@ const isDefaultExpression = (left, right) =>
 	right &&
 	left.type === 'Identifier' &&
 	right.type === 'LogicalExpression' &&
+	right.operator === '||' &&
 	right.left.type === 'Identifier' &&
 	right.right.type === 'Literal';
 

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -145,12 +145,6 @@ ruleTester.run('prefer-default-parameters', rule, {
 				console.log(foo, bar);
 			}
 		`,
-		outdent`
-			function abc(foo) {
-				const bar = foo || 'bar';
-				console.log(bar);
-			}
-		`,
 		// Last parameter is `RestElement`
 		outdent`
 			function abc(...foo) {
@@ -294,6 +288,19 @@ ruleTester.run('prefer-default-parameters', rule, {
 				}
 			`]
 		}),
+		invalidTestCase({
+			code: outdent`
+				function abc(foo) {
+					const bar = foo || 'bar';
+					console.log(bar);
+				}
+			`,
+			suggestions: [outdent`
+				function abc(bar = 'bar') {
+					console.log(bar);
+				}
+			`]
+		}),
 		// The following tests verify the correct code formatting
 		invalidTestCase({
 			code: 'function abc(foo) { foo = foo || \'bar\'; }',
@@ -370,16 +377,6 @@ ruleTester.run('prefer-default-parameters', rule, {
 					function ghi(bay = 'bar') {
 					}
 					foo = foo || 'bar';
-				}
-			`, outdent`
-				function abc(foo = 'bar') {
-					foo += 'bar';
-					function def(bar) {
-						bar = bar || 'foo';
-					}
-					function ghi(baz) {
-						const bay = baz || 'bar';
-					}
 				}
 			`]
 		})

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -9,9 +9,21 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-const error = {
-	ruleId: 'prefer-default-parameters',
-	messageId: 'preferDefaultParameters'
+const invalidTestCase = ({code, suggestions}) => {
+	const errors = suggestions.map(suggestion => ({
+		ruleId: 'prefer-default-parameters',
+		messageId: 'preferDefaultParameters',
+		suggestions: [{
+			messageId: 'preferDefaultParametersSuggest',
+			output: suggestion
+		}]
+	}));
+
+	return {
+		code,
+		output: code,
+		errors
+	};
 };
 
 ruleTester.run('prefer-default-parameters', rule, {
@@ -97,133 +109,123 @@ ruleTester.run('prefer-default-parameters', rule, {
 		`
 	],
 	invalid: [
-		{
+		invalidTestCase({
 			code: outdent`
 				function abc(foo) {
 					foo = foo || 123;
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(foo = 123) {
 				}
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				function abc(foo) {
 					foo = foo || true;
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(foo = true) {
 				}
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				function abc(foo, bar) {
 					foo = foo || 'bar';
 					baz();
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(foo = 'bar', bar) {
 					baz();
 				}
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				function abc(foo) {
 					const bar = foo || 'bar';
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(bar = 'bar') {
 				}
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				function abc(foo) {
 					let bar = foo || 'bar';
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(bar = 'bar') {
 				}
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				function abc(bar) {
 					foo();
 					bar = bar || 123;
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(bar = 123) {
 					foo();
 				}
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				const abc = (foo) => {
 					foo = foo || 'bar';
 				};
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				const abc = (foo = 'bar') => {
 				};
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				const abc = foo => {
 					foo = foo || 'bar';
 				};
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				const abc = (foo = 'bar') => {
 				};
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				const abc = (bar) => {
 					foo();
 					bar = bar || 'bar';
 				};
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				const abc = (bar = 'bar') => {
 					foo();
 				};
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				const abc = (foo) => {
 					const bar = foo || 'bar';
 				};
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				const abc = (bar = 'bar') => {
 				};
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				function abc(foo) {
 					foo = foo || 'bar';
@@ -231,39 +233,35 @@ ruleTester.run('prefer-default-parameters', rule, {
 					baz();
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(foo = 'bar') {
 					bar();
 					baz();
 				}
-			`,
-			errors: [error]
-		},
+			`]
+		}),
 		// The following tests verify the correct code formatting
-		{
+		invalidTestCase({
 			code: 'function abc(foo) { foo = foo || \'bar\'; }',
-			output: 'function abc(foo = \'bar\') { }',
-			errors: [error]
-		},
-		{
+			suggestions: ['function abc(foo = \'bar\') { }']
+		}),
+		invalidTestCase({
 			code: 'function abc(foo) { foo = foo || \'bar\';}',
-			output: 'function abc(foo = \'bar\') { }',
-			errors: [error]
-		},
-		{
+			suggestions: ['function abc(foo = \'bar\') { }']
+		}),
+		invalidTestCase({
 			code: outdent`
 				function abc(foo) {
 					foo = foo || 'bar'; bar(); baz();
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(foo = 'bar') {
 					bar(); baz();
 				}
-			`,
-			errors: [error]
-		},
-		{
+			`]
+		}),
+		invalidTestCase({
 			code: outdent`
 				function abc(foo) {
 					foo = foo || 'bar';
@@ -272,13 +270,64 @@ ruleTester.run('prefer-default-parameters', rule, {
 					}
 				}
 			`,
-			output: outdent`
+			suggestions: [outdent`
 				function abc(foo = 'bar') {
+					function def(bar) {
+						bar = bar || 'foo';
+					}
+				}
+			`, outdent`
+				function abc(foo) {
+					foo = foo || 'bar';
 					function def(bar = 'foo') {
 					}
 				}
+			`]
+		}),
+		invalidTestCase({
+			code: outdent`
+				function abc(foo) {
+					foo += 'bar';
+					function def(bar) {
+						bar = bar || 'foo';
+					}
+					function ghi(baz) {
+						const bay = baz || 'bar';
+					}
+					foo = foo || 'bar';
+				}
 			`,
-			errors: [error, error]
-		}
+			suggestions: [outdent`
+				function abc(foo) {
+					foo += 'bar';
+					function def(bar = 'foo') {
+					}
+					function ghi(baz) {
+						const bay = baz || 'bar';
+					}
+					foo = foo || 'bar';
+				}
+			`, outdent`
+				function abc(foo) {
+					foo += 'bar';
+					function def(bar) {
+						bar = bar || 'foo';
+					}
+					function ghi(bay = 'bar') {
+					}
+					foo = foo || 'bar';
+				}
+			`, outdent`
+				function abc(foo = 'bar') {
+					foo += 'bar';
+					function def(bar) {
+						bar = bar || 'foo';
+					}
+					function ghi(baz) {
+						const bay = baz || 'bar';
+					}
+				}
+			`]
+		})
 	]
 });

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -66,6 +66,12 @@ ruleTester.run('prefer-default-parameters', rule, {
 			}
 		`,
 		outdent`
+			function abc(foo, bar) {
+				foo = foo || 'bar';
+				baz();
+			}
+		`,
+		outdent`
 			function abc(foo) {
 				foo = foo && 'bar';
 			}
@@ -148,14 +154,6 @@ ruleTester.run('prefer-default-parameters', rule, {
 				function abc(foo = true) {
 				}
 			`]
-		}),
-		invalidTestCase({
-			code: outdent`
-				function abc(foo, bar) {
-					foo = foo || 'bar';
-					baz();
-				}
-			`
 		}),
 		invalidTestCase({
 			code: outdent`

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -1,0 +1,156 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import {outdent} from 'outdent';
+import rule from '../rules/prefer-default-parameters';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	}
+});
+
+const error = {
+	ruleId: 'prefer-default-parameters',
+	messageId: 'preferDefaultParameters'
+};
+
+ruleTester.run('prefer-default-parameters', rule, {
+	valid: [
+		'function abc(foo = { bar: 123 }) { }',
+		'function abc({ bar } = { bar: 123 }) { }',
+		'function abc({ bar = 123 } = { bar }) { }',
+		'function abc(foo = fooDefault) { }',
+		'function abc(foo = {}) { }',
+		'function abc(foo = \'bar\') { }',
+		'function abc({ bar = 123 } = {}) { }',
+		'function abc(foo) { foo = foo || bar(); }',
+		'function abc(foo) { foo = foo || {bar} }',
+		'function abc(foo) { const {bar} = foo || 123 }',
+		'function abc(foo, bar) { bar = foo || \'bar\' }',
+		'function abc(foo) { foo = foo || 1 && 2 || 3 }',
+		'function abc(foo) { foo = !foo || \'bar\' }',
+		'function abc(foo) { foo = (foo && bar) || baz }',
+		'function abc(foo = 123) { foo = foo || \'bar\' }',
+		'function abc() { let foo = 123; foo = foo || \'bar\' }',
+		'function abc() { let foo = 123; const bar = foo || \'bar\' }',
+		'const abc = (foo = \'bar\') => { };',
+		'const abc = (foo, bar) => { bar = foo || \'bar\' };',
+		'foo = foo || \'bar\';',
+		'const bar = foo || \'bar\';',
+		outdent`
+			function abc(foo) {
+				function def(bar) {
+					foo = foo || 'bar';
+				}
+			}
+		`
+	],
+	invalid: [
+		{
+			code: 'function abc(foo) { foo = foo || \'bar\'; }',
+			output: 'function abc(foo = \'bar\') { }',
+			errors: [error]
+		},
+		{
+			code: 'function abc(foo) { foo = foo || \'bar\';}',
+			output: 'function abc(foo = \'bar\') { }',
+			errors: [error]
+		},
+		{
+			code: 'function abc(foo) { foo = foo || 123; }',
+			output: 'function abc(foo = 123) { }',
+			errors: [error]
+		},
+		{
+			code: 'function abc(foo) { foo = foo || true; }',
+			output: 'function abc(foo = true) { }',
+			errors: [error]
+		},
+		{
+			code: 'function abc(foo, bar) { foo = foo || \'bar\'; baz(); }',
+			output: 'function abc(foo = \'bar\', bar) { baz(); }',
+			errors: [error]
+		},
+		{
+			code: 'function abc(foo) { const bar = foo || \'bar\'; }',
+			output: 'function abc(bar = \'bar\') { }',
+			errors: [error]
+		},
+		{
+			code: 'function abc(foo) { let bar = foo || \'bar\'; }',
+			output: 'function abc(bar = \'bar\') { }',
+			errors: [error]
+		},
+		{
+			code: 'function abc(bar) { foo(); bar = bar || 123; }',
+			output: 'function abc(bar = 123) { foo(); }',
+			errors: [error]
+		},
+		{
+			code: 'const abc = (foo) => { foo = foo || \'bar\'; };',
+			output: 'const abc = (foo = \'bar\') => { };',
+			errors: [error]
+		},
+		{
+			code: 'const abc = foo => { foo = foo || \'bar\'; };',
+			output: 'const abc = (foo = \'bar\') => { };',
+			errors: [error]
+		},
+		{
+			code: 'const abc = (bar) => { foo(); bar = bar || \'bar\'; };',
+			output: 'const abc = (bar = \'bar\') => { foo(); };',
+			errors: [error]
+		},
+		{
+			code: 'const abc = (foo) => { const bar = foo || \'bar\'; };',
+			output: 'const abc = (bar = \'bar\') => { };',
+			errors: [error]
+		},
+		{
+			code: outdent`
+				function abc(foo) {
+					foo = foo || 'bar';
+					bar();
+					baz();
+				}
+			`,
+			output: outdent`
+				function abc(foo = 'bar') {
+					bar();
+					baz();
+				}
+			`,
+			errors: [error]
+		},
+		{
+			code: outdent`
+				function abc(foo) {
+					foo = foo || 'bar'; bar(); baz();
+				}
+			`,
+			output: outdent`
+				function abc(foo = 'bar') {
+					bar(); baz();
+				}
+			`,
+			errors: [error]
+		},
+		{
+			code: outdent`
+				function abc(foo) {
+					foo = foo || 'bar';
+					function def(bar) {
+						bar = bar || 'foo';
+					}
+				}
+			`,
+			output: outdent`
+				function abc(foo = 'bar') {
+					function def(bar = 'foo') {
+					}
+				}
+			`,
+			errors: [error, error]
+		}
+	]
+});

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -113,6 +113,17 @@ ruleTester.run('prefer-default-parameters', rule, {
 					foo = foo || 'bar';
 				}
 			}
+		`,
+		outdent`
+			function abc(foo) {
+				const bar = foo = foo || 123;
+		   	}
+		`,
+		outdent`
+			function abc(foo) {
+				bar(foo = foo || 1);
+				baz(foo);
+			}
 		`
 	],
 	invalid: [

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -10,19 +10,28 @@ const ruleTester = avaRuleTester(test, {
 });
 
 const invalidTestCase = ({code, suggestions}) => {
-	const errors = suggestions.map(suggestion => ({
-		ruleId: 'prefer-default-parameters',
-		messageId: 'preferDefaultParameters',
-		suggestions: [{
-			messageId: 'preferDefaultParametersSuggest',
-			output: suggestion
-		}]
-	}));
+	if (!suggestions) {
+		return {
+			code,
+			output: code,
+			errors: [{
+				ruleId: 'prefer-default-parameters',
+				messageId: 'preferDefaultParameters'
+			}]
+		};
+	}
 
 	return {
 		code,
 		output: code,
-		errors
+		errors: suggestions.map(suggestion => ({
+			ruleId: 'prefer-default-parameters',
+			messageId: 'preferDefaultParameters',
+			suggestions: [{
+				messageId: 'preferDefaultParametersSuggest',
+				output: suggestion
+			}]
+		}))
 	};
 };
 
@@ -137,12 +146,7 @@ ruleTester.run('prefer-default-parameters', rule, {
 					foo = foo || 'bar';
 					baz();
 				}
-			`,
-			suggestions: [outdent`
-				function abc(foo = 'bar', bar) {
-					baz();
-				}
-			`]
+			`
 		}),
 		invalidTestCase({
 			code: outdent`

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -15,7 +15,6 @@ const invalidTestCase = ({code, suggestions}) => {
 			code,
 			output: code,
 			errors: [{
-				ruleId: 'prefer-default-parameters',
 				messageId: 'preferDefaultParameters'
 			}]
 		};
@@ -25,7 +24,6 @@ const invalidTestCase = ({code, suggestions}) => {
 		code,
 		output: code,
 		errors: suggestions.map(suggestion => ({
-			ruleId: 'prefer-default-parameters',
 			messageId: 'preferDefaultParameters',
 			suggestions: [{
 				messageId: 'preferDefaultParametersSuggest',

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -123,12 +123,44 @@ ruleTester.run('prefer-default-parameters', rule, {
 		outdent`
 			function abc(foo) {
 				const bar = foo = foo || 123;
-		   	}
+			}
 		`,
 		outdent`
 			function abc(foo) {
 				bar(foo = foo || 1);
 				baz(foo);
+			}
+		`,
+		// Used before assignment
+		outdent`
+			function abc(foo) {
+				console.log(foo);
+				foo = foo || 'bar';
+			}
+		`,
+		// Variable is used
+		outdent`
+			function abc(foo) {
+				const bar = foo || 'bar';
+				console.log(foo, bar);
+			}
+		`,
+		outdent`
+			function abc(foo) {
+				const bar = foo || 'bar';
+				console.log(bar);
+			}
+		`,
+		// Last parameter is `RestElement`
+		outdent`
+			function abc(...foo) {
+				foo = foo || 'bar';
+			}
+		`,
+		// Last parameter is `AssignmentPattern`
+		outdent`
+			function abc(foo = 'bar') {
+				foo = foo || 'baz';
 			}
 		`
 	],

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -27,6 +27,7 @@ ruleTester.run('prefer-default-parameters', rule, {
 		'function abc(foo) { foo = foo || {bar} }',
 		'function abc(foo) { const {bar} = foo || 123 }',
 		'function abc(foo, bar) { bar = foo || \'bar\' }',
+		'function abc(foo) { foo = foo && \'bar\' }',
 		'function abc(foo) { foo = foo || 1 && 2 || 3 }',
 		'function abc(foo) { foo = !foo || \'bar\' }',
 		'function abc(foo) { foo = (foo && bar) || baz }',

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -23,21 +23,71 @@ ruleTester.run('prefer-default-parameters', rule, {
 		'function abc(foo = {}) { }',
 		'function abc(foo = \'bar\') { }',
 		'function abc({ bar = 123 } = {}) { }',
-		'function abc(foo) { foo = foo || bar(); }',
-		'function abc(foo) { foo = foo || {bar} }',
-		'function abc(foo) { const {bar} = foo || 123 }',
-		'function abc(foo, bar) { bar = foo || \'bar\' }',
-		'function abc(foo) { foo = foo && \'bar\' }',
-		'function abc(foo) { foo = foo || 1 && 2 || 3 }',
-		'function abc(foo) { foo = !foo || \'bar\' }',
-		'function abc(foo) { foo = (foo && bar) || baz }',
-		'function abc(foo = 123) { foo = foo || \'bar\' }',
-		'function abc() { let foo = 123; foo = foo || \'bar\' }',
-		'function abc() { let foo = 123; const bar = foo || \'bar\' }',
 		'const abc = (foo = \'bar\') => { };',
-		'const abc = (foo, bar) => { bar = foo || \'bar\' };',
 		'foo = foo || \'bar\';',
 		'const bar = foo || \'bar\';',
+		outdent`
+			function abc(foo) {
+				foo = foo || bar();
+			}
+		`,
+		outdent`
+			function abc(foo) {
+				foo = foo || {bar};
+			}
+		`,
+		outdent`
+			function abc(foo) {
+				const {bar} = foo || 123;
+			}
+		`,
+		outdent`
+			function abc(foo, bar) {
+				bar = foo || 'bar';
+			}
+		`,
+		outdent`
+			function abc(foo) {
+				foo = foo && 'bar';
+			}
+		`,
+		outdent`
+			function abc(foo) {
+				foo = foo || 1 && 2 || 3;
+			}
+		`,
+		outdent`
+			function abc(foo) {
+				foo = !foo || 'bar';
+			}
+		`,
+		outdent`
+			function abc(foo) {
+				foo = (foo && bar) || baz;
+			}
+		`,
+		outdent`
+			function abc(foo = 123) {
+				foo = foo || 'bar';
+			}
+		`,
+		outdent`
+			function abc() {
+				let foo = 123;
+				foo = foo || 'bar';
+			}
+		`,
+		outdent`
+			function abc() {
+				let foo = 123;
+				const bar = foo || 'bar';
+			}
+		`,
+		outdent`
+			const abc = (foo, bar) => {
+				bar = foo || 'bar';
+			};
+		`,
 		outdent`
 			function abc(foo) {
 				function def(bar) {
@@ -48,63 +98,129 @@ ruleTester.run('prefer-default-parameters', rule, {
 	],
 	invalid: [
 		{
-			code: 'function abc(foo) { foo = foo || \'bar\'; }',
-			output: 'function abc(foo = \'bar\') { }',
+			code: outdent`
+				function abc(foo) {
+					foo = foo || 123;
+				}
+			`,
+			output: outdent`
+				function abc(foo = 123) {
+				}
+			`,
 			errors: [error]
 		},
 		{
-			code: 'function abc(foo) { foo = foo || \'bar\';}',
-			output: 'function abc(foo = \'bar\') { }',
+			code: outdent`
+				function abc(foo) {
+					foo = foo || true;
+				}
+			`,
+			output: outdent`
+				function abc(foo = true) {
+				}
+			`,
 			errors: [error]
 		},
 		{
-			code: 'function abc(foo) { foo = foo || 123; }',
-			output: 'function abc(foo = 123) { }',
+			code: outdent`
+				function abc(foo, bar) {
+					foo = foo || 'bar';
+					baz();
+				}
+			`,
+			output: outdent`
+				function abc(foo = 'bar', bar) {
+					baz();
+				}
+			`,
 			errors: [error]
 		},
 		{
-			code: 'function abc(foo) { foo = foo || true; }',
-			output: 'function abc(foo = true) { }',
+			code: outdent`
+				function abc(foo) {
+					const bar = foo || 'bar';
+				}
+			`,
+			output: outdent`
+				function abc(bar = 'bar') {
+				}
+			`,
 			errors: [error]
 		},
 		{
-			code: 'function abc(foo, bar) { foo = foo || \'bar\'; baz(); }',
-			output: 'function abc(foo = \'bar\', bar) { baz(); }',
+			code: outdent`
+				function abc(foo) {
+					let bar = foo || 'bar';
+				}
+			`,
+			output: outdent`
+				function abc(bar = 'bar') {
+				}
+			`,
 			errors: [error]
 		},
 		{
-			code: 'function abc(foo) { const bar = foo || \'bar\'; }',
-			output: 'function abc(bar = \'bar\') { }',
+			code: outdent`
+				function abc(bar) {
+					foo();
+					bar = bar || 123;
+				}
+			`,
+			output: outdent`
+				function abc(bar = 123) {
+					foo();
+				}
+			`,
 			errors: [error]
 		},
 		{
-			code: 'function abc(foo) { let bar = foo || \'bar\'; }',
-			output: 'function abc(bar = \'bar\') { }',
+			code: outdent`
+				const abc = (foo) => {
+					foo = foo || 'bar';
+				};
+			`,
+			output: outdent`
+				const abc = (foo = 'bar') => {
+				};
+			`,
 			errors: [error]
 		},
 		{
-			code: 'function abc(bar) { foo(); bar = bar || 123; }',
-			output: 'function abc(bar = 123) { foo(); }',
+			code: outdent`
+				const abc = foo => {
+					foo = foo || 'bar';
+				};
+			`,
+			output: outdent`
+				const abc = (foo = 'bar') => {
+				};
+			`,
 			errors: [error]
 		},
 		{
-			code: 'const abc = (foo) => { foo = foo || \'bar\'; };',
-			output: 'const abc = (foo = \'bar\') => { };',
+			code: outdent`
+				const abc = (bar) => {
+					foo();
+					bar = bar || 'bar';
+				};
+			`,
+			output: outdent`
+				const abc = (bar = 'bar') => {
+					foo();
+				};
+			`,
 			errors: [error]
 		},
 		{
-			code: 'const abc = foo => { foo = foo || \'bar\'; };',
-			output: 'const abc = (foo = \'bar\') => { };',
-			errors: [error]
-		},
-		{
-			code: 'const abc = (bar) => { foo(); bar = bar || \'bar\'; };',
-			output: 'const abc = (bar = \'bar\') => { foo(); };',
-			errors: [error]
-		},
-		{
-			code: 'const abc = (foo) => { const bar = foo || \'bar\'; };',
-			output: 'const abc = (bar = \'bar\') => { };',
+			code: outdent`
+				const abc = (foo) => {
+					const bar = foo || 'bar';
+				};
+			`,
+			output: outdent`
+				const abc = (bar = 'bar') => {
+				};
+			`,
 			errors: [error]
 		},
 		{
@@ -121,6 +237,17 @@ ruleTester.run('prefer-default-parameters', rule, {
 					baz();
 				}
 			`,
+			errors: [error]
+		},
+		// The following tests verify the correct code formatting
+		{
+			code: 'function abc(foo) { foo = foo || \'bar\'; }',
+			output: 'function abc(foo = \'bar\') { }',
+			errors: [error]
+		},
+		{
+			code: 'function abc(foo) { foo = foo || \'bar\';}',
+			output: 'function abc(foo = \'bar\') { }',
 			errors: [error]
 		},
 		{

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -131,6 +131,12 @@ ruleTester.run('prefer-default-parameters', rule, {
 				baz(foo);
 			}
 		`,
+		outdent`
+			function abc(foo) {
+				console.log(foo);
+				foo = foo || 123;
+			}
+		`,
 		// Used before assignment
 		outdent`
 			function abc(foo) {
@@ -178,6 +184,19 @@ ruleTester.run('prefer-default-parameters', rule, {
 			`,
 			suggestions: [outdent`
 				function abc(foo = true) {
+				}
+			`]
+		}),
+		invalidTestCase({
+			code: outdent`
+				function abc(foo) {
+					foo = foo || 123;
+					console.log(foo);
+				}
+			`,
+			suggestions: [outdent`
+				function abc(foo = 123) {
+					console.log(foo);
 				}
 			`]
 		}),

--- a/test/prefer-default-parameters.js
+++ b/test/prefer-default-parameters.js
@@ -4,8 +4,8 @@ import {outdent} from 'outdent';
 import rule from '../rules/prefer-default-parameters';
 
 const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
+	parserOptions: {
+		ecmaVersion: 2020
 	}
 });
 
@@ -280,6 +280,17 @@ ruleTester.run('prefer-default-parameters', rule, {
 				function abc(foo = 'bar') {
 					bar();
 					baz();
+				}
+			`]
+		}),
+		invalidTestCase({
+			code: outdent`
+				function abc(foo) {
+					foo = foo ?? 123;
+				}
+			`,
+			suggestions: [outdent`
+				function abc(foo = 123) {
 				}
 			`]
 		}),


### PR DESCRIPTION
Some notes: I've tried to keep the rule simple by only reporting `literal` assignments (see [this](https://github.com/sindresorhus/eslint-plugin-unicorn/issues/29#issuecomment-502794939) comment). Combining parameters with e.g. a return value of another function or variable might be desired in some cases and should in my opinion not be reported. I've had to work around arrow functions with only one parameter and no parentheses (`foo => {}`) to make sure the default parameter gets inserted correctly by including the missing parentheses.

Fixes #29


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#29: Prefer default parameters](https://issuehunt.io/repos/55832243/issues/29)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->