### PR TITLE
Ignore more types in `no-fn-reference-in-iterator` and `no-reduce` rule

### DIFF
--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -2,6 +2,7 @@
 const {isParenthesized} = require('eslint-utils');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const methodSelector = require('./utils/method-selector');
+const {notFunctionSelector} = require('./utils/not-function');
 
 const ERROR_WITH_NAME_MESSAGE_ID = 'error-with-name';
 const ERROR_WITHOUT_NAME_MESSAGE_ID = 'error-without-name';
@@ -127,14 +128,11 @@ function check(context, node, method, options) {
 	context.report(problem);
 }
 
-const ignoredFirstArgumentSelector = `:not(${
-	[
-		'[arguments.0.type="FunctionExpression"]',
-		'[arguments.0.type="ArrowFunctionExpression"]',
-		'[arguments.0.type="Literal"]',
-		'[arguments.0.type="Identifier"][arguments.0.name="undefined"]'
-	].join(',')
-})`;
+const ignoredFirstArgumentSelector = [
+	notFunctionSelector('arguments.0'),
+	'[arguments.0.type!="FunctionExpression"]',
+	'[arguments.0.type!="ArrowFunctionExpression"]'
+].join('');
 
 const create = context => {
 	const sourceCode = context.getSourceCode();

--- a/rules/utils/not-function.js
+++ b/rules/utils/not-function.js
@@ -2,19 +2,32 @@
 
 // AST Types:
 // https://github.com/eslint/espree/blob/master/lib/ast-node-types.js#L18
-// Only types possible to be `callee` or `argument` are listed
+// Only types possible to be `argument` are listed
 const impossibleNodeTypes = [
 	'ArrayExpression',
+	'BinaryExpression',
 	'ClassExpression',
 	'Literal',
 	'ObjectExpression',
 	'TemplateLiteral',
-	// Technically `this` could be a function, but most likely not
+	'UnaryExpression',
+	'UpdateExpression',
+];
+
+// Technically these nodes could be a function, but most likely not
+const mostLikelyNotNodeTypes = [
+	'AssignmentExpression',
+	'AwaitExpression',
+	'CallExpression',
+	'LogicalExpression',
+	'NewExpression',
+	'TaggedTemplateExpression',
 	'ThisExpression'
 ];
 
+
 const notFunctionSelector = node => [
-	...impossibleNodeTypes.map(type => `[${node}.type!="${type}"]`),
+	...[...impossibleNodeTypes, ...mostLikelyNotNodeTypes].map(type => `[${node}.type!="${type}"]`),
 	`:not([${node}.type="Identifier"][${node}.name="undefined"])`
 ].join('');
 

--- a/rules/utils/not-function.js
+++ b/rules/utils/not-function.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// AST Types:
+// https://github.com/eslint/espree/blob/master/lib/ast-node-types.js#L18
+// Only types possible to be `callee` or `argument` are listed
+const impossibleNodeTypes = [
+	'ArrayExpression',
+	'ClassExpression',
+	'Literal',
+	'ObjectExpression',
+	'TemplateLiteral',
+	// Technically `this` could be a function, but most likely not
+	'ThisExpression'
+];
+
+const notFunctionSelector = node => [
+	...impossibleNodeTypes.map(type => `[${node}.type!="${type}"]`),
+	`:not([${node}.type="Identifier"][${node}.name="undefined"])`
+].join('');
+
+module.exports = {
+	notFunctionSelector
+};

--- a/rules/utils/not-function.js
+++ b/rules/utils/not-function.js
@@ -11,7 +11,7 @@ const impossibleNodeTypes = [
 	'ObjectExpression',
 	'TemplateLiteral',
 	'UnaryExpression',
-	'UpdateExpression',
+	'UpdateExpression'
 ];
 
 // Technically these nodes could be a function, but most likely not
@@ -24,7 +24,6 @@ const mostLikelyNotNodeTypes = [
 	'TaggedTemplateExpression',
 	'ThisExpression'
 ];
-
 
 const notFunctionSelector = node => [
 	...[...impossibleNodeTypes, ...mostLikelyNotNodeTypes].map(type => `[${node}.type!="${type}"]`),

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
 import {outdent} from 'outdent';
 import rule from '../rules/no-fn-reference-in-iterator';
+import notFunctionTypes from './utils/not-function-types';
 
 const ERROR_WITH_NAME_MESSAGE_ID = 'error-with-name';
 const ERROR_WITHOUT_NAME_MESSAGE_ID = 'error-without-name';
@@ -22,8 +23,8 @@ const reduceLikeMethods = [
 ];
 
 const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
+	parserOptions: {
+		ecmaVersion: 2020
 	}
 });
 
