### PR TITLE
`prefer-number-properties`: Fix suggestion description

### DIFF
--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -5,6 +5,7 @@ const renameIdentifier = require('./utils/rename-identifier');
 
 const methodMessageId = 'method';
 const propertyMessageId = 'property';
+const fixMethodMessageId = 'fixMethod';
 
 const methods = {
 	// Safe
@@ -61,7 +62,15 @@ const create = context => {
 			if (isSafe) {
 				problem.fix = fix;
 			} else {
-				problem.suggest = [{messageId: methodMessageId, fix}];
+				problem.suggest = [
+					{
+						messageId: fixMethodMessageId,
+						data: {
+							name
+						},
+						fix
+					}
+				];
 			}
 
 			context.report(problem);
@@ -109,7 +118,8 @@ module.exports = {
 		fixable: 'code',
 		messages: {
 			[methodMessageId]: 'Prefer `Number.{{name}}()` over `{{name}}()`.',
-			[propertyMessageId]: 'Prefer `Number.{{name}}` over `{{name}}`.'
+			[propertyMessageId]: 'Prefer `Number.{{name}}` over `{{name}}`.',
+			[fixMethodMessageId]: 'Replace `{{name}}()` with `Number.{{name}}()`.'
 		}
 	}
 };

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -3,9 +3,9 @@ const getDocumentationUrl = require('./utils/get-documentation-url');
 const isShadowed = require('./utils/is-shadowed');
 const renameIdentifier = require('./utils/rename-identifier');
 
-const methodMessageId = 'method';
-const propertyMessageId = 'property';
-const fixMethodMessageId = 'fixMethod';
+const METHOD_ERROR_MESSAGE_ID = 'method-error';
+const METHOD_SUGGESTION_MESSAGE_ID = 'method-suggestion';
+const PROPERTY_ERROR_MESSAGE_ID = 'property-error';
 
 const methods = {
 	// Safe
@@ -51,7 +51,7 @@ const create = context => {
 
 			const problem = {
 				node,
-				messageId: methodMessageId,
+				messageId: METHOD_ERROR_MESSAGE_ID,
 				data: {
 					name
 				}
@@ -64,7 +64,7 @@ const create = context => {
 			} else {
 				problem.suggest = [
 					{
-						messageId: fixMethodMessageId,
+						messageId: METHOD_SUGGESTION_MESSAGE_ID,
 						data: {
 							name
 						},
@@ -98,7 +98,7 @@ const create = context => {
 			const {name} = node;
 			context.report({
 				node,
-				messageId: propertyMessageId,
+				messageId: PROPERTY_ERROR_MESSAGE_ID,
 				data: {
 					name
 				},
@@ -117,9 +117,9 @@ module.exports = {
 		},
 		fixable: 'code',
 		messages: {
-			[methodMessageId]: 'Prefer `Number.{{name}}()` over `{{name}}()`.',
-			[propertyMessageId]: 'Prefer `Number.{{name}}` over `{{name}}`.',
-			[fixMethodMessageId]: 'Replace `{{name}}()` with `Number.{{name}}()`.'
+			[METHOD_ERROR_MESSAGE_ID]: 'Prefer `Number.{{name}}()` over `{{name}}()`.',
+			[METHOD_SUGGESTION_MESSAGE_ID]: 'Replace `{{name}}()` with `Number.{{name}}()`.',
+			[PROPERTY_ERROR_MESSAGE_ID]: 'Prefer `Number.{{name}}` over `{{name}}`.'
 		}
 	}
 };

--- a/test/prefer-number-properties.js
+++ b/test/prefer-number-properties.js
@@ -6,6 +6,7 @@ import rule from '../rules/prefer-number-properties';
 const ruleId = 'prefer-number-properties';
 const methodMessageId = 'method';
 const propertyMessageId = 'property';
+const fixMethodMessageId = 'fixMethod';
 
 const methods = {
 	parseInt: {
@@ -37,7 +38,7 @@ const typescriptRuleTester = avaRuleTester(test, {
 });
 
 const invalidMethodTest = ({code, output, name}) => {
-	const isSafe = methods[name].safe;
+	const {safe} = methods[name];
 
 	const error = {
 		messageId: methodMessageId,
@@ -46,10 +47,24 @@ const invalidMethodTest = ({code, output, name}) => {
 		}
 	};
 
+	const suggestions = safe ? undefined : [
+		{
+			messageId: fixMethodMessageId,
+			data: {
+				name
+			}
+		}
+	];
+
 	return {
 		code,
-		output: isSafe ? output : code,
-		errors: isSafe ? [{...error, suggestions: undefined}] : [{suggestions: [error]}]
+		output: safe ? output : code,
+		errors: [
+			{
+				...error,
+				suggestions
+			}
+		]
 	};
 };
 
@@ -130,9 +145,13 @@ ruleTester.run(ruleId, rule, {
 					}
 				},
 				{
+					messageId: methodMessageId,
+					data: {
+						name: 'isNaN'
+					},
 					suggestions: [
 						{
-							messageId: methodMessageId,
+							messageId: fixMethodMessageId,
 							data: {
 								name: 'isNaN'
 							}
@@ -140,9 +159,13 @@ ruleTester.run(ruleId, rule, {
 					]
 				},
 				{
+					messageId: methodMessageId,
+					data: {
+						name: 'isFinite'
+					},
 					suggestions: [
 						{
-							messageId: methodMessageId,
+							messageId: fixMethodMessageId,
 							data: {
 								name: 'isFinite'
 							}

--- a/test/prefer-number-properties.js
+++ b/test/prefer-number-properties.js
@@ -4,9 +4,9 @@ import {outdent} from 'outdent';
 import rule from '../rules/prefer-number-properties';
 
 const ruleId = 'prefer-number-properties';
-const methodMessageId = 'method';
-const propertyMessageId = 'property';
-const fixMethodMessageId = 'fixMethod';
+const METHOD_ERROR_MESSAGE_ID = 'method-error';
+const METHOD_SUGGESTION_MESSAGE_ID = 'method-suggestion';
+const PROPERTY_ERROR_MESSAGE_ID = 'property-error';
 
 const methods = {
 	parseInt: {
@@ -37,11 +37,11 @@ const typescriptRuleTester = avaRuleTester(test, {
 	parser: require.resolve('@typescript-eslint/parser')
 });
 
-const invalidMethodTest = ({code, output, name}) => {
+const createError = name => {
 	const {safe} = methods[name];
 
 	const error = {
-		messageId: methodMessageId,
+		messageId: METHOD_ERROR_MESSAGE_ID,
 		data: {
 			name
 		}
@@ -49,7 +49,7 @@ const invalidMethodTest = ({code, output, name}) => {
 
 	const suggestions = safe ? undefined : [
 		{
-			messageId: fixMethodMessageId,
+			messageId: METHOD_SUGGESTION_MESSAGE_ID,
 			data: {
 				name
 			}
@@ -57,13 +57,19 @@ const invalidMethodTest = ({code, output, name}) => {
 	];
 
 	return {
+		...error,
+		suggestions
+	};
+};
+
+const invalidMethodTest = ({code, output, name}) => {
+	const {safe} = methods[name];
+
+	return {
 		code,
 		output: safe ? output : code,
 		errors: [
-			{
-				...error,
-				suggestions
-			}
+			createError(name)
 		]
 	};
 };
@@ -132,46 +138,10 @@ ruleTester.run(ruleId, rule, {
 				const d = isFinite(10);
 			`,
 			errors: [
-				{
-					messageId: methodMessageId,
-					data: {
-						name: 'parseInt'
-					}
-				},
-				{
-					messageId: methodMessageId,
-					data: {
-						name: 'parseFloat'
-					}
-				},
-				{
-					messageId: methodMessageId,
-					data: {
-						name: 'isNaN'
-					},
-					suggestions: [
-						{
-							messageId: fixMethodMessageId,
-							data: {
-								name: 'isNaN'
-							}
-						}
-					]
-				},
-				{
-					messageId: methodMessageId,
-					data: {
-						name: 'isFinite'
-					},
-					suggestions: [
-						{
-							messageId: fixMethodMessageId,
-							data: {
-								name: 'isFinite'
-							}
-						}
-					]
-				}
+				createError('parseInt'),
+				createError('parseFloat'),
+				createError('isNaN'),
+				createError('isFinite')
 			]
 		}
 	]
@@ -180,7 +150,7 @@ ruleTester.run(ruleId, rule, {
 // NaN
 const errorNaN = [
 	{
-		messageId: propertyMessageId,
+		messageId: PROPERTY_ERROR_MESSAGE_ID,
 		data: {
 			name: 'NaN'
 		}


### PR DESCRIPTION
I thought suggestion and error can share `data`, apparently, I was wrong.

Before: 
![image](https://user-images.githubusercontent.com/172584/77715366-65ef6280-7016-11ea-970d-8a5d58f30b51.png)

After:
![image](https://user-images.githubusercontent.com/172584/77715424-87504e80-7016-11ea-84ec-c2b1f66df3b8.png)


