### PR TITLE
`no-useless-undefined`: Ignore `undefined` use in compare functions

### DIFF
--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -32,6 +32,43 @@ const assignmentPatternSelector = getSelector('AssignmentPattern', 'right');
 
 const isUndefined = node => node && node.type === 'Identifier' && node.name === 'undefined';
 
+const compareFunctionNames = new Set([
+	'is',
+	'equal',
+	'notEqual',
+	'strictEqual',
+	'notStrictEqual',
+	'propertyVal',
+	'notPropertyVal',
+	'not',
+	'include',
+	'property',
+	'toBe',
+	'toContain',
+	'toContainEqual',
+	'toEqual',
+	'same',
+	'notSame',
+	'strictSame',
+	'strictNotSame'
+]);
+const isCompareFunction = node => {
+	let name;
+
+	if (node.type === 'Identifier') {
+		name = node.name;
+	} else if (
+		node.type === 'MemberExpression' &&
+		node.computed = false &&
+		node.property &&
+		node.property.type === 'Identifier'
+	) {
+		name = node.property.name;
+	}
+
+	return compareFunctionNames.has(name);
+}
+
 const create = context => {
 	const listener = fix => node => {
 		context.report({
@@ -64,6 +101,10 @@ const create = context => {
 			(node, fixer) => fixer.removeRange([node.parent.left.range[1], node.range[1]])
 		),
 		CallExpression: node => {
+			if (isCompareFunction(node.callee)) {
+				return;
+			}
+
 			const argumentNodes = node.arguments;
 			const undefinedArguments = [];
 			for (let index = argumentNodes.length - 1; index >= 0; index--) {

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -59,7 +59,7 @@ const isCompareFunction = node => {
 		name = node.name;
 	} else if (
 		node.type === 'MemberExpression' &&
-		node.computed = false &&
+		node.computed === false &&
 		node.property &&
 		node.property.type === 'Identifier'
 	) {

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -67,7 +67,7 @@ const isCompareFunction = node => {
 	}
 
 	return compareFunctionNames.has(name);
-}
+};
 
 const create = context => {
 	const listener = fix => node => {

--- a/test/no-useless-undefined.js
+++ b/test/no-useless-undefined.js
@@ -31,7 +31,28 @@ ruleTester.run('no-useless-undefined', rule, {
 		'function foo({bar} = {}) {}',
 		'function foo(bar) {}',
 		// I guess nobody use this, but `yield* undefined;` is valid code, and `yield*;` is not
-		'function* foo() {yield* undefined;}'
+		'function* foo() {yield* undefined;}',
+
+		// Ignored
+		'if (Object.is(foo, undefined)){}',
+		't.is(foo, undefined)',
+		'assert.equal(foo, undefined, message)',
+		'assert.notEqual(foo, undefined, message)',
+		'assert.strictEqual(foo, undefined, message)',
+		'assert.notStrictEqual(foo, undefined, message)',
+		'assert.propertyVal(foo, "bar", undefined, message)',
+		'assert.notPropertyVal(foo, "bar", undefined, message)',
+		'expect(foo).not(undefined)',
+		'expect(foo).to.have.property("bar", undefined)',
+		'expect(foo).to.have.property("bar", undefined)',
+		'expect(foo).toBe(undefined)',
+		'expect(foo).toContain(undefined)',
+		'expect(foo).toContainEqual(undefined)',
+		'expect(foo).toEqual(undefined)',
+		't.same(foo, undefined)',
+		't.notSame(foo, undefined)',
+		't.strictSame(foo, undefined)',
+		't.strictNotSame(foo, undefined)'
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Add popular assert/test lib compare function names to ignore them.

Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/728