### PR TITLE
`prefer-set-has`: Supports more types of array

### DIFF
--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -1,82 +1,75 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const getReferences = require('./utils/get-references');
+const methodSelector = require('./utils/method-selector');
 
 // `[]`
 const arrayExpressionSelector = [
 	'[init.type="ArrayExpression"]'
-];
+].join('');
 
 // `Array()`
 const ArraySelector = [
 	'[init.type="CallExpression"]',
 	'[init.callee.type="Identifier"]',
 	'[init.callee.name="Array"]'
-];
+].join('');
 
 // `new Array()`
 const newArraySelector = [
 	'[init.type="NewExpression"]',
 	'[init.callee.type="Identifier"]',
 	'[init.callee.name="Array"]'
-];
+].join('');
 
 // `Array.from()`
 // `Array.of()`
-const arrayStaticMethodSelector = [
-	'[init.type="CallExpression"]',
-	'[init.callee.type="MemberExpression"]',
-	'[init.callee.computed=false]',
-	'[init.callee.object.type="Identifier"]',
-	'[init.callee.object.name="Array"]',
-	'[init.callee.property.type="Identifier"]',
-	`:matches(${
-		[
-			'from',
-			'of'
-		].map(method => `[init.callee.property.name="${method}"]`).join(',')
-	})`
-];
+const arrayStaticMethodSelector = methodSelector({
+	object: 'Array',
+	names: ['from', 'of'],
+	property: 'init'
+});
 
-// `foo.concat()`
-// `foo.copyWithin()`
-// `foo.fill()`
-// `foo.filter()`
-// `foo.flat()`
-// `foo.flatMap()`
-// `foo.map()`
-// `foo.reverse()`
-// `foo.slice()`
-// `foo.sort()`
-// `foo.splice()`
-const arrayMethodSelector = [
-	'[init.type="CallExpression"]',
-	'[init.callee.type="MemberExpression"]',
-	'[init.callee.computed=false]',
-	'[init.callee.property.type="Identifier"]',
-	`:matches(${
-		[
-			'concat',
-			'copyWithin',
-			'fill',
-			'filter',
-			'flat',
-			'flatMap',
-			'map',
-			'reverse',
-			'slice',
-			'sort',
-			'splice'
-		].map(method => `[init.callee.property.name="${method}"]`).join(',')
-	})`
-];
+// `array.concat()`
+// `array.copyWithin()`
+// `array.fill()`
+// `array.filter()`
+// `array.flat()`
+// `array.flatMap()`
+// `array.map()`
+// `array.reverse()`
+// `array.slice()`
+// `array.sort()`
+// `array.splice()`
+const arrayMethodSelector = methodSelector({
+	names: [
+		'concat',
+		'copyWithin',
+		'fill',
+		'filter',
+		'flat',
+		'flatMap',
+		'map',
+		'reverse',
+		'slice',
+		'sort',
+		'splice'
+	],
+	property: 'init'
+});
 
 const selector = [
-	':not(ExportNamedDeclaration)',
-	'>',
 	'VariableDeclaration',
+	// Exclude `export const foo = [];`
+	`:not(${
+		[
+			'ExportNamedDeclaration',
+			'>',
+			'VariableDeclaration.declaration'
+		].join('')
+	})`,
 	'>',
-	'VariableDeclarator',
+	'VariableDeclarator.declarations',
 	`:matches(${
 		[
 			arrayExpressionSelector,
@@ -84,11 +77,10 @@ const selector = [
 			newArraySelector,
 			arrayStaticMethodSelector,
 			arrayMethodSelector
-		].map(pieces => pieces.join(''))
-			.join(',')
+		].join(',')
 	})`,
 	'>',
-	'Identifier'
+	'Identifier.id'
 ].join('');
 
 const MESSAGE_ID = 'preferSetHas';

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -2,13 +2,91 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const getReferences = require('./utils/get-references');
 
