### PR TITLE
`number-literal-case`: Fix false positive on `@typescript-eslint/parser`

### DIFF
--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -2,15 +2,13 @@
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
 const fix = (raw, isBigInt) => {
-	let fixed = raw;
-
-	fixed = fixed.toLowerCase();
+	let fixed = raw.toLowerCase();
 	if (fixed.startsWith('0x')) {
 		fixed = '0x' + fixed.slice(2).toUpperCase();
-	}
 
-	if (isBigInt) {
-		fixed = fixed.slice(0, -1) + 'n';
+		if (isBigInt) {
+			fixed = fixed.slice(0, -1) + 'n';
+		}
 	}
 
 	return fixed;

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -1,13 +1,19 @@
 'use strict';
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
-const fix = (value, isBigInt) => {
-	value = value.toLowerCase();
-	if (value.startsWith('0x')) {
-		value = '0x' + value.slice(2).toUpperCase();
+const fix = (raw, isBigInt) => {
+	let fixed = raw;
+
+	fixed = fixed.toLowerCase();
+	if (fixed.startsWith('0x')) {
+		fixed = '0x' + fixed.slice(2).toUpperCase();
 	}
 
-	return `${value}${isBigInt ? 'n' : ''}`;
+	if (isBigInt) {
+		fixed = fixed.slice(0, -1) + 'n';
+	}
+
+	return fixed;
 };
 
 const create = context => {
@@ -20,7 +26,7 @@ const create = context => {
 				return;
 			}
 
-			const fixed = fix(isBigInt ? bigint : raw, isBigInt);
+			const fixed = fix(raw, isBigInt);
 
 			if (raw !== fixed) {
 				context.report({

--- a/test/number-literal-case.js
+++ b/test/number-literal-case.js
@@ -11,18 +11,31 @@ const ruleTester = avaRuleTester(test, {
 		ecmaVersion: 2020
 	}
 });
+const babelRuleTester = avaRuleTester(test, {
+	parser: require.resolve('babel-eslint')
+});
+const typescriptRuleTester = avaRuleTester(test, {
+	parser: require.resolve('@typescript-eslint/parser')
+});
 
 const error = {
 	message: 'Invalid number literal casing.'
 };
 
-// TODO: Add numeric separator tests when ESLint supports it.
+// Legacy octal literals
 ruleTester.run('number-literal-case', rule, {
+	valid: [
+		'const foo = 0777',
+		'const foo = 0888'
+	],
+	invalid: []
+});
+
+// TODO: Add numeric separator tests when ESLint supports it.
+const tests = {
 	valid: [
 		// Number
 		'const foo = 1234',
-		'const foo = 0777',
-		'const foo = 0888',
 		'const foo = 0b10',
 		'const foo = 0o1234567',
 		'const foo = 0xABCDEF',
@@ -81,6 +94,22 @@ ruleTester.run('number-literal-case', rule, {
 			errors: [error],
 			output: 'const foo = 0xABCDEFn'
 		},
+		// `0n`
+		{
+			code: 'const foo = 0B0n',
+			errors: [error],
+			output: 'const foo = 0b0n'
+		},
+		{
+			code: 'const foo = 0O0n',
+			errors: [error],
+			output: 'const foo = 0o0n'
+		},
+		{
+			code: 'const foo = 0X0n',
+			errors: [error],
+			output: 'const foo = 0x0n'
+		},
 
 		// Exponential notation
 		{
@@ -116,4 +145,8 @@ ruleTester.run('number-literal-case', rule, {
 			`
 		}
 	]
-});
+};
+
+ruleTester.run('number-literal-case', rule, tests);
+babelRuleTester.run('number-literal-case', rule, tests);
+typescriptRuleTester.run('number-literal-case', rule, tests);


### PR DESCRIPTION

Fixes #812

- Run tests on `espree`, `babel-eslint`, `@typescript-eslint/parser`
- Add some `0n` tests