### PR TITLE
`no-fn-reference-in-iterator`: Ignore `this.` and `Vue.filter()`

### DIFF
--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -10,7 +10,11 @@ const REPLACE_WITHOUT_NAME_MESSAGE_ID = 'replace-without-name';
 
 const iteratorMethods = [
 	['every'],
-	['filter'],
+	[
+		'filter', {
+			extraSelector: '[callee.object.name!="Vue"]'
+		}
+	],
 	['find'],
 	['findIndex'],
 	['flatMap'],
@@ -46,6 +50,7 @@ const iteratorMethods = [
 		parameters: ['element', 'index', 'array'],
 		ignore: ['Boolean'],
 		minParameters: 1,
+		extraSelector: '',
 		...options
 	};
 	return [method, options];
@@ -67,7 +72,11 @@ const toSelector = name => {
 };
 
 // Select all the call expressions except the ones present in the blacklist
-const ignoredCalleeSelector = `${ignoredCallee.map(name => toSelector(name)).join('')}`;
+const ignoredCalleeSelector = [
+	// `this.{map, filter, …}()`
+	'[callee.object.type!="ThisExpression"]',
+	...ignoredCallee.map(name => toSelector(name))
+].join('');
 
 function check(context, node, method, options) {
 	const {type} = node;
@@ -133,6 +142,7 @@ const create = context => {
 				min: 1,
 				max: 2
 			}),
+			options.extraSelector,
 			ignoredCalleeSelector
 		].join('');
 		rules[selector] = node => {

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -57,6 +57,10 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 		...simpleMethods.map(method => `foo.${method}(element => fn(element))`),
 		...reduceLikeMethods.map(method => `foo.${method}((accumulator, element) => fn(element))`),
 
+		// `this.{map, filter, …}`
+		...simpleMethods.map(method => `this.${method}(fn)`),
+		...reduceLikeMethods.map(method => `this.${method}(fn)`),
+
 		// `Boolean`
 		...simpleMethods.map(method => `foo.${method}(Boolean)`),
 
@@ -83,7 +87,10 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 		'_.map(fn)',
 		'Async.map(list, fn)',
 		'async.map(list, fn)',
-		'React.children.forEach(children, fn)'
+		'React.children.forEach(children, fn)',
+
+		'Vue.filter(name, fn)'
+
 	],
 	invalid: [
 		// Suggestions


### PR DESCRIPTION
Fixes #698
Fixes #694