+// `[]`
+const arrayExpressionSelector = [
+	'[init.type="ArrayExpression"]'
+];
+
+// `Array()`
+const ArraySelector = [
+	'[init.type="CallExpression"]',
+	'[init.callee.type="Identifier"]',
+	'[init.callee.name="Array"]'
+];
+
+// `new Array()`
+const newArraySelector = [
+	'[init.type="NewExpression"]',
+	'[init.callee.type="Identifier"]',
+	'[init.callee.name="Array"]'
+];
+
+// `Array.from()`
+// `Array.of()`
+const arrayStaticMethodSelector = [
+	'[init.type="CallExpression"]',
+	'[init.callee.type="MemberExpression"]',
+	'[init.callee.computed=false]',
+	'[init.callee.object.type="Identifier"]',
+	'[init.callee.object.name="Array"]',
+	'[init.callee.property.type="Identifier"]',
+	`:matches(${
+		[
+			'from',
+			'of'
+		].map(method => `[init.callee.property.name="${method}"]`).join(',')
+	})`
+];
+
+// `foo.concat()`
+// `foo.copyWithin()`
+// `foo.fill()`
+// `foo.filter()`
+// `foo.flat()`
+// `foo.flatMap()`
+// `foo.map()`
+// `foo.reverse()`
+// `foo.slice()`
+// `foo.sort()`
+// `foo.splice()`
+const arrayMethodSelector = [
+	'[init.type="CallExpression"]',
+	'[init.callee.type="MemberExpression"]',
+	'[init.callee.computed=false]',
+	'[init.callee.property.type="Identifier"]',
+	`:matches(${
+		[
+			'concat',
+			'copyWithin',
+			'fill',
+			'filter',
+			'flat',
+			'flatMap',
+			'map',
+			'reverse',
+			'slice',
+			'sort',
+			'splice'
+		].map(method => `[init.callee.property.name="${method}"]`).join(',')
+	})`
+];
+
 const selector = [
 	':not(ExportNamedDeclaration)',
 	'>',
 	'VariableDeclaration',
 	'>',
 	'VariableDeclarator',
-	'[init.type="ArrayExpression"]',
+	`:matches(${
+		[
+			arrayExpressionSelector,
+			ArraySelector,
+			newArraySelector,
+			arrayStaticMethodSelector,
+			arrayMethodSelector
+		].map(pieces => pieces.join(''))
+			.join(',')
+	})`,
 	'>',
 	'Identifier'
 ].join('');

--- a/rules/utils/method-selector.js
+++ b/rules/utils/method-selector.js
@@ -7,18 +7,21 @@ module.exports = options => {
 		length,
 		object,
 		min,
-		max
+		max,
+		property = ''
 	} = {
 		min: 0,
 		max: Infinity,
 		...options
 	};
 
