### PR TITLE
Track JSX presence per-function, fixing some false negatives

### DIFF
--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -153,17 +153,16 @@ const create = context => {
 	const {scopeManager} = sourceCode;
 
 	const functions = [];
-	let hasJsx = false;
 
 	return {
-		'ArrowFunctionExpression, FunctionDeclaration': node => functions.push(node),
+		'ArrowFunctionExpression, FunctionDeclaration': () => functions.push(false),
 		JSXElement: () => {
 			// Turn off this rule if we see a JSX element because scope
 			// references does not include JSXElement nodes.
-			hasJsx = true;
+			functions[functions.length - 1] = true;
 		},
 		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': node => {
-			if (!hasJsx && !checkNode(node, scopeManager)) {
+			if (!functions[functions.length - 1] && !checkNode(node, scopeManager)) {
 				context.report({
 					node,
 					loc: getFunctionHeadLocation(node, sourceCode),
@@ -175,9 +174,6 @@ const create = context => {
 			}
 
 			functions.pop();
-			if (functions.length === 0) {
-				hasJsx = false;
-			}
 		}
 	};
 };

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -155,14 +155,17 @@ const create = context => {
 	const functions = [];
 
 	return {
-		'ArrowFunctionExpression, FunctionDeclaration': () => functions.push(false),
+		'ArrowFunctionExpression, FunctionDeclaration': () => {
+			functions.push(false);
+		},
 		JSXElement: () => {
 			// Turn off this rule if we see a JSX element because scope
 			// references does not include JSXElement nodes.
 			functions[functions.length - 1] = true;
 		},
 		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': node => {
-			if (!functions[functions.length - 1] && !checkNode(node, scopeManager)) {
+			const lastFunction = functions.pop();
+			if (!lastFunction && !checkNode(node, scopeManager)) {
 				context.report({
 					node,
 					loc: getFunctionHeadLocation(node, sourceCode),
@@ -172,8 +175,6 @@ const create = context => {
 					}
 				});
 			}
-
-			functions.pop();
 		}
 	};
 };

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -161,7 +161,9 @@ const create = context => {
 		JSXElement: () => {
 			// Turn off this rule if we see a JSX element because scope
 			// references does not include JSXElement nodes.
-			functions[functions.length - 1] = true;
+			if (functions.length !== 0) {
+				functions[functions.length - 1] = true;
+			}
 		},
 		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': node => {
 			const lastFunction = functions.pop();

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -166,8 +166,8 @@ const create = context => {
 			}
 		},
 		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': node => {
-			const lastFunction = functions.pop();
-			if (!lastFunction && !checkNode(node, scopeManager)) {
+			const currentFunctionHasJsx = functions.pop();
+			if (!currentFunctionHasJsx && !checkNode(node, scopeManager)) {
 				context.report({
 					node,
 					loc: getFunctionHeadLocation(node, sourceCode),

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -192,6 +192,15 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return Bar;
 			};
 		`,
+		// Functions that could be extracted are conservatively ignored due to JSX masking references
+		outdent`
+				function Foo() {
+					function Bar () {
+						return <div />
+					}
+					return <div>{ Bar() }</div>
+				}
+		`,
 		// `this`
 		outdent`
 			function doFoo(Foo) {
@@ -594,6 +603,32 @@ ruleTester.run('consistent-function-scoping', rule, {
 				)
 			`,
 			errors: [createError('function \'baz\'')]
+		},
+		{
+			code: outdent`
+				function Foo() {
+					const Bar = <div />
+					function doBaz() {
+						return 42
+					}
+					return <div>{ doBaz() }</div>
+				}
+			`,
+			errors: [createError('function \'doBaz\'')]
+		},
+		{
+			code: outdent`
+				function Foo() {
+					function Bar () {
+						return <div />
+					}
+					function doBaz() {
+						return 42
+					}
+					return <div>{ doBaz() }</div>
+				}
+			`,
+			errors: [createError('function \'doBaz\'')]
 		}
 	]
 });

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -192,6 +192,9 @@ ruleTester.run('consistent-function-scoping', rule, {
 				return Bar;
 			};
 		`,
+		outdent`
+			const foo = <JSX/>;
+		`,
 		// Functions that could be extracted are conservatively ignored due to JSX masking references
 		outdent`
 				function Foo() {

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -201,6 +201,20 @@ ruleTester.run('consistent-function-scoping', rule, {
 					return <div>{ Bar() }</div>
 				}
 		`,
+		outdent`
+			function foo() {
+				function bar() {
+					return <JSX a={foo()}/>;
+				}
+			}
+		`,
+		outdent`
+			function foo() {
+				function bar() {
+					return <JSX/>;
+				}
+			}
+		`,
 		// `this`
 		outdent`
 			function doFoo(Foo) {
@@ -629,6 +643,22 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 			`,
 			errors: [createError('function \'doBaz\'')]
+		},
+		// JSX
+		{
+			code: outdent`
+				function fn1() {
+					function a() {
+						return <JSX a={b()}/>;
+					}
+					function b() {}
+					function c() {}
+				}
+				function fn2() {
+					function foo() {}
+				}
+			`,
+			errors: ['b', 'c', 'foo'].map(functionName => createError(`function \'${functionName}\'`))
 		}
 	]
 });

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -661,7 +661,7 @@ ruleTester.run('consistent-function-scoping', rule, {
 					function foo() {}
 				}
 			`,
-			errors: ['b', 'c', 'foo'].map(functionName => createError(`function \'${functionName}\'`))
+			errors: ['b', 'c', 'foo'].map(functionName => createError(`function '${functionName}'`))
 		}
 	]
 });


### PR DESCRIPTION
Removing some false negatives of movable functions that were ignored because they were defined after some JSX

This is a follow up to https://github.com/sindresorhus/eslint-plugin-unicorn/commit/8a999c028f19337e8241f706b2bb1c4e8975efac

I noticed this example has a false negative:
```javascript
function Foo() {
  const Bar = <div />
  function doBaz() {
    return 42
  }
  return <div>{ doBaz() }</div>
}
```
where `doBaz` comes after `Bar`, so it's treated as unmovable because the rule is using a singular boolean flag.
If `const Bar = <div />` is moved to after `doBaz`, it correctly identifies it as movable because the flag hasn't been set yet.
The scope has to reach module-level again before the flag is turned off, meaning any safely-movable functions succeeding some JSX, or succeeding another *scope* with some JSX in are ignored.

This PR changes the rule to track whether JSX has been identified more finely, so it no longer ignores safe functions like these.

I tried this change out on a large-ish React codebase and whilst it picked up a previous false negative that could be safely moved, it didn't newly identify any false positives, so that's a good sign above and beyond the test examples.