### PR TITLE
Add `no-null` rule

### DIFF
--- a/docs/rules/no-null.md
+++ b/docs/rules/no-null.md
@@ -6,19 +6,45 @@ Disallow the use of the `null` literal, to encourage using `undefined` instead.
 
 ```js
 let foo = null;
+```
 
-if (bar === null) {}
+```js
+if (bar == null) {}
 ```
 
 ## Pass
 
 ```js
 let foo;
-
-Object.create(null)
 ```
 
-### Why
+```js
+const foo = Object.create(null);
+```
+
+```js
+if (foo === null) {}
+```
+
+## Options
+
+Type: `object`
+
+### checkStrictEquality
+
+Type: `boolean`\
+Default: `false`
+
+Strict equality(`===`) and strict inequality(`!==`) is ignored by default.
+
+#### Fail
+
+```js
+// eslint unicorn/no-null: ["error", {"checkStrictEquality": true}]
+if (foo === null) {}
+```
+
+## Why
 
 - [“Intent to stop using `null` in my JS code”](https://github.com/sindresorhus/meta/issues/7).
 - [TypeScript coding guidelines](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#null-and-undefined).

--- a/docs/rules/no-null.md
+++ b/docs/rules/no-null.md
@@ -1,0 +1,25 @@
+# Do not use `null`
+
+Disallows use of `null` literals, to encourage using `undefined` instead.
+
+## Fail
+
+```js
+let foo = null;
+
+if (bar === null) {}
+```
+
+## Pass
+
+```js
+let foo;
+
+Object.create(null)
+```
+
+### Why
+
+- [TypeScript coding guidelines](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#null-and-undefined).
+- [ESLint rule proposal](https://github.com/eslint/eslint/issues/6701).
+- [Douglas Crockford](https://www.youtube.com/watch?v=PSGEjv3Tqo0&t=9m21s) on bottom values in JavaScript.

--- a/docs/rules/no-null.md
+++ b/docs/rules/no-null.md
@@ -1,6 +1,6 @@
 # Do not use `null`
 
-Disallows use of `null` literals, to encourage using `undefined` instead.
+Disallow the use of the `null` literal, to encourage using `undefined` instead.
 
 ## Fail
 
@@ -20,6 +20,7 @@ Object.create(null)
 
 ### Why
 
+- [“Intent to stop using `null` in my JS code”](https://github.com/sindresorhus/meta/issues/7).
 - [TypeScript coding guidelines](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#null-and-undefined).
 - [ESLint rule proposal](https://github.com/eslint/eslint/issues/6701).
 - [Douglas Crockford](https://www.youtube.com/watch?v=PSGEjv3Tqo0&t=9m21s) on bottom values in JavaScript.

--- a/docs/rules/no-null.md
+++ b/docs/rules/no-null.md
@@ -1,4 +1,4 @@
-# Do not use `null`
+# Disallow the use of the `null` literal.
 
 Disallow the use of the `null` literal, to encourage using `undefined` instead.
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = {
 				'no-nested-ternary': 'off',
 				'unicorn/no-nested-ternary': 'error',
 				'unicorn/no-new-buffer': 'error',
+				'unicorn/no-null': 'error',
 				'unicorn/no-process-exit': 'error',
 				'unicorn/no-unreadable-array-destructuring': 'error',
 				'unicorn/no-unsafe-regex': 'off',

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ Configure it in `package.json`.
 - [no-keyword-prefix](docs/rules/no-keyword-prefix.md) - Disallow identifiers starting with `new` or `class`.
 - [no-nested-ternary](docs/rules/no-nested-ternary.md) - Disallow nested ternary expressions. *(partly fixable)*
 - [no-new-buffer](docs/rules/no-new-buffer.md) - Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`. *(fixable)*
-- [no-null](docs/rules/no-null.md) - Disallow use of `null` literals, to encourage using `undefined` instead.
+- [no-null](docs/rules/no-null.md) - Disallow the use of the `null` literal, to encourage using `undefined` instead.
 - [no-process-exit](docs/rules/no-process-exit.md) - Disallow `process.exit()`.
 - [no-unreadable-array-destructuring](docs/rules/no-unreadable-array-destructuring.md) - Disallow unreadable array destructuring.
 - [no-unsafe-regex](docs/rules/no-unsafe-regex.md) - Disallow unsafe regular expressions.

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ Configure it in `package.json`.
 - [no-keyword-prefix](docs/rules/no-keyword-prefix.md) - Disallow identifiers starting with `new` or `class`.
 - [no-nested-ternary](docs/rules/no-nested-ternary.md) - Disallow nested ternary expressions. *(partly fixable)*
 - [no-new-buffer](docs/rules/no-new-buffer.md) - Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`. *(fixable)*
-- [no-null](docs/rules/no-null.md) - Disallow the use of the `null` literal, to encourage using `undefined` instead.
+- [no-null](docs/rules/no-null.md) - Disallow the use of the `null` literal.
 - [no-process-exit](docs/rules/no-process-exit.md) - Disallow `process.exit()`.
 - [no-unreadable-array-destructuring](docs/rules/no-unreadable-array-destructuring.md) - Disallow unreadable array destructuring.
 - [no-unsafe-regex](docs/rules/no-unsafe-regex.md) - Disallow unsafe regular expressions.

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ Configure it in `package.json`.
 			"no-nested-ternary": "off",
 			"unicorn/no-nested-ternary": "error",
 			"unicorn/no-new-buffer": "error",
+			"unicorn/no-null": "error",
 			"unicorn/no-process-exit": "error",
 			"unicorn/no-unreadable-array-destructuring": "error",
 			"unicorn/no-unsafe-regex": "off",
@@ -110,6 +111,7 @@ Configure it in `package.json`.
 - [no-keyword-prefix](docs/rules/no-keyword-prefix.md) - Disallow identifiers starting with `new` or `class`.
 - [no-nested-ternary](docs/rules/no-nested-ternary.md) - Disallow nested ternary expressions. *(partly fixable)*
 - [no-new-buffer](docs/rules/no-new-buffer.md) - Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`. *(fixable)*
+- [no-null](docs/rules/no-null.md) - Disallow use of `null` literals, to encourage using `undefined` instead.
 - [no-process-exit](docs/rules/no-process-exit.md) - Disallow `process.exit()`.
 - [no-unreadable-array-destructuring](docs/rules/no-unreadable-array-destructuring.md) - Disallow unreadable array destructuring.
 - [no-unsafe-regex](docs/rules/no-unsafe-regex.md) - Disallow unsafe regular expressions.

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -280,7 +280,6 @@ const create = context => {
 		if (dates.length > 1) {
 			uses++;
 			context.report({
-				node: null,
 				loc: comment.loc,
 				messageId: MESSAGE_ID_AVOID_MULTIPLE_DATES,
 				data: {
@@ -295,7 +294,6 @@ const create = context => {
 			const shouldIgnore = options.ignoreDatesOnPullRequests && ci.isPR;
 			if (!shouldIgnore && reachedDate(date)) {
 				context.report({
-					node: null,
 					loc: comment.loc,
 					messageId: MESSAGE_ID_EXPIRED_TODO,
 					data: {
@@ -309,7 +307,6 @@ const create = context => {
 		if (packageVersions.length > 1) {
 			uses++;
 			context.report({
-				node: null,
 				loc: comment.loc,
 				messageId: MESSAGE_ID_AVOID_MULTIPLE_PACKAGE_VERSIONS,
 				data: {
@@ -329,7 +326,6 @@ const create = context => {
 			const compare = semverComparisonForOperator(condition);
 			if (packageVersion && compare(packageVersion, decidedPackageVersion)) {
 				context.report({
-					node: null,
 					loc: comment.loc,
 					messageId: MESSAGE_ID_REACHED_PACKAGE_VERSION,
 					data: {
@@ -356,7 +352,6 @@ const create = context => {
 
 				if (trigger) {
 					context.report({
-						node: null,
 						loc: comment.loc,
 						messageId,
 						data: {
@@ -381,7 +376,6 @@ const create = context => {
 
 			if (compare(targetPackageVersion, todoVersion)) {
 				context.report({
-					node: null,
 					loc: comment.loc,
 					messageId: MESSAGE_ID_VERSION_MATCHES,
 					data: {
@@ -413,7 +407,6 @@ const create = context => {
 
 			if (compare(targetPackageEngineVersion, todoEngine)) {
 				context.report({
-					node: null,
 					loc: comment.loc,
 					messageId: MESSAGE_ID_ENGINE_MATCHES,
 					data: {
@@ -438,7 +431,6 @@ const create = context => {
 				if (parseArgument(testString).type !== 'unknowns') {
 					uses++;
 					context.report({
-						node: null,
 						loc: comment.loc,
 						messageId: MESSAGE_ID_MISSING_AT_SYMBOL,
 						data: {
@@ -456,7 +448,6 @@ const create = context => {
 			if (parseArgument(withoutWhitespaces).type !== 'unknowns') {
 				uses++;
 				context.report({
-					node: null,
 					loc: comment.loc,
 					messageId: MESSAGE_ID_REMOVE_WHITESPACES,
 					data: {

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -30,6 +30,7 @@ const create = context => ({
 
 		const fix = fixer => fixer.replaceText(node, 'undefined');
 
+		/* istanbul ignore next */
 		const {parent = {}} = node;
 		if (isLooseEqual(parent)) {
 			problem.fix = fix;

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -1,0 +1,23 @@
+'use strict';
+const getDocumentationUrl = require('./utils/get-documentation-url');
+
+const create = (context) => ({
+  Literal: (node) => {
+    if (node.raw === 'null') {
+      context.report({
+        node: node,
+        message: 'Use undefined instead of null'
+      });
+    }
+  },
+});
+
+module.exports = {
+  meta: {
+		type: 'suggestion',
+		docs: {
+			url: getDocumentationUrl(__filename)
+		},
+	},
+  create,
+};

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -1,23 +1,29 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
-const create = (context) => ({
-  Literal: (node) => {
-    if (node.raw === 'null') {
-      context.report({
-        node: node,
-        message: 'Use undefined instead of null'
-      });
-    }
-  },
+// The number of chars in "Object.create("
+const objectCreateCharCount = 14;
+const objectCreate = 'Object.create(null';
+// Check if the 14 chars preceding `null` are "Object.create("
+const isObjectCreate = (context, node) => context.getSource(node, objectCreateCharCount) === objectCreate;
+
+const create = context => ({
+	Literal: node => {
+		if (node.raw === 'null' && !isObjectCreate(context, node)) {
+			context.report({
+				node,
+				message: 'Use undefined instead of null'
+			});
+		}
+	}
 });
 
 module.exports = {
-  meta: {
+	meta: {
 		type: 'suggestion',
 		docs: {
 			url: getDocumentationUrl(__filename)
-		},
+		}
 	},
-  create,
+	create
 };

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -38,14 +38,14 @@ const create = context => ({
 			problem.suggest = [
 				{
 					messageId: SUGGESTION_REMOVE_MESSAGE_ID,
-					fix: fixer => fixer.replaceText(node, '')
+					fix: fixer => fixer.remove(node)
 				}
 			];
 		} else if (parent.type === 'VariableDeclarator' && parent.init === node && parent.parent.kind !== 'const') {
 			problem.suggest = [
 				{
 					messageId: SUGGESTION_REMOVE_MESSAGE_ID,
-					fix: fixer => fixer.replaceTextRange([parent.id.range[1], node.range[1]], '')
+					fix: fixer => fixer.removeRange([parent.id.range[1], node.range[1]])
 				}
 			];
 		} else {

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -2,6 +2,10 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const methodSelector = require('./utils/method-selector');
 
+const ERROR_MESSAGE_ID = 'error';
+const SUGGESTION_REPLACE_MESSAGE_ID = 'replace';
+const SUGGESTION_REMOVE_MESSAGE_ID = 'remove';
+
 const objectCreateSelector = methodSelector({
 	object: 'Object',
 	name: 'create',
@@ -15,21 +19,59 @@ const selector = [
 	'[raw="null"]'
 ].join('');
 
+const isLooseEqual = node => node.type === 'BinaryExpression' && ['==', '!='].includes(node.operator);
+
 const create = context => ({
 	[selector]: node => {
-		context.report({
+		const problem = {
 			node,
-			message: 'Use undefined instead of null'
-		});
+			messageId: ERROR_MESSAGE_ID
+		};
+
+		const fix = fixer => fixer.replaceText(node, 'undefined');
+
+		const {parent = {}} = node;
+		if (isLooseEqual(parent)) {
+			problem.fix = fix;
+		} else if (parent.type === 'ReturnStatement' && parent.argument === node) {
+			problem.suggest = [
+				{
+					messageId: SUGGESTION_REMOVE_MESSAGE_ID,
+					fix: fixer => fixer.replaceText(node, '')
+				}
+			];
+		} else if (parent.type === 'VariableDeclarator' && parent.init === node && parent.parent.kind !== 'const') {
+			problem.suggest = [
+				{
+					messageId: SUGGESTION_REMOVE_MESSAGE_ID,
+					fix: fixer => fixer.replaceTextRange([parent.id.range[1], node.range[1]], '')
+				}
+			];
+		} else {
+			problem.suggest = [
+				{
+					messageId: SUGGESTION_REPLACE_MESSAGE_ID,
+					fix
+				}
+			];
+		}
+
+		context.report(problem);
 	}
 });
 
 module.exports = {
+	create,
 	meta: {
 		type: 'suggestion',
 		docs: {
 			url: getDocumentationUrl(__filename)
-		}
-	},
-	create
+		},
+		messages: {
+			[ERROR_MESSAGE_ID]: 'Use `undefined` instead of `null`.',
+			[SUGGESTION_REPLACE_MESSAGE_ID]: 'Replace `null` with `undefined`.',
+			[SUGGESTION_REMOVE_MESSAGE_ID]: 'Remove `null`.'
+		},
+		fixable: true
+	}
 };

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -1,20 +1,26 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
+const methodSelector = require('./utils/method-selector');
 
-// The number of chars in "Object.create("
-const objectCreateCharCount = 14;
-const objectCreate = 'Object.create(null';
-// Check if the 14 chars preceding `null` are "Object.create("
-const isObjectCreate = (context, node) => context.getSource(node, objectCreateCharCount) === objectCreate;
+const objectCreateSelector = methodSelector({
+	object: 'Object',
+	name: 'create',
+	length: 1
+});
+
+const selector = [
+	`:not(${objectCreateSelector})`,
+	'>',
+	'Literal',
+	'[raw="null"]'
+].join('');
 
 const create = context => ({
-	Literal: node => {
-		if (node.raw === 'null' && !isObjectCreate(context, node)) {
-			context.report({
-				node,
-				message: 'Use undefined instead of null'
-			});
-		}
+	[selector]: node => {
+		context.report({
+			node,
+			message: 'Use undefined instead of null'
+		});
 	}
 });
 

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -43,6 +43,10 @@ const create = context => {
 			}
 
 			const fix = fixer => fixer.replaceText(node, 'undefined');
+			const replaceSuggestion = {
+				messageId: SUGGESTION_REPLACE_MESSAGE_ID,
+				fix
+			};
 
 			if (isLooseEqual(parent)) {
 				problem.fix = fix;
@@ -51,21 +55,20 @@ const create = context => {
 					{
 						messageId: SUGGESTION_REMOVE_MESSAGE_ID,
 						fix: fixer => fixer.remove(node)
-					}
+					},
+					replaceSuggestion
 				];
 			} else if (parent.type === 'VariableDeclarator' && parent.init === node && parent.parent.kind !== 'const') {
 				problem.suggest = [
 					{
 						messageId: SUGGESTION_REMOVE_MESSAGE_ID,
 						fix: fixer => fixer.removeRange([parent.id.range[1], node.range[1]])
-					}
+					},
+					replaceSuggestion
 				];
 			} else {
 				problem.suggest = [
-					{
-						messageId: SUGGESTION_REPLACE_MESSAGE_ID,
-						fix
-					}
+					replaceSuggestion
 				];
 			}
 

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -139,7 +139,7 @@ const create = context => {
 							return {identifier: parent};
 						}
 
-						return null;
+						return undefined;
 					}
 
 					if (parent.type === 'MemberExpression') {
@@ -152,7 +152,7 @@ const create = context => {
 							return {identifier: parent};
 						}
 
-						return null;
+						return undefined;
 					}
 
 					if (
@@ -163,7 +163,7 @@ const create = context => {
 							return {identifier: parent};
 						}
 
-						return null;
+						return undefined;
 					}
 
 					if (
@@ -174,7 +174,7 @@ const create = context => {
 							return {identifier: parent};
 						}
 
-						return null;
+						return undefined;
 					}
 
 					return reference;

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -54,7 +54,7 @@ const create = context => {
 	let isDisabled;
 
 	const nodeReturnsSomething = new WeakMap();
-	let codePathInfo = null;
+	let codePathInfo;
 
 	return {
 		onCodePathStart(codePath, node) {

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -4,6 +4,7 @@ const getDocumentationUrl = require('./utils/get-documentation-url');
 const isLiteralValue = require('./utils/is-literal-value');
 
 const isApplySignature = (argument1, argument2) => (
+	// Please remove this file from `test/lint/lint.js` when fixing `null` issue
 	(isLiteralValue(argument1, null) ||
 		argument1.type === 'ThisExpression') &&
 	(argument2.type === 'ArrayExpression' ||

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -148,7 +148,7 @@ list.run()
 					const {line} = error2.eslintMessage;
 
 					console.error(chalk.gray(`${project.repository}/tree/master/${path.relative(destination, file.filePath)}#L${line}`));
-					console.error(chalk.gray(JSON.stringify(error2.eslintMessage, null, 2)));
+					console.error(chalk.gray(JSON.stringify(error2.eslintMessage, undefined, 2)));
 				}
 			}
 		} else {

--- a/test/lint/lint.js
+++ b/test/lint/lint.js
@@ -12,7 +12,13 @@ const unicornRules = new Map(Object.entries(unicorn.rules));
 const cli = new CLIEngine({
 	baseConfig: recommended,
 	useEslintrc: false,
-	fix
+	fix,
+	ignorePattern: [
+		// This can't disable by `eslint-disable` before `xo` update
+		'rules/prefer-reflect-apply.js',
+		// Not sure about `JSON.stringify()` replacer
+		'test/integration/test.js'
+	]
 });
 
 cli.addPlugin('eslint-plugin-unicorn', unicorn);

--- a/test/lint/lint.js
+++ b/test/lint/lint.js
@@ -15,9 +15,7 @@ const cli = new CLIEngine({
 	fix,
 	ignorePattern: [
 		// This can't disable by `eslint-disable` before `xo` update
-		'rules/prefer-reflect-apply.js',
-		// Not sure about `JSON.stringify()` replacer
-		'test/integration/test.js'
+		'rules/prefer-reflect-apply.js'
 	]
 });
 

--- a/test/no-null.js
+++ b/test/no-null.js
@@ -3,9 +3,6 @@ import avaRuleTester from 'eslint-ava-rule-tester';
 import rule from '../rules/no-null';
 
 const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
-	},
 	parserOptions: {
 		sourceType: 'module'
 	}
@@ -19,7 +16,11 @@ const noNullError = {
 ruleTester.run('no-null', rule, {
 	valid: [
 		'let foo',
-		'Object.create(null)'
+		'Object.create(null)',
+		// Not `null`
+		'const foo = "null";',
+		// More/Less arguments
+		'Object.create()'
 	],
 	invalid: [
 		{
@@ -30,6 +31,68 @@ ruleTester.run('no-null', rule, {
 		},
 		{
 			code: 'if (bar === null) {}',
+			errors: [
+				noNullError
+			]
+		},
+		// Not `CallExpression`
+		{
+			code: 'new Object.create(null)',
+			errors: [
+				noNullError
+			]
+		},
+		// Not `MemberExpression`
+		{
+			code: 'create(null)',
+			errors: [
+				noNullError
+			]
+		},
+		// `callee.property` is not a `Identifier`
+		{
+			code: 'Object["create"](null)',
+			errors: [
+				noNullError
+			]
+		},
+		// Computed
+		{
+			code: 'Object[create](null)',
+			errors: [
+				noNullError
+			]
+		},
+		// Not `create`
+		{
+			code: 'Object.notCreate(null)',
+			errors: [
+				noNullError
+			]
+		},
+		// Not `Object`
+		{
+			code: 'NotObject.create(null)',
+			errors: [
+				noNullError
+			]
+		},
+		// `callee.object.type` is not a `Identifier`
+		{
+			code: 'lib.Object.create(null)',
+			errors: [
+				noNullError
+			]
+		},
+		// More/Less arguments
+		{
+			code: 'Object.create(null, "")',
+			errors: [
+				noNullError
+			]
+		},
+		{
+			code: 'Object.create(...[null])',
 			errors: [
 				noNullError
 			]

--- a/test/no-null.js
+++ b/test/no-null.js
@@ -18,14 +18,13 @@ const invalidTestCase = testCase => {
 	const {
 		code,
 		output,
-		suggestionOutput,
-		suggestionMessageId = SUGGESTION_REPLACE_MESSAGE_ID,
+		suggestions,
 		checkStrictEquality
 	} = typeof testCase === 'string' ? {code: testCase} : testCase;
 
 	const options = typeof checkStrictEquality === 'boolean' ? [{checkStrictEquality}] : [];
 
-	if (suggestionOutput) {
+	if (suggestions) {
 		return {
 			code,
 			output: code,
@@ -33,12 +32,7 @@ const invalidTestCase = testCase => {
 			errors: [
 				{
 					messageId: ERROR_MESSAGE_ID,
-					suggestions: [
-						{
-							messageId: suggestionMessageId,
-							output: suggestionOutput
-						}
-					]
+					suggestions
 				}
 			]
 		};
@@ -127,33 +121,74 @@ ruleTester.run('no-null', rule, {
 					return null;
 				}
 			`,
-			suggestionOutput: outdent`
-				function foo() {
-					return ;
+			suggestions: [
+				{
+					messageId: SUGGESTION_REMOVE_MESSAGE_ID,
+					output: outdent`
+						function foo() {
+							return ;
+						}
+					`
+				},
+				{
+					messageId: SUGGESTION_REPLACE_MESSAGE_ID,
+					output: outdent`
+						function foo() {
+							return undefined;
+						}
+					`
 				}
-			`,
-			suggestionMessageId: SUGGESTION_REMOVE_MESSAGE_ID
+			]
 		}),
 
 		// Suggestion `VariableDeclaration`
 		invalidTestCase({
 			code: 'let foo = null;',
-			suggestionOutput: 'let foo;',
-			suggestionMessageId: SUGGESTION_REMOVE_MESSAGE_ID
+			suggestions: [
+				{
+					messageId: SUGGESTION_REMOVE_MESSAGE_ID,
+					output: 'let foo;'
+				},
+				{
+					messageId: SUGGESTION_REPLACE_MESSAGE_ID,
+					output: 'let foo = undefined;'
+				}
+			]
 		}),
 		invalidTestCase({
 			code: 'var foo = null;',
-			suggestionOutput: 'var foo;',
-			suggestionMessageId: SUGGESTION_REMOVE_MESSAGE_ID
+			suggestions: [
+				{
+					messageId: SUGGESTION_REMOVE_MESSAGE_ID,
+					output: 'var foo;'
+				},
+				{
+					messageId: SUGGESTION_REPLACE_MESSAGE_ID,
+					output: 'var foo = undefined;'
+				}
+			]
 		}),
 		invalidTestCase({
 			code: 'var foo = 1, bar = null, baz = 2;',
-			suggestionOutput: 'var foo = 1, bar, baz = 2;',
-			suggestionMessageId: SUGGESTION_REMOVE_MESSAGE_ID
+			suggestions: [
+				{
+					messageId: SUGGESTION_REMOVE_MESSAGE_ID,
+					output: 'var foo = 1, bar, baz = 2;'
+				},
+				{
+					messageId: SUGGESTION_REPLACE_MESSAGE_ID,
+					output: 'var foo = 1, bar = undefined, baz = 2;'
+				}
+			]
 		}),
 		invalidTestCase({
 			code: 'const foo = null;',
-			suggestionOutput: 'const foo = undefined;'
+			suggestions: [
+				{
+					messageId: SUGGESTION_REPLACE_MESSAGE_ID,
+					output: 'const foo = undefined;'
+				}
+			]
 		}),
 
 		// `checkStrictEquality`

--- a/test/no-null.js
+++ b/test/no-null.js
@@ -1,0 +1,38 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-null';
+
+const ruleTester = avaRuleTester(test, {
+	env: {
+		es6: true
+	},
+	parserOptions: {
+		sourceType: 'module'
+	}
+});
+
+const noNullError = {
+	ruleId: 'no-null',
+	message: 'Use undefined instead of null'
+};
+
+ruleTester.run('no-null', rule, {
+	valid: [
+		'let foo',
+		'Object.create(null)'
+	],
+	invalid: [
+		{
+			code: 'const foo = null',
+			errors: [
+				noNullError
+			]
+		},
+		{
+			code: 'if (bar === null) {}',
+			errors: [
+				noNullError
+			]
+		}
+	]
+});

--- a/test/no-null.js
+++ b/test/no-null.js
@@ -68,7 +68,10 @@ ruleTester.run('no-null', rule, {
 		// Not `null`
 		'const foo = "null";',
 		// More/Less arguments
-		'Object.create()'
+		'Object.create()',
+		// Not `null`
+		'Object.create(bar)',
+		'Object.create("null")'
 	],
 	invalid: [
 		invalidTestCase('const foo = null'),

--- a/test/no-null.js
+++ b/test/no-null.js
@@ -1,16 +1,64 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
+import {outdent} from 'outdent';
 import rule from '../rules/no-null';
+
+const ERROR_MESSAGE_ID = 'error';
+const SUGGESTION_REPLACE_MESSAGE_ID = 'replace';
+const SUGGESTION_REMOVE_MESSAGE_ID = 'remove';
 
 const ruleTester = avaRuleTester(test, {
 	parserOptions: {
+		ecmaVersion: 2020,
 		sourceType: 'module'
 	}
 });
 
-const noNullError = {
-	ruleId: 'no-null',
-	message: 'Use undefined instead of null'
+const invalidTestCase = options => {
+	const {
+		code,
+		output,
+		suggestionOutput,
+		suggestionMessageId = SUGGESTION_REPLACE_MESSAGE_ID
+	} = typeof options === 'string' ? {code: options} : options;
+
+	if (suggestionOutput) {
+		return {
+			code,
+			output: code,
+			errors: [
+				{
+					messageId: ERROR_MESSAGE_ID,
+					suggestions: [
+						{
+							messageId: suggestionMessageId,
+							output: suggestionOutput
+						}
+					]}
+			]
+		};
+	}
+
+	if (output) {
+		return {
+			code,
+			output,
+			errors: [
+				{
+					messageId: ERROR_MESSAGE_ID,
+					suggestions: undefined}
+			]
+		};
+	}
+
+	return {
+		code,
+		output: code,
+		errors: [
+			{
+				messageId: ERROR_MESSAGE_ID}
+		]
+	};
 };
 
 ruleTester.run('no-null', rule, {
@@ -23,79 +71,83 @@ ruleTester.run('no-null', rule, {
 		'Object.create()'
 	],
 	invalid: [
-		{
-			code: 'const foo = null',
-			errors: [
-				noNullError
-			]
-		},
-		{
-			code: 'if (bar === null) {}',
-			errors: [
-				noNullError
-			]
-		},
+		invalidTestCase('const foo = null'),
+		invalidTestCase('if (foo === null) {}'),
+
+		// Auto fix
+		invalidTestCase({
+			code: 'if (foo == null) {}',
+			output: 'if (foo == undefined) {}'
+		}),
+		invalidTestCase({
+			code: 'if (foo != null) {}',
+			output: 'if (foo != undefined) {}'
+		}),
+		invalidTestCase({
+			code: 'if (null == foo) {}',
+			output: 'if (undefined == foo) {}'
+		}),
+		invalidTestCase({
+			code: 'if (null != foo) {}',
+			output: 'if (undefined != foo) {}'
+		}),
+
+		// Suggestion `ReturnStatement`
+		invalidTestCase({
+			code: outdent`
+				function foo() {
+					return null;
+				}
+			`,
+			suggestionOutput: outdent`
+				function foo() {
+					return ;
+				}
+			`,
+			suggestionMessageId: SUGGESTION_REMOVE_MESSAGE_ID
+		}),
+
+		// Suggestion `VariableDeclaration`
+		invalidTestCase({
+			code: 'let foo = null;',
+			suggestionOutput: 'let foo;',
+			suggestionMessageId: SUGGESTION_REMOVE_MESSAGE_ID
+		}),
+		invalidTestCase({
+			code: 'var foo = null;',
+			suggestionOutput: 'var foo;',
+			suggestionMessageId: SUGGESTION_REMOVE_MESSAGE_ID
+		}),
+		invalidTestCase({
+			code: 'var foo = 1, bar = null, baz = 2;',
+			suggestionOutput: 'var foo = 1, bar, baz = 2;',
+			suggestionMessageId: SUGGESTION_REMOVE_MESSAGE_ID
+		}),
+		invalidTestCase({
+			code: 'const foo = null;',
+			suggestionOutput: 'const foo = undefined;'
+		}),
+
 		// Not `CallExpression`
-		{
-			code: 'new Object.create(null)',
-			errors: [
-				noNullError
-			]
-		},
+		invalidTestCase('new Object.create(null)'),
 		// Not `MemberExpression`
-		{
-			code: 'create(null)',
-			errors: [
-				noNullError
-			]
-		},
+		invalidTestCase('create(null)'),
 		// `callee.property` is not a `Identifier`
-		{
-			code: 'Object["create"](null)',
-			errors: [
-				noNullError
-			]
-		},
+		invalidTestCase('Object["create"](null)'),
 		// Computed
+		invalidTestCase('Object[create](null)'),
 		{
-			code: 'Object[create](null)',
-			errors: [
-				noNullError
-			]
+			code: 'Object[null](null)',
+			errors: [{}, {}]
 		},
 		// Not `create`
-		{
-			code: 'Object.notCreate(null)',
-			errors: [
-				noNullError
-			]
-		},
+		invalidTestCase('Object.notCreate(null)'),
 		// Not `Object`
-		{
-			code: 'NotObject.create(null)',
-			errors: [
-				noNullError
-			]
-		},
+		invalidTestCase('NotObject.create(null)'),
 		// `callee.object.type` is not a `Identifier`
-		{
-			code: 'lib.Object.create(null)',
-			errors: [
-				noNullError
-			]
-		},
+		invalidTestCase('lib.Object.create(null)'),
 		// More/Less arguments
-		{
-			code: 'Object.create(null, "")',
-			errors: [
-				noNullError
-			]
-		},
-		{
-			code: 'Object.create(...[null])',
-			errors: [
-				noNullError
-			]
-		}
+		invalidTestCase('Object.create(null, "")'),
+		invalidTestCase('Object.create(...[null])')
 	]
 });


### PR DESCRIPTION
Adds a `no-null` rule to disallow use of `null` in favor of `undefined`.

Resolves #612 