### PR TITLE
`prevent-abbreviations`: Add `fn`/`func` -> `function`, `i`/`idx`/`j` -> `index` replacements

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,15 @@
 		],
 		"rules": {
 			"strict": "error",
-			"unicorn/no-null": "error"
+			"unicorn/no-null": "error",
+			"unicorn/prevent-abbreviations": [
+				"error",
+				{
+					"replacements": {
+						"fn": false
+					}
+				}
+			]
 		}
 	}
 }

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -15,8 +15,8 @@ const isApplySignature = (argument1, argument2) => (
 	)
 );
 
-const getReflectApplyCall = (sourceCode, func, receiver, arguments_) => (
-	`Reflect.apply(${sourceCode.getText(func)}, ${sourceCode.getText(receiver)}, ${sourceCode.getText(arguments_)})`
+const getReflectApplyCall = (sourceCode, target, receiver, argumentsList) => (
+	`Reflect.apply(${sourceCode.getText(target)}, ${sourceCode.getText(receiver)}, ${sourceCode.getText(argumentsList)})`
 );
 
 const fixDirectApplyCall = (node, sourceCode) => {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -106,6 +106,21 @@ const defaultReplacements = {
 	exts: {
 		extensions: true
 	},
+	fn: {
+		function: true
+	},
+	func: {
+		function: true
+	},
+	i: {
+		index: true
+	},
+	idx: {
+		index: true
+	},
+	j: {
+		index: true
+	},
 	len: {
 		length: true
 	},

--- a/rules/utils/cartesian-product-samples.js
+++ b/rules/utils/cartesian-product-samples.js
@@ -15,8 +15,8 @@ module.exports = (combinations, length = Infinity) => {
 	const samples = Array.from({length: Math.min(total, length)}, (_, sampleIndex) => {
 		let indexRemaining = sampleIndex;
 		const combination = [];
-		for (let i = combinations.length - 1; i >= 0; i--) {
-			const items = combinations[i];
+		for (let combinationIndex = combinations.length - 1; combinationIndex >= 0; combinationIndex--) {
+			const items = combinations[combinationIndex];
 			const {length} = items;
 			const index = indexRemaining % length;
 			indexRemaining = (indexRemaining - index) / length;

--- a/test/lint/lint.js
+++ b/test/lint/lint.js
@@ -18,7 +18,17 @@ const eslint = new ESLint({
 		ignorePatterns: [
 			'coverage',
 			'test/integration/fixtures'
-		]
+		],
+		rules: {
+			'unicorn/prevent-abbreviations': [
+				'error',
+				{
+					replacements: {
+						fn: false
+					}
+				}
+			]
+		}
 	}
 });
 

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -840,6 +840,86 @@ ruleTester.run('prevent-abbreviations', rule, {
 			errors: createErrors()
 		},
 
+		// This test need run eslint 3 times to get the correct result
+		{
+			code: outdent`
+				function fn() {
+					for (let i = 0; i<10; i++) {
+						for (let j = 0; j<10; j++) {
+							console.log(i, j)
+						}
+					}
+				}
+				const func = fn;
+			`,
+			output: outdent`
+				function function_() {
+					for (let i = 0; i<10; i++) {
+						for (let j = 0; j<10; j++) {
+							console.log(i, j)
+						}
+					}
+				}
+				const func = function_;
+			`,
+			errors: [
+				...createErrors('The variable `fn` should be named `function_`. A more descriptive name will do too.'),
+				...createErrors('The variable `i` should be named `index`. A more descriptive name will do too.'),
+				...createErrors('The variable `j` should be named `index_`. A more descriptive name will do too.'),
+				...createErrors('The variable `func` should be named `function__`. A more descriptive name will do too.')
+			]
+		},
+		{
+			code: outdent`
+				function function_() {
+					for (let i = 0; i<10; i++) {
+						for (let j = 0; j<10; j++) {
+							console.log(i, j)
+						}
+					}
+				}
+				const func = function_;
+			`,
+			output: outdent`
+				function function_() {
+					for (let index = 0; index<10; index++) {
+						for (let j = 0; j<10; j++) {
+							console.log(index, j)
+						}
+					}
+				}
+				const function__ = function_;
+			`,
+			errors: [
+				...createErrors('The variable `i` should be named `index`. A more descriptive name will do too.'),
+				...createErrors('The variable `j` should be named `index_`. A more descriptive name will do too.'),
+				...createErrors('The variable `func` should be named `function__`. A more descriptive name will do too.')
+			]
+		},
+		{
+			code: outdent`
+				function function_() {
+					for (let index = 0; index<10; index++) {
+						for (let j = 0; j<10; j++) {
+							console.log(index, j)
+						}
+					}
+				}
+				const function__ = function_;
+			`,
+			output: outdent`
+				function function_() {
+					for (let index = 0; index<10; index++) {
+						for (let index_ = 0; index_<10; index_++) {
+							console.log(index, index_)
+						}
+					}
+				}
+				const function__ = function_;
+			`,
+			errors: createErrors('The variable `j` should be named `index_`. A more descriptive name will do too.')
+		},
+
 		// `package` is a reserved word in strict mode
 		{
 			code: 'let pkg',


### PR DESCRIPTION


Fixes #831
