### PR TITLE
`catch-error-name`: Only allow `_` when it's not used

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -4,7 +4,9 @@ Applies to both `try/catch` clauses and `promise.catch(…)` handlers.
 
 The desired name is configurable, but defaults to `error`.
 
-This rule is fixable unless the reported code was destructuring an error.
+The error name `_` is ignored, if the error is not used.
+
+This rule is fixable.
 
 ## Fail
 
@@ -93,12 +95,12 @@ You can set the `name` option like this:
 "unicorn/catch-error-name": [
 	"error",
 	{
-		"caughtErrorsIgnorePattern": "^_$"
+		"caughtErrorsIgnorePattern": "^error\\d*$"
 	}
 ]
 ```
 
-This option lets you specify a regex pattern for matches to ignore. The default allows `_` and descriptive names like `networkError`.
+This option lets you specify a regex pattern for matches to ignore. The default allows descriptive names like `networkError`.
 
 With `^unicorn$`, this would fail:
 

--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -4,7 +4,7 @@ Applies to both `try/catch` clauses and `promise.catch(…)` handlers.
 
 The desired name is configurable, but defaults to `error`.
 
-The error name `_` is ignored, if the error is not used.
+The error name `_` is ignored if the error is not used.
 
 This rule is fixable.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.1.0",
 		"eslint-template-visitor": "^1.1.0",
-		"eslint-utils": "2.0.0",
+		"eslint-utils": "^2.0.0",
 		"import-modules": "^2.0.0",
 		"lodash": "^4.17.15",
 		"read-pkg-up": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.1.0",
 		"eslint-template-visitor": "^1.1.0",
+		"eslint-utils": "2.0.0",
 		"import-modules": "^2.0.0",
 		"lodash": "^4.17.15",
 		"read-pkg-up": "^7.0.1",

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -1,5 +1,6 @@
 'use strict';
 const astUtils = require('eslint-ast-utils');
+const { findVariable } = require("eslint-utils")
 const avoidCapture = require('./utils/avoid-capture');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const renameIdentifier = require('./utils/rename-identifier');
@@ -44,18 +45,18 @@ const create = context => {
 	function check(parameter, node) {
 		if (
 			parameter.type !== 'Identifier' ||
-			ignoreRegex.test(parameter.name) ||
-			(
-				parameter.name === '_' &&
-				// Should be `node.body.body` in `CatchClause`, body also not right
-				// will fix it when fixing #648
-				!astUtils.someContainIdentifier('_', node.body)
-			)
+			ignoreRegex.test(parameter.name)
 		) {
 			return;
 		}
 
 		const scope = context.getScope();
+		const variable = findVariable(scope, parameter);
+
+		if (parameter.name === '_' && variable.references.length === 0) {
+			return;
+		}
+
 		const fixed = avoidCapture(name, [scope.variableScope], ecmaVersion);
 
 		if (parameter.name === fixed) {

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -1,6 +1,5 @@
 'use strict';
-const astUtils = require('eslint-ast-utils');
-const { findVariable } = require("eslint-utils")
+const {findVariable} = require('eslint-utils');
 const avoidCapture = require('./utils/avoid-capture');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const renameIdentifier = require('./utils/rename-identifier');

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -178,7 +178,10 @@ ruleTester.run('catch-error-name', rule, {
 			}
 		`,
 		'try {} catch (descriptiveError) {}',