+	const prefix = property ? `${property}.` : '';
+
 	const selector = [
-		'CallExpression',
-		'[callee.type="MemberExpression"]',
-		'[callee.computed=false]',
-		'[callee.property.type="Identifier"]'
+		`[${prefix}type="CallExpression"]`,
+		`[${prefix}callee.type="MemberExpression"]`,
+		`[${prefix}callee.computed=false]`,
+		`[${prefix}callee.property.type="Identifier"]`
 	];
 
 	if (name) {
@@ -28,33 +31,33 @@ module.exports = options => {
 	if (Array.isArray(names) && names.length !== 0) {
 		selector.push(
 			':matches(' +
-			names.map(name => `[callee.property.name="${name}"]`).join(', ') +
+			names.map(name => `[${prefix}callee.property.name="${name}"]`).join(', ') +
 			')'
 		);
 	}
 
 	if (object) {
-		selector.push('[callee.object.type="Identifier"]');
-		selector.push(`[callee.object.name="${object}"]`);
+		selector.push(`[${prefix}callee.object.type="Identifier"]`);
+		selector.push(`[${prefix}callee.object.name="${object}"]`);
 	}
 
 	if (typeof length === 'number') {
-		selector.push(`[arguments.length=${length}]`);
+		selector.push(`[${prefix}arguments.length=${length}]`);
 	}
 
 	if (min !== 0) {
-		selector.push(`[arguments.length>=${min}]`);
+		selector.push(`[${prefix}arguments.length>=${min}]`);
 	}
 
 	if (Number.isFinite(max)) {
-		selector.push(`[arguments.length<=${max}]`);
+		selector.push(`[${prefix}arguments.length<=${max}]`);
 	}
 
 	const maxArguments = Number.isFinite(max) ? max : length;
 	if (typeof maxArguments === 'number') {
 		// Exclude arguments with `SpreadElement` type
 		for (let index = 0; index < maxArguments; index += 1) {
-			selector.push(`[arguments.${index}.type!="SpreadElement"]`);
+			selector.push(`[${prefix}arguments.${index}.type!="SpreadElement"]`);
 		}
 	}
 

--- a/test/prefer-set-has.js
+++ b/test/prefer-set-has.js
@@ -21,6 +21,20 @@ const createError = name => [
 	}
 ];
 
+const methodsReturnsArray = [
+	'concat',
+	'copyWithin',
+	'fill',
+	'filter',
+	'flat',
+	'flatMap',
+	'map',
+	'reverse',
+	'slice',
+	'sort',
+	'splice'
+];
+
 ruleTester.run(ruleId, rule, {
 	valid: [
 		outdent`
@@ -84,17 +98,8 @@ ruleTester.run(ruleId, rule, {
 			const exists = foo.includes(1);
 		`,
 
-		// Not `ArrayExpression`, maybe we can enable some of those later
 		outdent`
 			const foo = bar;
-			const exists = foo.includes(1);
-		`,
-		outdent`
-			const foo = [1, 2, 3].slice();
-			const exists = foo.includes(1);
-		`,
-		outdent`
-			const foo = Array.from(bar);
 			const exists = foo.includes(1);
 		`,
 
@@ -171,6 +176,100 @@ ruleTester.run(ruleId, rule, {
 			const foo = [1, 2, 3];
 			module.exports.foo = foo;
 			const exists = foo.includes(1);
+		`,
+
+		// `Array()`
+		outdent`
+			const foo = NotArray(1, 2);
+			const exists = foo.includes(1);
+		`,
+
+		// `new Array()`
+		outdent`
+			const foo = new NotArray(1, 2);
+			const exists = foo.includes(1);
+		`,
+
+		// `Array.from()` / `Array.of()`
+		// Not `Array`
+		outdent`
+			const foo = NotArray.from({length: 1}, (_, index) => index);
+			const exists = foo.includes(1);
+		`,
+		outdent`
+			const foo = NotArray.of(1, 2);
+			const exists = foo.includes(1);
+		`,
+		// Not `Listed`
+		outdent`
+			const foo = Array.notListed();
+			const exists = foo.includes(1);
+		`,
+		// Computed
+		outdent`
+			const foo = Array[from]({length: 1}, (_, index) => index);
+			const exists = foo.includes(1);
+		`,
+		outdent`
+			const foo = Array[of](1, 2);
+			const exists = foo.includes(1);
+		`,
+		// Not Identifier
+		outdent`
+			const foo = 'Array'.from({length: 1}, (_, index) => index);
+			const exists = foo.includes(1);
+		`,
+		outdent`
+			const foo = 'Array'.of(1, 2);
+			const exists = foo.includes(1);
+		`,
+		outdent`
+			const foo = Array['from']({length: 1}, (_, index) => index);
+			const exists = foo.includes(1);
+		`,
+		outdent`
+			const foo = Array['of'](1, 2);
+			const exists = foo.includes(1);
+		`,
+
+		outdent`
+			const foo = of(1, 2);
+			const exists = foo.includes(1);
+		`,
+		outdent`
+			const foo = from({length: 1}, (_, index) => index);
+			const exists = foo.includes(1);
+		`,
+
+		// Methods
+		// Not call
+		...methodsReturnsArray.map(method => outdent`
+			const foo = bar.${method};
+			const exists = foo.includes(1);
+		`),
+		...methodsReturnsArray.map(method => outdent`
+			const foo = new bar.${method}();
+			const exists = foo.includes(1);
+		`),
+		// Not MemberExpression
+		...methodsReturnsArray.map(method => outdent`
+			const foo = ${method}();
+			const exists = foo.includes(1);
+		`),
+		// Computed
+		...methodsReturnsArray.map(method => outdent`
+			const foo = bar[${method}]();
+			const exists = foo.includes(1);
+		`),
+		// Not `Identifier`
+		...methodsReturnsArray.map(method => outdent`
+			const foo = bar["${method}"]();
+			const exists = foo.includes(1);
+		`),
+		// Not listed method
+		outdent`
+			const foo = bar.notListed();
+			const exists = foo.includes(1);
 		`
 	],
 	invalid: [
@@ -238,6 +337,71 @@ ruleTester.run(ruleId, rule, {
 				...createError('foo'),
 				...createError('bar')
 			]
-		}
+		},
+
+		// `Array()`
+		{
+			code: outdent`
+				const foo = Array(1, 2);
+				const exists = foo.includes(1);
+			`,
+			output: outdent`
+				const foo = new Set(Array(1, 2));
+				const exists = foo.has(1);
+			`,
+			errors: createError('foo')
+		},
+
+		// `new Array()`
+		{
+			code: outdent`
+				const foo = new Array(1, 2);
+				const exists = foo.includes(1);
+			`,
+			output: outdent`
+				const foo = new Set(new Array(1, 2));
+				const exists = foo.has(1);
+			`,
+			errors: createError('foo')
+		},
+
+		// `Array.from()`
+		{
+			code: outdent`
+				const foo = Array.from({length: 1}, (_, index) => index);
+				const exists = foo.includes(1);
+			`,
+			output: outdent`
+				const foo = new Set(Array.from({length: 1}, (_, index) => index));
+				const exists = foo.has(1);
+			`,
+			errors: createError('foo')
+		},
+
+		// `Array.of()`
+		{
+			code: outdent`
+				const foo = Array.of(1, 2);
+				const exists = foo.includes(1);
+			`,
+			output: outdent`
+				const foo = new Set(Array.of(1, 2));
+				const exists = foo.has(1);
+			`,
+			errors: createError('foo')
+		},
+
+		// Methods
+		...methodsReturnsArray.map(method => ({
+			code: outdent`
+				const foo = bar.${method}();
+				const exists = foo.includes(1);
+			`,
+			output: outdent`
+				const foo = new Set(bar.${method}());
+				const exists = foo.has(1);
+			`,
+			errors: createError('foo')
+		}))
 	]
 });


### PR DESCRIPTION
Previously, we only check `variable` init with `[…]`.

I've thinking about this for a few days, I'd like to expand more types of array, including

- `new Array()`
- `Array()`
- `Array.from()`
- `Array.of()`
- `array.concat()`
- `array.copyWithin()`
- `array.fill()`
- `array.filter()`
- `array.flat()`
- `array.flatMap()`
- `array.map()`
- `array.reverse()`
- `array.slice()`
- `array.sort()`
- `array.splice()`

This could be very useful when define an array with `[1,2,3].map(…)` or `Array.from({…}, …)` (I use both a lot).

In this rule, we require those variables call `.includes()`, so the odds that those variables not `array` is very low.

For `lodash.includes(collection, value)`, it requires two arguments, we only check `.includes()` with one argument, so this won't be a problem.

I also considered this case,

```js
const foo = lodash([1,2,3]);
const bar = foo.map(v => v); // <-- bar is a `LodashWrapper` object.
if (bar.includes(1)){}
```

This will fix to 

```js
const foo = lodash([1,2,3]);
const bar = new Set(foo.map(v => v));
if (bar.has(1)){}
```

In this case `bar` is not an `array`, but this fixed code can work, bacause it's [`iterable`](https://lodash.com/docs/4.17.15#prototype-Symbol-iterator)