### PR TITLE
`prevent-abbreviations`: Allow ignore words contains number

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -304,6 +304,14 @@ const getNameReplacements = (name, options, limit = 3) => {
 		};
 	}
 
+	const whitelistWordPlaceholders = [];
+	for (const whitelistWord of whitelist.keys()) {
+		if (/\d/.test(whitelistWord) && name.includes(whitelistWord)) {
+			const index = whitelistWordPlaceholders.push(whitelistWord);
+			name = name.split(whitelistWord).join(`\0placeholder_${index}_placeholder\0`)
+		}
+	}
+
 	// Split words
 	const words = name.split(/(?=[^a-z])|(?<=[^A-Za-z])/).filter(Boolean);
 
@@ -329,9 +337,14 @@ const getNameReplacements = (name, options, limit = 3) => {
 		samples
 	} = cartesianProductSamples(combinations, limit);
 
+	const restoreWhitelistPlaceHolders = name => name.replace(
+		/\0placeholder_(\d+)_placeholder\0/,
+		(_, index) => whitelistWordPlaceholders[index]
+	);
+
 	return {
 		total,
-		samples: samples.map(words => words.join(''))
+		samples: samples.map(words => restoreWhitelistPlaceHolders(words.join('')))
 	};
 };
 

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -306,11 +306,13 @@ const getNameReplacements = (name, options, limit = 3) => {
 
 	const whitelistWordPlaceholders = [];
 	for (const whitelistWord of whitelist.keys()) {
-		if (/\d/.test(whitelistWord) && name.includes(whitelistWord)) {
-			const index = whitelistWordPlaceholders.push(whitelistWord);
+		if (/\d/.test(whitelistWord)) {
 			name = name.replace(
-				new RegExp(`(?<=[^A-Za-z])${whitelistWord}(?<=[^A-Za-z])`, 'g')
-				`\0placeholder_${index}_placeholder\0`
+				new RegExp(`(?<![a-z])${whitelistWord}(?![a-z])`, 'ig'),
+				word => {
+					const index = whitelistWordPlaceholders.push(word);
+					return `\0placeholder_${index}_placeholder\0`;
+				}
 			);
 		}
 	}

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -308,7 +308,10 @@ const getNameReplacements = (name, options, limit = 3) => {
 	for (const whitelistWord of whitelist.keys()) {
 		if (/\d/.test(whitelistWord) && name.includes(whitelistWord)) {
 			const index = whitelistWordPlaceholders.push(whitelistWord);
-			name = name.split(whitelistWord).join(`\0placeholder_${index}_placeholder\0`)
+			name = name.replace(
+				new RegExp(`(?<=[^A-Za-z])${whitelistWord}(?<=[^A-Za-z])`, 'g')
+				`\0placeholder_${index}_placeholder\0`
+			);
 		}
 	}
 

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -283,6 +283,27 @@ ruleTester.run('prevent-abbreviations', rule, {
 		{
 			code: 'const propTypes = 2;const err = 2;',
 			options: extendDefaultWhitelistOptions
+		},
+
+		// special `whitelist`
+		// #567
+		{
+			code: 'const is_e2e = true;',
+			options: [{whitelist: {e2e: true}}]
+		},
+		{
+			code: 'foo();',
+			filename: 'some.spec.e2e.js',
+			options: [{whitelist: {e2e: true}}]
+		},
+		{
+			code: 'const e2e_and_e2e = true;',
+			options: [{whitelist: {e2e: true}}]
+		},
+		{
+			code: 'foo();',
+			filename: 'e2e.spec.e2e.js',
+			options: [{whitelist: {e2e: true}}]
 		}
 	],
 
@@ -1226,6 +1247,14 @@ ruleTester.run('prevent-abbreviations', rule, {
 			code: 'const propTypes = 2;const err = 2;',
 			output: 'const propertyTypes = 2;const err = 2;',
 			options: noExtendDefaultWhitelistOptions,
+			errors: createErrors()
+		},
+
+		// special `whitelist`
+		{
+			code: 'const err = 1',
+			output: 'const error = 1',
+			options: [{whitelist: {e: true}}], // Should not replace `e`
 			errors: createErrors()
 		}
 	]

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -285,15 +285,24 @@ ruleTester.run('prevent-abbreviations', rule, {
 			options: extendDefaultWhitelistOptions
 		},
 
-		// special `whitelist`
+		// Special `whitelist`
 		// #567
 		{
 			code: 'const is_e2e = true;',
 			options: [{whitelist: {e2e: true}}]
 		},
 		{
+			code: 'const is_E2e = true;',
+			options: [{whitelist: {e2e: true}}]
+		},
+		{
 			code: 'foo();',
 			filename: 'some.spec.e2e.js',
+			options: [{whitelist: {e2e: true}}]
+		},
+		{
+			code: 'foo();',
+			filename: 'some.spec.e2E.js',
 			options: [{whitelist: {e2e: true}}]
 		},
 		{
@@ -1250,7 +1259,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 			errors: createErrors()
 		},
 
-		// special `whitelist`
+		// Special `whitelist`
 		{
 			code: 'const err = 1',
 			output: 'const error = 1',
@@ -1262,7 +1271,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 			output: 'const tree2error = 1',
 			options: [{whitelist: {e2e: true}}],
 			errors: createErrors()
-		},
+		}
 	]
 });
 

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1256,7 +1256,13 @@ ruleTester.run('prevent-abbreviations', rule, {
 			output: 'const error = 1',
 			options: [{whitelist: {e: true}}], // Should not replace `e`
 			errors: createErrors()
-		}
+		},
+		{
+			code: 'const tree2err = 1',
+			output: 'const tree2error = 1',
+			options: [{whitelist: {e2e: true}}],
+			errors: createErrors()
+		},
 	]
 });
 


### PR DESCRIPTION
Only replace whitelist word contains number, we can add more if we find other cases.

Fixes #567