### PR TITLE
Fix type typo in filename-case docs

### DIFF
--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -50,7 +50,7 @@ You can set the `case` option like this:
 
 ### cases
 
-Type: `{[type: string]: string}`
+Type: `{[type: string]: boolean}`
 
 You can set the `cases` option to allow multiple cases:
 


### PR DESCRIPTION
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
