### PR TITLE
`prefer-starts-ends-with`: Fix pipe in regex

### DIFF
--- a/rules/prefer-starts-ends-with.js
+++ b/rules/prefer-starts-ends-with.js
@@ -11,7 +11,7 @@ const doesNotContain = (string, characters) => characters.every(character => !st
 
 const isSimpleString = string => doesNotContain(
 	string,
-	['^', '$', '+', '[', '{', '(', '\\', '.', '?', '*']
+	['^', '$', '+', '[', '{', '(', '\\', '.', '?', '*', '|']
 );
 
 const regexTestSelector = [

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -27,7 +27,8 @@ const validRegex = [
 	/^foo/i,
 	/^foo/m,
 	/^foo/im,
-	/^A|B/
+	/^A|B/,
+	/A|B$/
 ];
 
 const invalidRegex = [

--- a/test/prefer-starts-ends-with.js
+++ b/test/prefer-starts-ends-with.js
@@ -26,7 +26,8 @@ const validRegex = [
 	/\^foo/,
 	/^foo/i,
 	/^foo/m,
-	/^foo/im
+	/^foo/im,
+	/^A|B/
 ];
 
 const invalidRegex = [


### PR DESCRIPTION
Fix the case where `/^A|B/.test(s)` → `s.startsWith('A|B')`.

Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/782

