### PR TITLE
`throw-new-error`: Check `MemberExpression` customError

### DIFF
--- a/docs/rules/throw-new-error.md
+++ b/docs/rules/throw-new-error.md
@@ -4,18 +4,30 @@ While it's possible to create a new error without using the `new` keyword, it's 
 
 This rule is fixable.
 
-
 ## Fail
 
 ```js
 throw Error();
+```
+
+```js
 throw TypeError('unicorn');
 ```
 
+```js
+throw lib.TypeError();
+```
 
 ## Pass
 
 ```js
 throw new Error();
+```
+
+```js
 throw new TypeError('unicorn');
+```
+
+```js
+throw new lib.TypeError();
 ```

--- a/test/throw-new-error.js
+++ b/test/throw-new-error.js
@@ -2,13 +2,15 @@ import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
 import rule from '../rules/throw-new-error';
 
+const messageId = 'throw-new-error';
+
 const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
+	parserOptions: {
+		ecmaVersion: 2020
 	}
 });
 
-const errors = [{ruleId: 'throw-new-error'}];
+const errors = [{messageId}];
 
 ruleTester.run('new-error', rule, {
 	valid: [
@@ -28,13 +30,44 @@ ruleTester.run('new-error', rule, {
 		'throw getError()',
 		// Not `CallExpression`
 		'throw CustomError',
-		// Not `Identifier`
-		'throw lib.Error()'
+		// Not `Identifier` / `MemberExpression`
+		'throw getErrorConstructor()()',
+		// `MemberExpression.computed`
+		'throw lib[Error]()',
+		// `MemberExpression.property` not `Identifier`
+		'throw lib["Error"]()',
+		// Not `FooError` like
+		'throw lib.getError()'
 	],
 	invalid: [
 		{
 			code: 'throw Error()',
 			output: 'throw new Error()',
+			errors
+		},
+		{
+			code: 'throw (Error)()',
+			output: 'throw new (Error)()',
+			errors
+		},
+		{
+			code: 'throw lib.Error()',
+			output: 'throw new lib.Error()',
+			errors
+		},
+		{
+			code: 'throw lib.mod.Error()',
+			output: 'throw new lib.mod.Error()',
+			errors
+		},
+		{
+			code: 'throw lib[mod].Error()',
+			output: 'throw new lib[mod].Error()',
+			errors
+		},
+		{
+			code: 'throw (lib.mod).Error()',
+			output: 'throw new (lib.mod).Error()',
 			errors
 		},
 		{


### PR DESCRIPTION
- Check `MemberExpression`, before, `throw lib.Error()` is not reported
- Use `messageId`
- Move `customError` check to selector