### PR TITLE
`prefer-starts-ends-with`: Code style

### DIFF
--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -1,6 +1,9 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
+const MESSAGE_STARTS_WITH = 'prefer-starts-with';
+const MESSAGE_ENDS_WITH = 'prefer-ends-with';
+
 const doesNotContain = (string, characters) => characters.every(character => !string.includes(character));
 
 const isSimpleString = string => doesNotContain(
@@ -39,10 +42,13 @@ const create = context => {
 			}
 
 			const {pattern} = regex;
-			if (pattern.startsWith('^') && isSimpleString(pattern.slice(1))) {
+			if (
+				pattern.startsWith('^') &&
+				isSimpleString(pattern.slice(1))
+			) {
 				context.report({
 					node,
-					message: 'Prefer `String#startsWith()` over a regex with `^`.'
+					messageId: MESSAGE_STARTS_WITH
 				});
 			} else if (
 				pattern.endsWith('$') &&
@@ -50,7 +56,7 @@ const create = context => {
 			) {
 				context.report({
 					node,
-					message: 'Prefer `String#endsWith()` over a regex with `$`.'
+					messageId: MESSAGE_ENDS_WITH
 				});
 			}
 		}
@@ -63,6 +69,10 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			url: getDocumentationUrl(__filename)
+		},
+		messages: {
+			[MESSAGE_STARTS_WITH]: 'Prefer `String#startsWith()` over a regex with `^`.',
+			[MESSAGE_ENDS_WITH]: 'Prefer `String#endsWith()` over a regex with `$`.'
 		}
 	}
 };

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -3,25 +3,13 @@ import avaRuleTester from 'eslint-ava-rule-tester';
 import rule from '../rules/prefer-starts-ends-with';
 
 const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
+	parserOptions: {
+		ecmaVersion: 2020
 	}
 });
 
-const errors = {
-	startsWith: [
-		{
-			ruleId: 'prefer-starts-ends-with',
-			message: 'Prefer `String#startsWith()` over a regex with `^`.'
-		}
-	],
-	endsWith: [
-		{
-			ruleId: 'prefer-starts-ends-with',
-			message: 'Prefer `String#endsWith()` over a regex with `$`.'
-		}
-	]
-};
+const MESSAGE_STARTS_WITH = 'prefer-starts-with';
+const MESSAGE_ENDS_WITH = 'prefer-ends-with';
 
 const validRegex = [
 	/foo/,
@@ -58,17 +46,29 @@ ruleTester.run('prefer-starts-ends-with', rule, {
 		'test()',
 		'test.test()',
 		'startWith("bar")',
-		'foo()()'
+		'foo()()',
+
+		...validRegex.map(re => `${re}.test(bar)`),
+		...validRegex.map(re => `bar.match(${re})`)
+	],
+	invalid: [
+		...invalidRegex.map(re => {
+			const code = `${re}.test(bar)`;
+			const messageId = re.source.startsWith('^') ? MESSAGE_STARTS_WITH : MESSAGE_ENDS_WITH;
+			return {
+				code,
+				output: code,
+				errors: [{messageId}]
+			};
+		}),
+		...invalidRegex.map(re => {
+			const code = `bar.match(${re})`;
+			const messageId = re.source.startsWith('^') ? MESSAGE_STARTS_WITH : MESSAGE_ENDS_WITH;
+			return {
+				code,
+				output: code,
+				errors: [{messageId}]
+			};
+		})
 	]
-		.concat(validRegex.map(re => `${re}.test(bar)`))
-		.concat(validRegex.map(re => `bar.match(${re})`)),
-	invalid: []
-		.concat(invalidRegex.map(re => ({
-			code: `${re}.test(bar)`,
-			errors: errors[`${re}`.startsWith('/^') ? 'startsWith' : 'endsWith']
-		})))
-		.concat(invalidRegex.map(re => ({
-			code: `bar.match(${re})`,
-			errors: errors[`${re}`.startsWith('/^') ? 'startsWith' : 'endsWith']
-		})))
 });


### PR DESCRIPTION
- Use `messageId`
- Refactor tests, use `...` instead of `.concat()`