### PR TITLE
Rewrite `no-fn-reference-in-iterator`

### DIFF
--- a/docs/rules/no-fn-reference-in-iterator.md
+++ b/docs/rules/no-fn-reference-in-iterator.md
@@ -30,8 +30,6 @@ const unicorn = require('unicorn');
 //=> [2, 3, 5]
 ```
 
-This rule is fixable.
-
 
 ## Fail
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
 				'unicorn/no-abusive-eslint-disable': 'error',
 				'unicorn/no-array-instanceof': 'error',
 				'unicorn/no-console-spaces': 'error',
-				'unicorn/no-fn-reference-in-iterator': 'off',
+				'unicorn/no-fn-reference-in-iterator': 'error',
 				'unicorn/no-for-loop': 'error',
 				'unicorn/no-hex-escape': 'error',
 				'unicorn/no-keyword-prefix': 'off',

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Configure it in `package.json`.
 			"unicorn/no-abusive-eslint-disable": "error",
 			"unicorn/no-array-instanceof": "error",
 			"unicorn/no-console-spaces": "error",
-			"unicorn/no-fn-reference-in-iterator": "off",
+			"unicorn/no-fn-reference-in-iterator": "error",
 			"unicorn/no-for-loop": "error",
 			"unicorn/no-hex-escape": "error",
 			"unicorn/no-keyword-prefix": "off",
@@ -104,7 +104,7 @@ Configure it in `package.json`.
 - [no-abusive-eslint-disable](docs/rules/no-abusive-eslint-disable.md) - Enforce specifying rules to disable in `eslint-disable` comments.
 - [no-array-instanceof](docs/rules/no-array-instanceof.md) - Require `Array.isArray()` instead of `instanceof Array`. *(fixable)*
 - [no-console-spaces](docs/rules/no-console-spaces.md) - Do not use leading/trailing space between `console.log` parameters. *(fixable)*
-- [no-fn-reference-in-iterator](docs/rules/no-fn-reference-in-iterator.md) - Prevent passing a function reference directly to iterator methods. *(fixable)*
+- [no-fn-reference-in-iterator](docs/rules/no-fn-reference-in-iterator.md) - Prevent passing a function reference directly to iterator methods.
 - [no-for-loop](docs/rules/no-for-loop.md) - Do not use a `for` loop that can be replaced with a `for-of` loop. *(partly fixable)*
 - [no-hex-escape](docs/rules/no-hex-escape.md) - Enforce the use of Unicode escapes instead of hexadecimal escapes. *(fixable)*
 - [no-keyword-prefix](docs/rules/no-keyword-prefix.md) - Disallow identifiers starting with `new` or `class`.

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -94,7 +94,7 @@ const customErrorDefinition = (context, node) => {
 
 	const constructorBody = constructorBodyNode.body;
 
-	const superExpression = constructorBody.find(isSuperExpression);
+	const superExpression = constructorBody.find(body => isSuperExpression(body));
 	const messageExpressionIndex = constructorBody.findIndex(x => isAssignmentExpression(x, 'message'));
 
 	if (!superExpression) {

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -236,7 +236,7 @@ const create = context => {
 		)
 		// Flatten
 		.reduce((accumulator, array) => accumulator.concat(array), [])
-		.filter(processComment);
+		.filter(comment => processComment(comment));
 
 	// This is highly dependable on ESLint's `no-warning-comments` implementation.
 	// What we do is patch the parts we know the rule will use, `getAllComments`.

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -141,7 +141,6 @@ module.exports = {
 		docs: {
 			url: getDocumentationUrl(__filename)
 		},
-		fixable: 'code',
 		messages: {
 			[ERROR_MESSAGE_ID]: 'Do not pass function `{{functionName}}` directly to `{{methodName}}()`.',
 			[REPLACE_MESSAGE_ID]: 'Replace function `{{functionName}}` with `({{parameters}}) => {{functionName}}({{parameters}})`.'

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -6,7 +6,7 @@ const methodSelector = require('./utils/method-selector');
 const ERROR_WITH_NAME_MESSAGE_ID = 'error-with-name';
 const ERROR_WITHOUT_NAME_MESSAGE_ID = 'error-without-name';
 const REPLACE_WITH_NAME_MESSAGE_ID = 'replace-with-name';
-const REPLACE_WITHOUT_NAME_MESSAGE_ID = 'error-without-name';
+const REPLACE_WITHOUT_NAME_MESSAGE_ID = 'replace-without-name';
 
 const iteratorMethods = [
 	['every'],
@@ -70,11 +70,13 @@ const toSelector = name => {
 const ignoredCalleeSelector = `${ignoredCallee.map(name => toSelector(name)).join('')}`;
 
 function check(context, node, method, options) {
-	const {type, name} = node;
+	const {type} = node;
 
 	if (type === 'FunctionExpression' || type === 'ArrowFunctionExpression') {
 		return;
 	}
+
+	const name = type === 'Identifier' ? node.name : '';
 
 	if (type === 'Identifier' && options.ignore.includes(name)) {
 		return;

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -144,7 +144,7 @@ module.exports = {
 		fixable: 'code',
 		messages: {
 			[ERROR_MESSAGE_ID]: 'Do not pass function `{{functionName}}` directly to `{{methodName}}()`.',
-			[REPLACE_MESSAGE_ID]: 'Replace function `{{functionName}}` with `({{parameters}}) => {{functionName}}({parameters})`.'
+			[REPLACE_MESSAGE_ID]: 'Replace function `{{functionName}}` with `({{parameters}}) => {{functionName}}({{parameters}})`.'
 		}
 	}
 };

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -150,8 +150,8 @@ module.exports = {
 			url: getDocumentationUrl(__filename)
 		},
 		messages: {
-			[ERROR_WITH_NAME_MESSAGE_ID]: 'Do not pass function `{{name}}` directly to `{{method}}(…)`.',
-			[ERROR_WITHOUT_NAME_MESSAGE_ID]: 'Do not pass function directly to `{{method}}(…)`.',
+			[ERROR_WITH_NAME_MESSAGE_ID]: 'Do not pass function `{{name}}` directly to `.{{method}}(…)`.',
+			[ERROR_WITHOUT_NAME_MESSAGE_ID]: 'Do not pass function directly to `.{{method}}(…)`.',
 			[REPLACE_WITH_NAME_MESSAGE_ID]: 'Replace function `{{name}}` with `… => {{name}}({{parameters}})`.',
 			[REPLACE_WITHOUT_NAME_MESSAGE_ID]: 'Replace function with `… => …({{parameters}})`.'
 		}

--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -67,7 +67,7 @@ const toSelector = name => {
 };
 
 // Select all the call expressions except the ones present in the blacklist
-const ignoredCalleeSelector = `${ignoredCallee.map(toSelector).join('')}`;
+const ignoredCalleeSelector = `${ignoredCallee.map(name => toSelector(name)).join('')}`;
 
 function check(context, node, method, options) {
 	const {type, name} = node;

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -8,7 +8,7 @@ const isCommaFollowedWithComma = (element, index, array) =>
 const create = context => {
 	return {
 		'ArrayPattern[elements.length>=3]': node => {
-			if (node.elements.some(isCommaFollowedWithComma)) {
+			if (node.elements.some((element, index, array) => isCommaFollowedWithComma(element, index, array))) {
 				context.report({
 					node,
 					message

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -210,11 +210,11 @@ const create = context => {
 	};
 
 	const checkVariables = scope => {
-		scope.variables.forEach(checkVariable);
+		scope.variables.forEach(variable => checkVariable(variable));
 	};
 
 	const checkChildScopes = scope => {
-		scope.childScopes.forEach(checkScope);
+		scope.childScopes.forEach(scope => checkScope(scope));
 	};
 
 	const checkScope = scope => {

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -24,7 +24,7 @@ const create = context => {
 				node,
 				message: 'Prefer the spread operator over `Array.from()`.',
 				fix: fixer => {
-					const [arrayLikeArgument, mapFn, thisArgument] = node.arguments.map(getSource);
+					const [arrayLikeArgument, mapFn, thisArgument] = node.arguments.map(node => getSource(node));
 					let replacement = `${
 						needsSemicolon(sourceCode.getTokenBefore(node), sourceCode) ? ';' : ''
 					}[...${arrayLikeArgument}]`;

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -391,7 +391,7 @@ const isExportedIdentifier = identifier => {
 };
 
 const shouldFix = variable => {
-	return !getVariableIdentifiers(variable).some(isExportedIdentifier);
+	return !getVariableIdentifiers(variable).some(identifier => isExportedIdentifier(identifier));
 };
 
 const isDefaultOrNamespaceImportName = identifier => {
@@ -634,11 +634,11 @@ const create = context => {
 	};
 
 	const checkVariables = scope => {
-		scope.variables.forEach(checkPossiblyWeirdClassVariable);
+		scope.variables.forEach(variable => checkPossiblyWeirdClassVariable(variable));
 	};
 
 	const checkChildScopes = scope => {
-		scope.childScopes.forEach(checkScope);
+		scope.childScopes.forEach(scope => checkScope(scope));
 	};
 
 	const checkScope = scope => {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -278,9 +278,10 @@ const getWordReplacements = (word, {replacements, whitelist}) => {
 
 	let wordReplacement = [];
 	if (replacement) {
+		const transform = isUpperFirst(word) ? upperFirst : lowerFirst;
 		wordReplacement = [...replacement.keys()]
 			.filter(name => replacement.get(name))
-			.map(isUpperFirst(word) ? upperFirst : lowerFirst);
+			.map(name => transform(name));
 	}
 
 	return wordReplacement.length > 0 ? wordReplacement.sort() : [];

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -25,7 +25,7 @@ const nameCollidesWithArgumentsSpecial = (name, scopes, isStrict) => {
 		return false;
 	}
 
-	return isStrict || scopes.some(scopeHasArgumentsSpecial);
+	return isStrict || scopes.some(scope => scopeHasArgumentsSpecial(scope));
 };
 
 /*

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -157,6 +157,21 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 			})
 		),
 
+		// Actual messages
+		{
+			code: 'foo.map(fn)',
+			errors: [
+				{
+					message: 'Do not pass function `fn` directly to `map()`.',
+					suggestions: [
+						{desc: 'Replace function `fn` with `(element) => fn(element)`.'},
+						{desc: 'Replace function `fn` with `(element, index) => fn(element, index)`.'},
+						{desc: 'Replace function `fn` with `(element, index, array) => fn(element, index, array)`.'}
+					]
+				}
+			]
+		},
+
 		// #418
 		invalidTestCase({
 			code: outdent`

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -233,6 +233,32 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 				}
 			]
 		},
