### PR TITLE
Fix integration tests

### DIFF
--- a/test/integration/projects.js
+++ b/test/integration/projects.js
@@ -60,7 +60,10 @@ module.exports = [
 			'aio/content/examples/animations/src/app/open-close.component.3.ts',
 
 			'--ignore-pattern',
-			'aio/tools/transforms/templates/data-module.template.js'
+			'aio/tools/transforms/templates/data-module.template.js',
+
+			'--ignore-pattern',
+			'aio/content/examples/router/src/app/app-routing.module.9.ts'
 		]
 	},
 	{


### PR DESCRIPTION
Exclude the valid file, missing a `]` [here](https://github.com/angular/angular/blob/4275b3412f129f24f216c4c557772511b31f8a5a/aio/content/examples/router/src/app/app-routing.module.9.ts#L18)