@@ -90,15 +91,13 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 		'React.children.forEach(children, fn)',
 		'Vue.filter(name, fn)',
 
+		// First argument is not a function
+		...notFunctionTypes.map(data => `foo.map(${data})`),
+
 		// Ignored
 		'foo.map(() => {})',
 		'foo.map(function() {})',
-		'foo.map(function bar() {})',
-		'foo.map("string")',
-		'foo.map(null)',
-		'foo.map(1)',
-		'foo.map(true)',
-		'foo.map(undefined)'
+		'foo.map(function bar() {})'
 	],
 	invalid: [
 		// Suggestions

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -213,15 +213,6 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 				'foo.map((element, index, array) => (a ? b : c)(element, index, array))'
 			]
 		}),
-		invalidTestCase({
-			code: 'foo.map((() => _.map)())',
-			method: 'map',
-			suggestions: [
-				'foo.map((element) => (() => _.map)()(element))',
-				'foo.map((element, index) => (() => _.map)()(element, index))',
-				'foo.map((element, index, array) => (() => _.map)()(element, index, array))'
-			]
-		}),
 		// Note: `await` is not handled, not sure if this is needed
 		// invalidTestCase({
 		// 	code: `foo.map(await foo())`,

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -97,7 +97,20 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 		// Ignored
 		'foo.map(() => {})',
 		'foo.map(function() {})',
