### PR TITLE
`no-nested-ternary`: Fix incorrect result with TypeScript parser

### DIFF
--- a/rules/no-nested-ternary.js
+++ b/rules/no-nested-ternary.js
@@ -1,18 +1,6 @@
 'use strict';
+const {isParenthesized} = require('eslint-utils');
 const getDocumentationUrl = require('./utils/get-documentation-url');
-
-const isParenthesized = (sourceCode, node) => {
-	const previousToken = sourceCode.getTokenBefore(node);
-	const nextToken = sourceCode.getTokenAfter(node);
-
-	return (
-		Boolean(previousToken && nextToken) &&
-		previousToken.value === '(' &&
-		previousToken.end <= node.range[0] &&
-		nextToken.value === ')' &&
-		nextToken.start >= node.range[1]
-	);
-};
 
 const create = context => {
 	const sourceCode = context.getSourceCode();
@@ -35,7 +23,7 @@ const create = context => {
 				) {
 					context.report({node, message});
 					break;
-				} else if (!isParenthesized(sourceCode, childNode)) {
+				} else if (!isParenthesized(childNode, sourceCode)) {
 					context.report({
 						node: childNode,
 						message,

--- a/test/no-nested-ternary.js
+++ b/test/no-nested-ternary.js
@@ -1,11 +1,16 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
 import rule from '../rules/no-nested-ternary';
+import {outdent} from 'outdent';
 
 const ruleTester = avaRuleTester(test, {
 	env: {
 		es6: true
 	}
+});
+
+const typescriptRuleTester = avaRuleTester(test, {
+	parser: require.resolve('@typescript-eslint/parser')
 });
 
 const errors = [
@@ -69,4 +74,20 @@ ruleTester.run('new-error', rule, {
 			errors
 		}
 	]
+});
+
+typescriptRuleTester.run('new-error', rule, {
+	valid: [
+		// #663
+		outdent`
+			const pluginName = isAbsolute ?
+				pluginPath.slice(pluginPath.lastIndexOf('/') + 1) :
+				(
+					isNamespaced ?
+					pluginPath.split('@')[1].split('/')[1] :
+					pluginPath
+				);
+		`
+	],
+	invalid: []
 });


### PR DESCRIPTION
Fixes #663