+		{
+			code: 'foo.map(lib.fn)',
+			errors: [
+				{
+					message: 'Do not pass function directly to `.map(…)`.',
+					suggestions: [
+						{desc: 'Replace function with `… => …(element)`.'},
+						{desc: 'Replace function with `… => …(element, index)`.'},
+						{desc: 'Replace function with `… => …(element, index, array)`.'}
+					]
+				}
+			]
+		},
+		{
+			code: 'foo.reduce(lib.fn)',
+			errors: [
+				{
+					message: 'Do not pass function directly to `.reduce(…)`.',
+					suggestions: [
+						{desc: 'Replace function with `… => …(accumulator, element)`.'},
+						{desc: 'Replace function with `… => …(accumulator, element, index)`.'},
+						{desc: 'Replace function with `… => …(accumulator, element, index, array)`.'}
+					]
+				}
+			]
+		},
 
 		// #418
 		invalidTestCase({

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
+import {outdent} from 'outdent';
 import rule from '../rules/no-fn-reference-in-iterator';
 
 const ERROR_MESSAGE_ID = 'error';
@@ -154,6 +155,30 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 					`foo.${methodName}((accumulator, element, index, array) => Boolean(accumulator, element, index, array), initialValue)`
 				]
 			})
-		)
+		),
+
+		// #418
+		invalidTestCase({
+			code: outdent`
+				const fn = (x, y) => x + y;
+				[1, 2, 3].map(fn);
+			`,
+			methodName: 'map',
+			functionName: 'fn',
+			suggestions: [
+				outdent`
+					const fn = (x, y) => x + y;
+					[1, 2, 3].map((element) => fn(element));
+				`,
+				outdent`
+					const fn = (x, y) => x + y;
+					[1, 2, 3].map((element, index) => fn(element, index));
+				`,
+				outdent`
+					const fn = (x, y) => x + y;
+					[1, 2, 3].map((element, index, array) => fn(element, index, array));
+				`
+			]
+		})
 	]
 });

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -211,7 +211,7 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 			code: 'foo.map(fn)',
 			errors: [
 				{
-					message: 'Do not pass function `fn` directly to `map(…)`.',
+					message: 'Do not pass function `fn` directly to `.map(…)`.',
 					suggestions: [
 						{desc: 'Replace function `fn` with `… => fn(element)`.'},
 						{desc: 'Replace function `fn` with `… => fn(element, index)`.'},
@@ -224,7 +224,7 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 			code: 'foo.reduce(fn)',
 			errors: [
 				{
-					message: 'Do not pass function `fn` directly to `reduce(…)`.',
+					message: 'Do not pass function `fn` directly to `.reduce(…)`.',
 					suggestions: [
 						{desc: 'Replace function `fn` with `… => fn(accumulator, element)`.'},
 						{desc: 'Replace function `fn` with `… => fn(accumulator, element, index)`.'},

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -171,6 +171,19 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 				}
 			]
 		},
+		{
+			code: 'foo.reduce(fn)',
+			errors: [
+				{
+					message: 'Do not pass function `fn` directly to `reduce()`.',
+					suggestions: [
+						{desc: 'Replace function `fn` with `(accumulator, element) => fn(accumulator, element)`.'},
+						{desc: 'Replace function `fn` with `(accumulator, element, index) => fn(accumulator, element, index)`.'},
+						{desc: 'Replace function `fn` with `(accumulator, element, index, array) => fn(accumulator, element, index, array)`.'}
+					]
+				}
+			]
+		},
 
 		// #418
 		invalidTestCase({


### PR DESCRIPTION
Improvements:

- Remove all auto-fix, there is no way to know how many arguments `iterator` accept, so we can't fix it.
- Add `flatMap` method
- Ignore `lodash` and `underscore`
- Support more types of `iterator` 

Regressions:

~- `CallExpression` was supported, I removed it for now, we need handle more types, like `foo.map(lib.fn)`(MemberExpression)~ Update: fixed.

Fixes #418