-		'foo.map(function bar() {})'
+		'foo.map(function bar() {})',
+
+		// #755
+		outdent`
+			const results = collection
+				.find({
+					$and: [cursorQuery, params.query]
+				}, {
+					projection: params.projection
+				})
+				.sort($sort)
+				.limit(params.limit + 1)
+				.toArray()
+		`
 	],
 	invalid: [
 		// Suggestions

--- a/test/no-reduce.js
+++ b/test/no-reduce.js
@@ -3,6 +3,7 @@ import avaRuleTester from 'eslint-ava-rule-tester';
 import {flatten} from 'lodash';
 import rule from '../rules/no-reduce';
 import {outdent} from 'outdent';
+import notFunctionTypes from './utils/not-function-types';
 
 const MESSAGE_ID_REDUCE = 'reduce';
 const MESSAGE_ID_REDUCE_RIGHT = 'reduceRight';
@@ -27,14 +28,7 @@ const tests = {
 		'[1, 2].reduce.call(() => {}, 34)',
 
 		// First argument is not a function
-		'a.reduce(123)',
-		'a.reduce(\'abc\')',
-		'a.reduce(null)',
-		'a.reduce(undefined)',
-		'a.reduce(123, initialValue)',
-		'a.reduce(\'abc\', initialValue)',
-		'a.reduce(null, initialValue)',
-		'a.reduce(undefined, initialValue)',
+		...notFunctionTypes.map(data => `foo.reduce(${data})`),
 
 		// Test `.reduce`
 		// Not `CallExpression`
@@ -104,7 +98,11 @@ const tests = {
 		'[].reducex.call(arr, foo)',
 		'[].xreduce.call(arr, foo)',
 		'Array.prototype.reducex.call(arr, foo)',
-		'Array.prototype.xreduce.call(arr, foo)'
+		'Array.prototype.xreduce.call(arr, foo)',
+
+		// Second argument is not a function
+		...notFunctionTypes.map(data => `Array.prototype.reduce.call(foo, ${data})`)
+
 	].map(code => [code, code.replace('reduce', 'reduceRight')])),
 	invalid: flatten([
 		'arr.reduce((total, item) => total + item)',

--- a/test/utils/not-function-types.js
+++ b/test/utils/not-function-types.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = [
+	// ArrayExpression
+	'[]',
+	'[element]',
+	'[...elements]',
+	// ClassExpression
+	'class Node {}',
+	// Literal
+	'0',
+	'1',
+	'0.1',
+	'""',
+	'"string"',
+	'/regex/',
+	'null',
+	'0n',
+	'1n',
+	'true',
+	'false',
+	// ObjectExpression
+	'{}',
+	// TemplateLiteral
+	'`templateLiteral`',
+	// Undefined
+	'undefined',
+	// ThisExpression
+	'this'
+];

--- a/test/utils/not-function-types.js
+++ b/test/utils/not-function-types.js
@@ -5,6 +5,10 @@ module.exports = [
 	'[]',
 	'[element]',
 	'[...elements]',
+	// BinaryExpression
+	'1 + fn',
+	'"length" in fn',
+	'fn instanceof Function',
 	// ClassExpression
 	'class Node {}',
 	// Literal
@@ -25,6 +29,24 @@ module.exports = [
 	'`templateLiteral`',
 	// Undefined
 	'undefined',
-	// ThisExpression
-	'this'
+	// UnaryExpression
+	'- fn',
+	'+ fn',
+	'~ fn',
+	'typeof fn',
+	'void fn',
+	'delete fn',
+	// UpdateExpression
+	'++ fn',
+	'-- fn',
+
+	// Following are not safe
+	'a = fn', // could be a function
+	// 'await fn', // this requires async function to test, ignore for now
+	'fn()', // could be a factory returns a function
+	'false || fn', // could be a function
+	'new Fn()', // class constructor could return a function
+	'new Function()', // class constructor could return a function
+	'fn``', // same as `CallExpression`
+	'this' // could be a function
 ];

--- a/test/utils/not-function-types.js
+++ b/test/utils/not-function-types.js
@@ -41,12 +41,12 @@ module.exports = [
 	'-- fn',
 
 	// Following are not safe
-	'a = fn', // could be a function
-	// 'await fn', // this requires async function to test, ignore for now
-	'fn()', // could be a factory returns a function
-	'false || fn', // could be a function
-	'new Fn()', // class constructor could return a function
-	'new Function()', // class constructor could return a function
-	'fn``', // same as `CallExpression`
-	'this' // could be a function
+	'a = fn', // Could be a function
+	// 'await fn', // This requires async function to test, ignore for now
+	'fn()', // Could be a factory returns a function
+	'false || fn', // Could be a function
+	'new Fn()', // `class` constructor could return a function
+	'new Function()', // `function`
+	'fn``', // Same as `CallExpression`
+	'this' // Could be a function
 ];

--- a/test/utils/not-function-types.js
+++ b/test/utils/not-function-types.js
@@ -10,7 +10,7 @@ module.exports = [
 	'"length" in fn',
 	'fn instanceof Function',
 	// ClassExpression
-	'class Node {}',
+	'class ClassCantUseAsFunction {}',
 	// Literal
 	'0',
 	'1',
@@ -44,8 +44,8 @@ module.exports = [
 	'a = fn', // Could be a function
 	// 'await fn', // This requires async function to test, ignore for now
 	'fn()', // Could be a factory returns a function
-	'false || fn', // Could be a function
-	'new Fn()', // `class` constructor could return a function
+	'fn1 || fn2', // Could be a function
+	'new ClassReturnsFunction()', // `class` constructor could return a function
 	'new Function()', // `function`
 	'fn``', // Same as `CallExpression`
 	'this' // Could be a function


### PR DESCRIPTION
- Ignore more types that can't be a `function` on `no-fn-reference-in-iterator` and `no-reduce` rule.

Including some unsafe node types, like

```
a.find(a = fn);
a.find(await fn);
a.find(fn());
a.find(fn1 || fn2);
a.find(new Foo());
a.find(new Function());
a.find(tag`unicorn`);
a.find(this);
```

They could be function, but not very common. Some might need discuss. like `fn()` and `fn1 || fn2`.

- Fix some logic error in `no-reduce` rule.

Fixes #755
