### PR TITLE
Allow `Children` in `no-fn-reference-in-iterator`

### DIFF
--- a/rules/no-fn-reference-in-iterator.js
+++ b/rules/no-fn-reference-in-iterator.js
@@ -60,6 +60,7 @@ const iteratorMethods = [
 const ignoredCallee = [
 	'Promise',
 	'React.children',
+	'Children',
 	'lodash',
 	'underscore',
 	'_',

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -88,7 +88,8 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 		'_.map(fn)',
 		'Async.map(list, fn)',
 		'async.map(list, fn)',
-		'React.children.forEach(children, fn)',
+		'React.Children.forEach(children, fn)',
+		'Children.forEach(children, fn)',
 		'Vue.filter(name, fn)',
 
 		// First argument is not a function

--- a/test/no-fn-reference-in-iterator.js
+++ b/test/no-fn-reference-in-iterator.js
@@ -89,7 +89,7 @@ ruleTester.run('no-fn-reference-in-iterator', rule, {
 		'Async.map(list, fn)',
 		'async.map(list, fn)',
 		'React.Children.forEach(children, fn)',
-		'Children.forEach(children, fn)',
+		'Children.forEach(children, fn)', // `import {Children} from 'react';`
 		'Vue.filter(name, fn)',
 
 		// First argument is not a function


### PR DESCRIPTION
This allows the use of `Children.map(children, fn)` in
`no-fn-reference-in-iterator`. This handles the following situation.

```js
import { Children } from 'react';

export default ({ children ]) => (
  Children.map(children, (child) => child)
);
```

The casing for `React.Children` in the test has been changed to better reflect
reality.

Refs #121