### PR TITLE
`catch-error-name`: Add nesting tests

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -37,18 +37,6 @@ somePromise.catch(error => {})
 ```js
 try {
 	doSomething();
-} catch (anyName) { // Nesting of catch clauses disables the rule
-	try {
-		doSomethingElse();
-	} catch (anyOtherName) {
-		// ...
-	}
-}
-```
-
-```js
-try {
-	doSomething();
 } catch (_) {
 	// `_` is allowed when the error is not used
 	console.log(foo);

--- a/test/catch-error-name.js
+++ b/test/catch-error-name.js
@@ -278,17 +278,6 @@ ruleTester.run('catch-error-name', rule, {
 			`,
 			name: 'err'
 		}),
-		// Failing tests for #107
-		// invalidTestCase(outdent`
-		// 	foo.then(() => {
-		// 		try {} catch (e) {}
-		// 	}).catch(error => error);
-		// `),
-		// invalidTestCase(outdent`
-		// 	foo.then(() => {
-		// 		try {} catch (e) {}
-		// 	});
-		// `),
 		{
 			code: outdent`
 				const handleError = error => {
@@ -478,6 +467,30 @@ ruleTester.run('catch-error-name', rule, {
 		},
 
 		// #107
+		invalidTestCase({
+			code: outdent`
+				foo.then(() => {
+					try {} catch (e) {}
+				}).catch(error => error);
+			`,
+			output: outdent`
+				foo.then(() => {
+					try {} catch (error) {}
+				}).catch(error => error);
+			`
+		}),
+		invalidTestCase({
+			code: outdent`
+				foo.then(() => {
+					try {} catch (e) {}
+				});
+			`,
+			output: outdent`
+				foo.then(() => {
+					try {} catch (error) {}
+				});
+			`
+		}),
 		{
 			code: outdent`
 				foo.then(() => {


### PR DESCRIPTION
Add tests to confirm #107 is fixed by #647

Closes #107


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#107: `catch-error-name` fails when try/catch is inside a promise that is caught](https://issuehunt.io/repos/55832243/issues/107)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->