-		'try {} catch (descriptiveerror) {}'
+		'try {} catch (descriptiveerror) {}',
+		'try {} catch ({message}) {}',
+		'obj.catch(function ({message}) {})',
+		'obj.catch(({message}) => {})'
 	],
 
 	invalid: [
@@ -211,7 +214,6 @@ ruleTester.run('catch-error-name', rule, {
 			`,
 			name: 'err'
 		}),
-		invalidTestCase('try {} catch ({message}) {}'),
 		{
 			code: 'try {} catch (outerError) {}',
 			output: 'try {} catch (error) {}',
@@ -251,7 +253,6 @@ ruleTester.run('catch-error-name', rule, {
 			output: 'obj.catch(err => err.stack)',
 			name: 'err'
 		}),
-		invalidTestCase('obj.catch(({message}) => {})'),
 		invalidTestCase({
 			code: outdent`
 				obj.catch(function (err) {
@@ -264,7 +265,6 @@ ruleTester.run('catch-error-name', rule, {
 				})
 			`
 		}),
-		invalidTestCase('obj.catch(function ({message}) {})'),
 		invalidTestCase({
 			code: outdent`
 				obj.catch(function (error) {

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -138,8 +138,6 @@ ruleTester.run('catch-error-name', rule, {
 			})
 		`,
 		'obj.catch()',
-		'obj.catch(_ => { console.log(_); })',
-		'obj.catch(function (_) { console.log(_); })',
 		'foo(function (error) {})',
 		'foo().then(function (error) {})',
 		'foo().catch(function (error) {})',
@@ -150,16 +148,6 @@ ruleTester.run('catch-error-name', rule, {
 				try {
 				} catch (_) {}
 			}
-		`,
-		'try {} catch (_) { console.log(_); }',
-		outdent`
-				const handleError = error => {
-					try {
-						doSomething();
-					} catch (_) {
-						console.log(_);
-					}
-				}
 		`,
 		'obj.catch(_ => {})',
 		{
@@ -475,7 +463,68 @@ ruleTester.run('catch-error-name', rule, {
 					caughtErrorsIgnorePattern: '^_$'
 				}
 			]
-		}
+		},
+
+		// `_`
+		invalidTestCase({
+			code: outdent`
+				obj.catch(_ => {
+					console.log(_);
+				})
+			`,
+			output: outdent`
+				obj.catch(error => {
+					console.log(error);
+				})
+			`
+		}),
+		invalidTestCase({
+			code: outdent`
+				obj.catch(function (_) {
+					console.log(_);
+				})
+			`,
+			output: outdent`
+				obj.catch(function (error) {
+					console.log(error);
+				})
+			`
+		}),
+		invalidTestCase({
+			code: outdent`
+				try {
+				} catch (_) {
+					console.log(_);
+				}
+			`,
+			output: outdent`
+				try {
+				} catch (error) {
+					console.log(error);
+				}
+			`
+		}),
+		// TODO: this should fix to `error`, not `error_`
+		invalidTestCase({
+			code: outdent`
+				const handleError = error => {
+					try {
+						doSomething();
+					} catch (_) {
+						console.log(_);
+					}
+				}
+			`,
+			output: outdent`
+				const handleError = error => {
+					try {
+						doSomething();
+					} catch (error_) {
+						console.log(error_);
+					}
+				}
+			`
+		}),
 	]
 });
 

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -30,8 +30,6 @@ function invalidTestCase(options) {
 ruleTester.run('catch-error-name', rule, {
 	valid: [
 		'try {} catch (error) {}',
-		'try {} catch (_) {}',
-		'try {} catch (_) { console.log(foo); }',
 		{
 			code: 'try {} catch (err) {}',
 			options: [{name: 'err'}]
@@ -112,8 +110,6 @@ ruleTester.run('catch-error-name', rule, {
 			}
 		`,
 		'obj.catch(() => {})',
-		'obj.catch((_) => {})',
-		'obj.catch((_) => { console.log(foo); })',
 		{
 			code: 'obj.catch(err => {})',
 			options: [{name: 'err'}]
@@ -141,8 +137,6 @@ ruleTester.run('catch-error-name', rule, {
 		'foo(function (error) {})',
 		'foo().then(function (error) {})',
 		'foo().catch(function (error) {})',
-		'try {} catch (_) {}',
-		'obj.catch(_ => {})',
 		{
 			code: 'try {} catch (skipErr) {}',
 			options: [
@@ -164,6 +158,12 @@ ruleTester.run('catch-error-name', rule, {
 		'obj.catch(function ({message}) {})',
 		'obj.catch(({message}) => {})',
 
+		// `_`
+		'obj.catch(_ => {})',
+		'obj.catch((_) => {})',
+		'obj.catch((_) => { console.log(foo); })',
+		'try {} catch (_) {}',
+		'try {} catch (_) { console.log(foo); }',
 		outdent`
 			try {
 			} catch (_) {

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -600,7 +600,7 @@ ruleTester.run('catch-error-name', rule, {
 				}
 			`,
 			errors: [{ruleId: 'catch-error-name'}, {ruleId: 'catch-error-name'}]
-		},
+		}
 	]
 });
 


### PR DESCRIPTION
Fixes #648