### PR TITLE
fix: Prefer-flat-map rule: allow .map(...).flat(Infinity)

### DIFF
--- a/rules/prefer-flat-map.js
+++ b/rules/prefer-flat-map.js
@@ -141,8 +141,10 @@ const create = context => ({
 
 		if (
 			node.arguments.length === 1 &&
-			node.arguments[0].type === 'Literal' &&
-			node.arguments[0].value !== 1
+			((node.arguments[0].type === 'Literal' &&
+			node.arguments[0].value !== 1) ||
+			(node.arguments[0].type === 'Identifier' &&
+			node.arguments[0].value === 'Infinity'))
 		) {
 			return;
 		}


### PR DESCRIPTION
Small fix that no longer show error when using Infinity in `.map(...).flat(Infinity)`