### PR TITLE
`expiring-todo-comments`: Add `unicorn/` prefix to message ids

### DIFF
--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -5,17 +5,18 @@ const ci = require('ci-info');
 const baseRule = require('eslint/lib/rules/no-warning-comments');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
-const MESSAGE_ID_AVOID_MULTIPLE_DATES = 'avoidMultipleDates';
-const MESSAGE_ID_EXPIRED_TODO = 'expiredTodo';
+// `unicorn/` prefix is added to avoid conflicts with core rule
+const MESSAGE_ID_AVOID_MULTIPLE_DATES = 'unicorn/avoidMultipleDates';
+const MESSAGE_ID_EXPIRED_TODO = 'unicorn/expiredTodo';
 const MESSAGE_ID_AVOID_MULTIPLE_PACKAGE_VERSIONS =
-	'avoidMultiplePackageVersions';
-const MESSAGE_ID_REACHED_PACKAGE_VERSION = 'reachedPackageVersion';
-const MESSAGE_ID_HAVE_PACKAGE = 'havePackage';
-const MESSAGE_ID_DONT_HAVE_PACKAGE = 'dontHavePackage';
-const MESSAGE_ID_VERSION_MATCHES = 'versionMatches';
-const MESSAGE_ID_ENGINE_MATCHES = 'engineMatches';
-const MESSAGE_ID_REMOVE_WHITESPACES = 'removeWhitespaces';
-const MESSAGE_ID_MISSING_AT_SYMBOL = 'missingAtSymbol';
+	'unicorn/avoidMultiplePackageVersions';
+const MESSAGE_ID_REACHED_PACKAGE_VERSION = 'unicorn/reachedPackageVersion';
+const MESSAGE_ID_HAVE_PACKAGE = 'unicorn/havePackage';
+const MESSAGE_ID_DONT_HAVE_PACKAGE = 'unicorn/dontHavePackage';
+const MESSAGE_ID_VERSION_MATCHES = 'unicorn/versionMatches';
+const MESSAGE_ID_ENGINE_MATCHES = 'unicorn/engineMatches';
+const MESSAGE_ID_REMOVE_WHITESPACES = 'unicorn/removeWhitespaces';
+const MESSAGE_ID_MISSING_AT_SYMBOL = 'unicorn/missingAtSymbol';
 
 const packageResult = readPkgUp.sync();
 const hasPackage = Boolean(packageResult);
@@ -533,7 +534,8 @@ module.exports = {
 			[MESSAGE_ID_REMOVE_WHITESPACES]:
 				'Avoid using whitespaces on TODO argument. On \'{{original}}\' use \'{{fix}}\'. {{message}}',
 			[MESSAGE_ID_MISSING_AT_SYMBOL]:
-				'Missing \'@\' on TODO argument. On \'{{original}}\' use \'{{fix}}\'. {{message}}'
+				'Missing \'@\' on TODO argument. On \'{{original}}\' use \'{{fix}}\'. {{message}}',
+			...baseRule.meta.messages
 		},
 		schema
 	}


### PR DESCRIPTION
In ESLint v7 alpha `expiring-todo-comments` will throw error , because we don't has `unexpectedComment` message.

So I add the messages from core rule. To avoid conflicts, adding a `unicorn/` prefix to our message ids.

I feel this should be done before ESLint v7 release.

See https://github.com/sindresorhus/eslint-plugin-unicorn/pull/577/checks?check_run_id=567088519#step:5:5674
