### PR TITLE
`escape-case`: Fix missing characters

### DIFF
--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -7,7 +7,7 @@ const escapePatternWithLowercase = /(?<=(?:^|[^\\])(?:\\\\)*\\)(?<data>x[\dA-Fa-
 const message = 'Use uppercase characters for the value of the escape sequence.';
 
 const create = context => {
-	const check = ({node, original, regex, fix}) => {
+	const check = ({node, original, regex = escapeWithLowercase, fix}) => {
 		const fixed = original.replace(regex, data => data.slice(0, 1) + data.slice(1).toUpperCase());
 
 		if (fixed !== original) {
@@ -27,8 +27,7 @@ const create = context => {
 
 			check({
 				node,
-				original: node.raw,
-				regex: escapeWithLowercase
+				original: node.raw
 			});
 		},
 		'Literal[regex]'(node) {
@@ -42,7 +41,6 @@ const create = context => {
 			check({
 				node,
 				original: node.value.raw,
-				regex: escapePatternWithLowercase,
 				fix: (fixer, fixed) => replaceTemplateElement(fixer, node, fixed)
 			});
 		}

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -2,25 +2,12 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const replaceTemplateElement = require('./utils/replace-template-element');
 
-const escapeWithLowercase = /(?<=(?:^|[^\\])(?:\\\\)*\\)(?<data>x[\dA-Fa-f]{2}|u[\dA-Fa-f]{4}|u{[\dA-Fa-f]+})/;
-const escapePatternWithLowercase = /(?<=(?:^|[^\\])(?:\\\\)*\\)(?<data>x[\dA-Fa-f]{2}|u[\dA-Fa-f]{4}|u{[\dA-Fa-f]+}|c[a-z])/;
+const escapeWithLowercase = /(?<=(?:^|[^\\])(?:\\\\)*\\)(?<data>x[\dA-Fa-f]{2}|u[\dA-Fa-f]{4}|u{[\dA-Fa-f]+})/g;
+const escapePatternWithLowercase = /(?<=(?:^|[^\\])(?:\\\\)*\\)(?<data>x[\dA-Fa-f]{2}|u[\dA-Fa-f]{4}|u{[\dA-Fa-f]+}|c[a-z])/g;
 const message = 'Use uppercase characters for the value of the escape sequence.';
 
-const fix = (value, regexp) => {
-	const results = regexp.exec(value);
-
-	if (results) {
-		const {data} = results.groups;
-		const fixedEscape = data.slice(0, 1) + data.slice(1).toUpperCase();
-		return (
-			value.slice(0, results.index) +
-			fixedEscape +
-			value.slice(results.index + data.length)
-		);
-	}
-
-	return value;
-};
+const fix = (value, regexp) => 
+  value.replace(regexp, data => data.slice(0, 1) + data.slice(1).toUpperCase());
 
 const create = context => {
 	return {

--- a/test/escape-case.js
+++ b/test/escape-case.js
@@ -31,6 +31,7 @@ ruleTester.run('escape-case', rule, {
 		'const foo = "foo\\\\ubarbaz";',
 		'const foo = "foo\\\\\\\\xbar";',
 		'const foo = "foo\\\\\\\\ubarbaz";',
+		'const foo = "\\ca";',
 
 		// TemplateLiteral
 		'const foo = `\\xA9`;',
@@ -46,6 +47,7 @@ ruleTester.run('escape-case', rule, {
 		'const foo = `foo\\\\ubarbaz`;',
 		'const foo = `foo\\\\\\\\xbar`;',
 		'const foo = `foo\\\\\\\\ubarbaz`;',
+		'const foo = `\\ca`;',
 
 		// Literal regex
 		'const foo = /foo\\xA9/',
@@ -63,6 +65,7 @@ ruleTester.run('escape-case', rule, {
 		'const foo = new RegExp("/\\xA9")',
 		'const foo = new RegExp("/\\uD834/")',
 		'const foo = new RegExp("/\\u{1D306}/", "u")',
+		'const foo = new RegExp("/\\ca/")',
 		'const foo = new RegExp("/\\cA/")'
 	],
 	invalid: [
@@ -195,6 +198,30 @@ ruleTester.run('escape-case', rule, {
 			output: 'const foo = `foo \\\\\\uD834`;'
 		},
 
+		// Mixed cases
+		{
+			code: 'const foo = `\\xAa`;',
+			errors,
+			output: 'const foo = `\\xAA`;'
+		},
+		{
+			code: 'const foo = `\\uAaAa`;',
+			errors,
+			output: 'const foo = `\\uAAAA`;'
+		},
+		{
+			code: 'const foo = `\\u{AaAa}`;',
+			errors,
+			output: 'const foo = `\\u{AAAA}`;'
+		},
+
+		// Many
+		{
+			code: 'const foo = `\\xAaa\\xaaa\\xAA${foo}\\uAaAaa\\uaaaaa\\uAAAAa\\u{AaAa}${foo}\\u{aaaa}a\\u{AAAA}`;',
+			errors: Array.from({length: 3}, () => errors[0]),
+			output: 'const foo = `\\xAAa\\xAAa\\xAA${foo}\\uAAAAa\\uAAAAa\\uAAAAa\\u{AAAA}${foo}\\u{AAAA}a\\u{AAAA}`;'
+		},
+
 		// Literal regex
 		{
 			code: 'const foo = /\\xa9/;',
@@ -225,6 +252,30 @@ ruleTester.run('escape-case', rule, {
 			code: 'const foo = /foo\\\\\\\\\\xa9/;',
 			errors,
 			output: 'const foo = /foo\\\\\\\\\\xA9/;'
+		},
+
+		// Mixed cases
+		{
+			code: 'const foo = /\\xAa/;',
+			errors,
+			output: 'const foo = /\\xAA/;'
+		},
+		{
+			code: 'const foo = /\\uAaAa/;',
+			errors,
+			output: 'const foo = /\\uAAAA/;'
+		},
+		{
+			code: 'const foo = /\\u{AaAa}/;',
+			errors,
+			output: 'const foo = /\\u{AAAA}/;'
+		},
+
+		// Many
+		{
+			code: 'const foo = /\\xAaa\\xaaa\\xAAa\\uAaAaa\\uaaaaa\\uAAAAa\\u{AaAa}a\\u{aaaa}a\\u{AAAA}a\\ca/;',
+			errors,
+			output: 'const foo = /\\xAAa\\xAAa\\xAAa\\uAAAAa\\uAAAAa\\uAAAAa\\u{AAAA}a\\u{AAAA}a\\u{AAAA}a\\cA/;'
 		},
 
 		// RegExp

--- a/test/escape-case.js
+++ b/test/escape-case.js
@@ -72,6 +72,7 @@ ruleTester.run('escape-case', rule, {
 			errors,
 			output: 'const foo = "\\xA9";'
 		},
+
 		// Mixed cases
 		{
 			code: 'const foo = "\\xAa";',
@@ -88,6 +89,14 @@ ruleTester.run('escape-case', rule, {
 			errors,
 			output: 'const foo = "\\u{AAAA}";'
 		},
+
+		// Many
+		{
+			code: 'const foo = "\\xAaa\\xaaa\\xAAa\\uAaAaa\\uaaaaa\\uAAAAa\\u{AaAa}a\\u{aaaa}a\\u{AAAA}";',
+			errors,
+			output: 'const foo = "\\xAAa\\xAAa\\xAAa\\uAAAAa\\uAAAAa\\uAAAAa\\u{AAAA}a\\u{AAAA}a\\u{AAAA}";'
+		},
+   
 		{
 			code: 'const foo = "\\ud834";',
 			errors,

--- a/test/escape-case.js
+++ b/test/escape-case.js
@@ -95,9 +95,9 @@ ruleTester.run('escape-case', rule, {
 
 		// Many
 		{
-			code: 'const foo = "\\xAaa\\xaaa\\xAAa\\uAaAaa\\uaaaaa\\uAAAAa\\u{AaAa}a\\u{aaaa}a\\u{AAAA}";',
+			code: 'const foo = "\\xAab\\xaab\\xAAb\\uAaAab\\uaaaab\\uAAAAb\\u{AaAa}b\\u{aaaa}b\\u{AAAA}";',
 			errors,
-			output: 'const foo = "\\xAAa\\xAAa\\xAAa\\uAAAAa\\uAAAAa\\uAAAAa\\u{AAAA}a\\u{AAAA}a\\u{AAAA}";'
+			output: 'const foo = "\\xAAb\\xAAb\\xAAb\\uAAAAb\\uAAAAb\\uAAAAb\\u{AAAA}b\\u{AAAA}b\\u{AAAA}";'
 		},
 
 		{
@@ -217,9 +217,9 @@ ruleTester.run('escape-case', rule, {
 
 		// Many
 		{
-			code: 'const foo = `\\xAaa\\xaaa\\xAA${foo}\\uAaAaa\\uaaaaa\\uAAAAa\\u{AaAa}${foo}\\u{aaaa}a\\u{AAAA}`;',
+			code: 'const foo = `\\xAab\\xaab\\xAA${foo}\\uAaAab\\uaaaab\\uAAAAb\\u{AaAa}${foo}\\u{aaaa}b\\u{AAAA}`;',
 			errors: Array.from({length: 3}, () => errors[0]),
-			output: 'const foo = `\\xAAa\\xAAa\\xAA${foo}\\uAAAAa\\uAAAAa\\uAAAAa\\u{AAAA}${foo}\\u{AAAA}a\\u{AAAA}`;'
+			output: 'const foo = `\\xAAb\\xAAb\\xAA${foo}\\uAAAAb\\uAAAAb\\uAAAAb\\u{AAAA}${foo}\\u{AAAA}b\\u{AAAA}`;'
 		},
 
 		// Literal regex
@@ -273,9 +273,9 @@ ruleTester.run('escape-case', rule, {
 
 		// Many
 		{
-			code: 'const foo = /\\xAaa\\xaaa\\xAAa\\uAaAaa\\uaaaaa\\uAAAAa\\u{AaAa}a\\u{aaaa}a\\u{AAAA}a\\ca/;',
+			code: 'const foo = /\\xAab\\xaab\\xAAb\\uAaAab\\uaaaab\\uAAAAb\\u{AaAa}b\\u{aaaa}b\\u{AAAA}b\\ca/;',
 			errors,
-			output: 'const foo = /\\xAAa\\xAAa\\xAAa\\uAAAAa\\uAAAAa\\uAAAAa\\u{AAAA}a\\u{AAAA}a\\u{AAAA}a\\cA/;'
+			output: 'const foo = /\\xAAb\\xAAb\\xAAb\\uAAAAb\\uAAAAb\\uAAAAb\\u{AAAA}b\\u{AAAA}b\\u{AAAA}b\\cA/;'
 		},
 
 		// RegExp

--- a/test/escape-case.js
+++ b/test/escape-case.js
@@ -96,7 +96,7 @@ ruleTester.run('escape-case', rule, {
 			errors,
 			output: 'const foo = "\\xAAa\\xAAa\\xAAa\\uAAAAa\\uAAAAa\\uAAAAa\\u{AAAA}a\\u{AAAA}a\\u{AAAA}";'
 		},
-   
+
 		{
 			code: 'const foo = "\\ud834";',
 			errors,


### PR DESCRIPTION
- Fix missing characters 
- Simplify logic
- Remove `\ca` from `TemplateElement`, should only work in `regex`
- More tests

Fixes #677