### PR TITLE
`catch-error-name`: Allow more names by default, update `ignore` option

### DIFF
--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -8,7 +8,7 @@ The following names are ignored:
 
 - `_`, but only if the error is not used.
 - Descriptive names, for example, `fsError` or `authError`.
-- Names matches [options.ignore](#ignore).
+- Names matching [`options.ignore`](#ignore).
 
 This rule is fixable.
 
@@ -69,6 +69,9 @@ somePromise.catch(_ => {
 ## Options
 
 ### name
+
+Type: `string`\
+Default: `'error'`
 
 You can set the `name` option like this:
 

--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -2,9 +2,13 @@
 
 Applies to both `try/catch` clauses and `promise.catch(…)` handlers.
 
-The desired name is configurable, but defaults to `error`.
+The desired name is [configurable](#name), but defaults to `error`.
 
-The error name `_` is ignored if the error is not used.
+The following names are ignored:
+
+- `_`, but only if the error is not used.
+- Descriptive names, for example, `fsError` or `authError`.
+- Names matches [options.ignore](#ignore).
 
 This rule is fixable.
 
@@ -77,18 +81,26 @@ You can set the `name` option like this:
 ]
 ```
 
-### caughtErrorsIgnorePattern
+### ignore
+
+Type: `Array<string | RegExp>`\
+Default: `[]`
+
+This option lets you specify a regex pattern for matches to ignore.
+
+When a string is given, it's interpreted as a regular expressions inside a string. Needed for ESLint config in JSON.
 
 ```js
 "unicorn/catch-error-name": [
 	"error",
 	{
-		"caughtErrorsIgnorePattern": "^error\\d*$"
+		"ignore": [
+			"^error\\d*$",
+			/^ignore/i
+		]
 	}
 ]
 ```
-
-This option lets you specify a regex pattern for matches to ignore. The default allows descriptive names like `networkError`.
 
 With `^unicorn$`, this would fail:
 
@@ -112,4 +124,4 @@ try {
 
 ## Tip
 
-In order to avoid shadowing in nested catch clauses, the auto-fix rule appends underscores to the identifier name. Since this might be hard to read, the default setting for `caughtErrorsIgnorePattern` allows the use of descriptive names instead, for example, `fsError` or `authError`.
+In order to avoid shadowing in nested catch clauses, the auto-fix rule appends underscores to the identifier name.

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -33,21 +33,27 @@ const create = context => {
 	const {ecmaVersion} = context.parserOptions;
 	const sourceCode = context.getSourceCode();
 
-	const {name, caughtErrorsIgnorePattern} = {
+	const options = {
 		name: 'error',
-		caughtErrorsIgnorePattern: /^[\dA-Za-z]+[Ee]rror$/.source,
+		ignore: [],
 		...context.options[0]
 	};
-	const ignoreRegex = new RegExp(caughtErrorsIgnorePattern);
+	const {name: expectedName} = options;
+	const ignore = options.ignore.map(
+		pattern => pattern instanceof RegExp ? pattern : new RegExp(pattern, 'u')
+	);
+	const isNameAllowed = name =>
+		name === expectedName ||
+		ignore.some(regexp => regexp.test(name)) ||
+		name.endsWith(expectedName) ||
+		name.endsWith(expectedName.charAt(0).toUpperCase() + expectedName.slice(1));
 
 	function check(node) {
 		const originalName = node.name;
-		const cleanName = originalName.replace(/_+$/g, '');
 
 		if (
-			cleanName === name ||
-			ignoreRegex.test(originalName) ||
-			ignoreRegex.test(cleanName)
+			isNameAllowed(originalName) ||
+			isNameAllowed(originalName.replace(/_+$/g, ''))
 		) {
 			return;
 		}
@@ -63,7 +69,7 @@ const create = context => {
 			variable.scope,
 			...variable.references.map(({from}) => from)
 		];
-		const fixed = avoidCapture(name, scopes, ecmaVersion);
+		const fixed = avoidCapture(expectedName, scopes, ecmaVersion);
 
 		context.report({
 			node,
@@ -92,8 +98,9 @@ const schema = [
 			name: {
 				type: 'string'
 			},
-			caughtErrorsIgnorePattern: {
-				type: 'string'
+			ignore: {
+				type: 'array',
+				uniqueItems: true
 			}
 		}
 	}


### PR DESCRIPTION
Update logic.

Allways ignore descriptive names, like `fsError`.
If use `name:"unicorn"`, `fsUnicorn` will be ignore, but `fsError` will reported.

Note: I changed the old `/^[\dA-Za-z]+[Ee]rror$/` test to check name ends with `error`/`Error`(or configured name), so something like `_error`/`$error` will get pass.

change `caughtErrorsIgnorePattern` option to `ignore`, and accept `Array<string | RegExp>`.


Fixes #656