### PR TITLE
`no-unused-properties`: Fix error thrown when using rest in object destructuring 

### DIFF
--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -57,7 +57,7 @@ const propertyKeysEqual = (keyA, keyB) => {
 
 const objectPatternMatchesObjectExprPropertyKey = (pattern, key) => {
 	return pattern.properties.some(property => {
-		if (property.type === 'ExperimentalRestProperty') {
+		if (property.type === 'ExperimentalRestProperty' || property.type === 'RestElement') {
 			return true;
 		}
 

--- a/test/no-unused-properties.js
+++ b/test/no-unused-properties.js
@@ -8,6 +8,7 @@ const ruleTester = avaRuleTester(test, {
 		es6: true
 	},
 	parserOptions: {
+		ecmaVersion: 2020,
 		sourceType: 'module'
 	}
 });
@@ -280,6 +281,10 @@ ruleTester.run('no-unused-properties', rule, {
 				a: 1
 			};
 			exports.foo = foo;
+		`,
+		outdent`
+			const foo = {a: 1, b: 2};
+			const {a, ...rest} = foo;
 		`
 	],
 


### PR DESCRIPTION
Fixes #810