### PR TITLE
Bump `eslint-template-visitor` to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"ci-info": "^2.0.0",
 		"clean-regexp": "^1.0.0",
 		"eslint-ast-utils": "^1.1.0",
-		"eslint-template-visitor": "^1.1.0",
+		"eslint-template-visitor": "^2.0.0",
 		"eslint-utils": "^2.0.0",
 		"import-modules": "^2.0.0",
 		"lodash": "^4.17.15",


### PR DESCRIPTION
Bumps [`eslint-template-visitor`](https://github.com/futpib/eslint-template-visitor) to latest.

See https://github.com/futpib/eslint-template-visitor/issues/8. It's not actually a major version change, it just bumps the `peerDependencies` required version of ESLint to `^7`, so that we can avoid the install warning.

https://github.com/futpib/eslint-template-visitor/commit/c66c16cb1abd0f565533b7580e805473a0ee01cb#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R7
