### PR TITLE
`prefer-text-content`: Refactor with selector

### DIFF
--- a/rules/prefer-text-content.js
+++ b/rules/prefer-text-content.js
@@ -3,22 +3,21 @@ const getDocumentationUrl = require('./utils/get-documentation-url');
 
 const message = 'Prefer `.textContent` over `.innerText`.';
 
+const selector = [
+	'MemberExpression',
+	'[computed=false]',
+	'[property.type="Identifier"]',
+	'[property.name="innerText"]'
+].join('');
+
 const create = context => {
 	return {
-		MemberExpression: node => {
-			const {property} = node;
-
-			if (
-				property.type === 'Identifier' &&
-				!node.computed &&
-				property.name === 'innerText'
-			) {
-				context.report({
-					node,
-					message,
-					fix: fixer => fixer.replaceText(property, 'textContent')
-				});
-			}
+		[selector]: ({property: node}) => {
+			context.report({
+				node,
+				message,
+				fix: fixer => fixer.replaceText(node, 'textContent')
+			});
 		}
 	};
 };


### PR DESCRIPTION
- Use selector instead of `if`
- Report on `property` instead of whole `MemberExpression`

Before:
![image](https://user-images.githubusercontent.com/172584/77729688-3d795f80-703a-11ea-9ca5-39d3cae09688.png)

After:
![image](https://user-images.githubusercontent.com/172584/77729623-1884ec80-703a-11ea-9abb-c12bf087af1d.png)
