### PR TITLE
`custom-error-definition`: Support class properties

### DIFF
--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -11,7 +11,9 @@ const ruleTester = avaRuleTester(test, {
 		sourceType: 'module'
 	}
 });
-
+const babelRuleTester = avaRuleTester(test, {
+	parser: require.resolve('babel-eslint')
+});
 const typescriptRuleTester = avaRuleTester(test, {
 	parser: require.resolve('@typescript-eslint/parser')
 });
@@ -476,6 +478,34 @@ const tests = {
 
 ruleTester.run('custom-error-definition', rule, tests);
 typescriptRuleTester.run('custom-error-definition', rule, tests);
+
+babelRuleTester.run('custom-error-definition', rule, {
+	valid: [
+		// #130
+		outdent`
+			export class ValidationError extends Error {
+				name = 'ValidationError';
+				constructor(message) {
+					super(message);
+				}
+			}
+		`
+	],
+	invalid: [
+		// #130
+		{
+			code: outdent`
+				export class ValidationError extends Error {
+					name = 'FOO';
+					constructor(message) {
+						super(message);
+					}
+				}
+			`,
+			errors: [invalidNameError('ValidationError')]
+		}
+	]
+});
 
 typescriptRuleTester.run('custom-error-definition', rule, {
 	valid: [

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -503,6 +503,17 @@ babelRuleTester.run('custom-error-definition', rule, {
 				}
 			`,
 			errors: [invalidNameError('ValidationError')]
+		},
+		{
+			code: outdent`
+				export class ValidationError extends Error {
+					'name': SomeType;
+					constructor(message) {
+						super(message);
+					}
+				}
+			`,
+			errors: [invalidNameError('ValidationError')]
 		}
 	]
 });


### PR DESCRIPTION
Fixes #130


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#130: custom-error-definition does not understand class properties](https://issuehunt.io/repos/55832243/issues/130)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->