### PR TITLE
`throw-new-error`: Minor refactor

### DIFF
--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -1,18 +1,23 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
+const selector = [
+	'ThrowStatement',
+	'[argument.type="CallExpression"]',
+	'[argument.callee.type="Identifier"]'
+].join('');
 const customError = /^(?:[A-Z][\da-z]*)*Error$/;
+const message = 'Use `new` when throwing an error.';
 
 const create = context => ({
-	ThrowStatement: node => {
-		const {argument} = node;
-		const error = argument.callee;
+	[selector]: ({argument: error}) => {
+		const errorConstructor = error.callee;
 
-		if (argument.type === 'CallExpression' && customError.test(error.name)) {
+		if (customError.test(errorConstructor.name)) {
 			context.report({
-				node,
-				message: 'Use `new` when throwing an error.',
-				fix: fixer => fixer.insertTextBefore(error, 'new ')
+				node: error,
+				message,
+				fix: fixer => fixer.insertTextBefore(errorConstructor, 'new ')
 			});
 		}
 	}

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -3,21 +3,20 @@ const getDocumentationUrl = require('./utils/get-documentation-url');
 
 const selector = [
 	'ThrowStatement',
-	'[argument.type="CallExpression"]',
-	'[argument.callee.type="Identifier"]'
+	'>',
+	'CallExpression',
+	'[callee.type="Identifier"]'
 ].join('');
 const customError = /^(?:[A-Z][\da-z]*)*Error$/;
 const message = 'Use `new` when throwing an error.';
 
 const create = context => ({
-	[selector]: ({argument: error}) => {
-		const errorConstructor = error.callee;
-
-		if (customError.test(errorConstructor.name)) {
+	[selector]: node => {
+		if (customError.test(node.callee.name)) {
 			context.report({
-				node: error,
+				node,
 				message,
-				fix: fixer => fixer.insertTextBefore(errorConstructor, 'new ')
+				fix: fixer => fixer.insertTextBefore(node, 'new ')
 			});
 		}
 	}

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -22,7 +22,14 @@ ruleTester.run('new-error', rule, {
 		'throw new URIError()',
 		'throw new CustomError()',
 		'throw new FooBarBazError()',
-		'throw new ABCError()'
+		'throw new ABCError()',
+
+		// Not `FooError` like
+		'throw getError()',
+		// Not `CallExpression`
+		'throw CustomError',
+		// Not `Identifier`
+		'throw lib.Error()'
 	],
 	invalid: [
 		{


### PR DESCRIPTION
- Add `Identifier` check to avoid `customError` test on `undefined`
- Report on `error` instead of `ThrowStatement`

Before:
![image](https://user-images.githubusercontent.com/172584/77887038-744eb000-729c-11ea-803a-64eced481fb2.png)

After:
![image](https://user-images.githubusercontent.com/172584/77887225-cdb6df00-729c-11ea-97ab-fe39d687e3b3.png)

- 100% coverage