### PR TITLE
Tweak integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    env:
-      CI: 1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
+    env:
+      CI: 1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
 		"ava": "^3.5.0",
 		"babel-eslint": "^10.1.0",
 		"chalk": "^3.0.0",
-		"del": "^5.1.0",
 		"eslint": "^6.8.0",
 		"eslint-ava-rule-tester": "^4.0.0",
 		"eslint-plugin-eslint-plugin": "^2.2.1",

--- a/test/integration/readme.md
+++ b/test/integration/readme.md
@@ -1,5 +1,5 @@
 # Integration tests
 
-To run the integration tests, go to project root, and run `$ npm run integration`.
+To run the integration tests, go to the project root, and run `$ npm run integration`.
 
 To run tests on specific projects, run `$ npm run integration projectName1 projectName2 … projectNameN`. The project names can be found in [`project.js`](project.js).

--- a/test/integration/readme.md
+++ b/test/integration/readme.md
@@ -1,0 +1,5 @@
+# Integration test
+
+Run integration test, go to project root, run `$ npm run integration`.
+
+To run tests on specific projects, run `$ npm run integration projectName1 projectName2 … projectNameN`, the project names can be founded in [`./project.js`](./project.js).

--- a/test/integration/readme.md
+++ b/test/integration/readme.md
@@ -1,5 +1,5 @@
-# Integration test
+# Integration tests
 
-Run integration test, go to project root, run `$ npm run integration`.
+To run the integration tests, go to project root, and run `$ npm run integration`.
 
-To run tests on specific projects, run `$ npm run integration projectName1 projectName2 … projectNameN`, the project names can be founded in [`./project.js`](./project.js).
+To run tests on specific projects, run `$ npm run integration projectName1 projectName2 … projectNameN`. The project names can be found in [`project.js`](project.js).

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 'use strict';
+const fs = require('fs');
 const path = require('path');
 const Listr = require('listr');
 const execa = require('execa');
-const del = require('del');
 const chalk = require('chalk');
 const {isCI} = require('ci-info');
 const projects = require('./projects');
@@ -81,6 +81,7 @@ const execute = project => {
 	return new Listr([
 		{
 			title: 'Cloning',
+			skip: () => fs.existsSync(destination) ? 'Project already downloaded.' : false,
 			task: () => execa('git', [
 				'clone',
 				project.repository,
@@ -93,13 +94,10 @@ const execute = project => {
 		{
 			title: 'Running eslint',
 			task: makeEslintTask(project, destination)
-		},
-		{
-			title: 'Clean up',
-			task: () => del(destination, {force: true})
 		}
-	].map(({title, task}) => ({
+	].map(({title, task, skip}) => ({
 		title: `${project.name} / ${title}`,
+		skip,
 		task
 	})), {
 		exitOnError: false

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -6,7 +6,12 @@ const Listr = require('listr');
 const execa = require('execa');
 const chalk = require('chalk');
 const {isCI} = require('ci-info');
-const projects = require('./projects');
+const allProjects = require('./projects');
+
+const projectsArguments = process.argv.slice(2);
+const projects = projectsArguments.length === 0 ?
+	allProjects :
+	allProjects.filter(({name}) => projectsArguments.includes(name));
 
 const enrichErrors = (packageName, cliArguments, f) => async (...arguments_) => {
 	try {


### PR DESCRIPTION
- ~Set `CI` environment variable on CI, [`ci-info` stable version hasn't support github actions](https://github.com/watson/ci-info/pull/42)~
- Keep downloaded repos, some projects are huge, we don't want download again and again on local tests