### PR TITLE
Fixed issue requiring eslint sub-rule with VSCode-eslint

### DIFF
--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -2,7 +2,8 @@
 const readPkgUp = require('read-pkg-up');
 const semver = require('semver');
 const ci = require('ci-info');
-const baseRule = require('eslint/lib/rules/no-warning-comments');
+const path = require('path');
+const baseRule = require(path.join(__dirname, '..', 'node_modules', 'eslint', 'lib', 'rules', 'no-warning-comments'));
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
 // `unicorn/` prefix is added to avoid conflicts with core rule


### PR DESCRIPTION
So eslint-plugin-unicorn causes an error when using the VSCode eslint extension:
`Error: Cannot find module 'eslint/lib/rules/no-warning-comments'`

It does work correctly when just running `eslint` from the console.

I think it's because the VSCode eslint extension loads the rules/*.js files individually and thus the baseRule isn't able to be included the way it's attempting to be included.

The fix is pretty simple, to include it directly, based on the rules file location.

This fixes the issue for VSCode eslint and also still works fine from console too.
