### PR TITLE
Add ev-to-event default replacement to prevent-abbreviations rule

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -94,9 +94,9 @@ const defaultReplacements = {
 	err: {
 		error: true
 	},
-  ev: {
-    event: true
-  },
+	ev: {
+		event: true
+	},
 	evt: {
 		event: true
 	},

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -94,6 +94,9 @@ const defaultReplacements = {
 	err: {
 		error: true
 	},
+  ev: {
+    event: true
+  },
 	evt: {
 		event: true
 	},


### PR DESCRIPTION
This adds a new default replacement to the `prevent-abbreviations` rule for `ev` -> `event`.

I'm not sure if there is a lot of process around adding something like this so feel free to close this or ask for changes that I may have missed.