### PR TITLE
`prefer-starts-ends-with`: Fix bug with `m` flag

### DIFF
--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -25,7 +25,7 @@ const stringMatchSelector = [
 ].join('');
 
 const checkRegex = ({pattern, flags}) => {
-	if (flags.includes('i')) {
+	if (flags.includes('i') || flags.includes('m')) {
 		return;
 	}
 

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -24,7 +24,9 @@ const validRegex = [
 	/^foo./,
 	/foo.$/,
 	/\^foo/,
-	/^foo/i
+	/^foo/i,
+	/^foo/m,
+	/^foo/im
 ];
 
 const invalidRegex = [


### PR DESCRIPTION
```js
/^b/.test('a\nb')
false

/^b/m.test('a\nb')
true
```

When regex has `m` flag, should not be a problem.