### PR TITLE
`prefer-string-slice`: Handle negative length in `.substr()`

### DIFF
--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -63,20 +63,20 @@ const create = context => {
 			const firstArgument = argumentNodes[0] ? sourceCode.getText(argumentNodes[0]) : undefined;
 			const secondArgument = argumentNodes[1] ? sourceCode.getText(argumentNodes[1]) : undefined;
 
-			let slice;
+			let sliceArguments;
 
 			if (argumentNodes.length === 0) {
-				slice = [];
+				sliceArguments = [];
 			} else if (argumentNodes.length === 1) {
-				slice = [firstArgument];
+				sliceArguments = [firstArgument];
 			} else if (argumentNodes.length === 2) {
 				if (firstArgument === '0') {
-					slice = [firstArgument, secondArgument];
+					sliceArguments = [firstArgument, secondArgument];
 				} else if (
 					isLiteralNumber(argumentNodes[0]) &&
 					isLiteralNumber(argumentNodes[1])
 				) {
-					slice = [
+					sliceArguments = [
 						firstArgument,
 						argumentNodes[0].value + argumentNodes[1].value
 					];
@@ -84,14 +84,14 @@ const create = context => {
 					isLikelyNumeric(argumentNodes[0]) &&
 					isLikelyNumeric(argumentNodes[1])
 				) {
-					slice = [firstArgument, firstArgument + ' + ' + secondArgument];
+					sliceArguments = [firstArgument, firstArgument + ' + ' + secondArgument];
 				}
 			}
 
-			if (slice) {
+			if (sliceArguments) {
 				const objectText = getNodeText(objectNode);
 
-				problem.fix = fixer => fixer.replaceText(node, `${objectText}.slice(${slice.join(', ')})`);
+				problem.fix = fixer => fixer.replaceText(node, `${objectText}.slice(${sliceArguments.join(', ')})`);
 			}
 
 			context.report(problem);
@@ -111,27 +111,27 @@ const create = context => {
 
 			const firstNumber = argumentNodes[0] ? getNumericValue(argumentNodes[0]) : undefined;
 
-			let slice;
+			let sliceArguments;
 
 			if (argumentNodes.length === 0) {
-				slice = [];
+				sliceArguments = [];
 			} else if (argumentNodes.length === 1) {
 				if (firstNumber !== undefined) {
-					slice = [Math.max(0, firstNumber)];
+					sliceArguments = [Math.max(0, firstNumber)];
 				} else if (isLengthProperty(argumentNodes[0])) {
-					slice = [firstArgument];
+					sliceArguments = [firstArgument];
 				} else {
-					slice = [`Math.max(0, ${firstArgument})`];
+					sliceArguments = [`Math.max(0, ${firstArgument})`];
 				}
 			} else if (argumentNodes.length === 2) {
 				const secondNumber = argumentNodes[1] ? getNumericValue(argumentNodes[1]) : undefined;
 
 				if (firstNumber !== undefined && secondNumber !== undefined) {
-					slice = firstNumber > secondNumber ?
+					sliceArguments = firstNumber > secondNumber ?
 						[Math.max(0, secondNumber), Math.max(0, firstNumber)] :
 						[Math.max(0, firstNumber), Math.max(0, secondNumber)];
 				} else if (firstNumber === 0 || secondNumber === 0) {
-					slice = [0, `Math.max(0, ${firstNumber === 0 ? secondArgument : firstArgument})`];
+					sliceArguments = [0, `Math.max(0, ${firstNumber === 0 ? secondArgument : firstArgument})`];
 				} else {
 					// As values aren't Literal, we can not know whether secondArgument will become smaller than the first or not, causing an issue:
 					//   .substring(0, 2) and .substring(2, 0) returns the same result
@@ -142,9 +142,9 @@ const create = context => {
 				}
 			}
 
-			if (slice) {
+			if (sliceArguments) {
 				const objectText = getNodeText(objectNode);
-				problem.fix = fixer => fixer.replaceText(node, `${objectText}.slice(${slice.join(', ')})`);
+				problem.fix = fixer => fixer.replaceText(node, `${objectText}.slice(${sliceArguments.join(', ')})`);
 			}
 
 			context.report(problem);

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -74,7 +74,7 @@ const create = context => {
 					sliceArguments = [firstArgument];
 					if (isLiteralNumber(secondArgument) || isLengthProperty(argumentNodes[1])) {
 						sliceArguments.push(secondArgument);
-					} else if (getNumericValue(argumentNodes[1]) !== undefined) {
+					} else if (typeof getNumericValue(argumentNodes[1]) === 'number') {
 						sliceArguments.push(Math.max(0, getNumericValue(argumentNodes[1])));
 					} else {
 						sliceArguments.push(`Math.max(0, ${secondArgument})`);

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -71,7 +71,14 @@ const create = context => {
 				sliceArguments = [firstArgument];
 			} else if (argumentNodes.length === 2) {
 				if (firstArgument === '0') {
-					sliceArguments = [firstArgument, secondArgument];
+					sliceArguments = [firstArgument];
+					if (isLiteralNumber(secondArgument) || isLengthProperty(argumentNodes[1])) {
+						sliceArguments.push(secondArgument);
+					} else if (getNumericValue(argumentNodes[1]) !== undefined) {
+						sliceArguments.push(Math.max(0, getNumericValue(argumentNodes[1])));
+					} else {
+						sliceArguments.push(`Math.max(0, ${secondArgument})`);
+					}
 				} else if (
 					isLiteralNumber(argumentNodes[0]) &&
 					isLiteralNumber(argumentNodes[1])
@@ -124,7 +131,7 @@ const create = context => {
 					sliceArguments = [`Math.max(0, ${firstArgument})`];
 				}
 			} else if (argumentNodes.length === 2) {
-				const secondNumber = argumentNodes[1] ? getNumericValue(argumentNodes[1]) : undefined;
+				const secondNumber = getNumericValue(argumentNodes[1]);
 
 				if (firstNumber !== undefined && secondNumber !== undefined) {
 					sliceArguments = firstNumber > secondNumber ?

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -84,7 +84,7 @@ ruleTester.run('prefer-string-slice', rule, {
 			`,
 			output: outdent`
 				const length = 123;
-				"foo".slice(0, length)
+				"foo".slice(0, Math.max(0, length))
 			`,
 			errors
 		},
@@ -97,6 +97,16 @@ ruleTester.run('prefer-string-slice', rule, {
 				const length = 123;
 				"foo".substr('0', length)
 			`,
+			errors
+		},
+		{
+			code: '"foo".substr(0, -1)',
+			output: '"foo".slice(0, 0)',
+			errors
+		},
+		{
+			code: '"foo".substr(0, "foo".length)',
+			output: '"foo".slice(0, "foo".length)',
 			errors
 		},
 		{
@@ -136,6 +146,18 @@ ruleTester.run('prefer-string-slice', rule, {
 		},
 		{
 			code: '"foo".substr(1, 2)',
+			errors
+		},
+		// Extra arguments
+		{
+			code: 'foo.substr(1, 2, 3)',
+			output: 'foo.substr(1, 2, 3)',
+			errors
+		},
+		// #700
+		{
+			code: '"Sample".substr(0, "Sample".lastIndexOf("/"))',
+			output: '"Sample".slice(0, Math.max(0, "Sample".lastIndexOf("/")))',
 			errors
 		},
 
@@ -209,6 +231,12 @@ ruleTester.run('prefer-string-slice', rule, {
 		},
 		{
 			code: '"foo".substring(1, 3)',
+			errors
+		},
+		// Extra arguments
+		{
+			code: 'foo.substring(1, 2, 3)',
+			output: 'foo.substring(1, 2, 3)',
 			errors
 		}
 	]


### PR DESCRIPTION
- Rename `slice` to `sliceArguments`
- Handle negative length in `.substr()`
- Improve coverage
- Remove dead code


Fixes #700