### PR TITLE
`consistent-function-scoping`: Fix wrong report when using JSX

### DIFF
--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -159,7 +159,7 @@ const create = context => {
 		JSXElement() {
 			hasJsx = true;
 		},
-		'ArrowFunctionExpression, FunctionDeclaration'(node){
+		'ArrowFunctionExpression, FunctionDeclaration'(node) {
 			if (!hasJsx) {
 				functions.push(node);
 			}

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -608,7 +608,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 			`,
 			errors: [createError('function \'baz\'')]
 		},
-		// Jsx
+		// JSX
 		{
 			// Function `c` is not used, but we can't tell
 			code: outdent`

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -198,6 +198,13 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 			}
 		`,
+		outdent`
+			function foo() {
+				function bar() {
+					return <JSX/>;
+				}
+			}
+		`,
 		// `this`
 		outdent`
 			function doFoo(Foo) {

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -189,7 +189,13 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return <FooComponent />;
 				}
 				return Bar;
-			};
+			}
+		`,
+		outdent`
+			function doFoo(FooComponent) {
+				function bar() {}
+				return <FooComponent a={bar()}/>;
+			}
 		`,
 		// `this`
 		outdent`

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -603,19 +603,21 @@ ruleTester.run('consistent-function-scoping', rule, {
 		},
 		// Jsx
 		{
+			// Function `c` is not used, but we can't tell
 			code: outdent`
 				function fn1() {
 					function a() {
 						return <JSX a={b()}/>;
 					}
 					function b() {}
+					function c() {}
 				}
 				function fn2() {
 					function foo() {}
 				}
 			`,
 			errors: [createError('function \'foo\'')]
-		},
+		}
 	]
 });
 

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -192,9 +192,10 @@ ruleTester.run('consistent-function-scoping', rule, {
 			}
 		`,
 		outdent`
-			function doFoo(FooComponent) {
-				function bar() {}
-				return <FooComponent a={bar()}/>;
+			function foo() {
+				function bar() {
+					return <JSX a={foo()}/>;
+				}
 			}
 		`,
 		// `this`
@@ -599,7 +600,22 @@ ruleTester.run('consistent-function-scoping', rule, {
 				)
 			`,
 			errors: [createError('function \'baz\'')]
-		}
+		},
+		// Jsx
+		{
+			code: outdent`
+				function fn1() {
+					function a() {
+						return <JSX a={b()}/>;
+					}
+					function b() {}
+				}
+				function fn2() {
+					function foo() {}
+				}
+			`,
+			errors: [createError('function \'foo\'')]
+		},
 	]
 });
 


### PR DESCRIPTION
~I'm not sure if this regression of #551, but I think the old one also not right, the function position should not effect the result.~

~In this PR, I simply ignore all functions if JSX is used.~

~Maybe we can improve this rule later.~

It should be regression of #551