### PR TITLE
`explicit-length-check`: Use `'non-zero': 'greater-than'` by default

### DIFF
--- a/docs/rules/explicit-length-check.md
+++ b/docs/rules/explicit-length-check.md
@@ -1,6 +1,6 @@
 # Enforce explicitly comparing the `length` property of a value
 
-Enforce explicitly checking the length of a value array in an `if` condition, rather than checking the truthiness of the length.
+Enforce explicitly checking the length of a value array in an `if` condition, rather than checking the truthiness of the length, and enforce comparison style.
 
 This rule is partly fixable.
 
@@ -10,6 +10,7 @@ This rule is partly fixable.
 if (string.length) {}
 if (array.length) {}
 if (!array.length) {}
+if (array.length !== 0) {}
 ```
 
 ### Pass
@@ -17,14 +18,13 @@ if (!array.length) {}
 ```js
 if (string.length > 0) {}
 if (array.length > 0) {}
-if (array.length !== 0) {}
 if (array.length === 0) {}
 ```
 
 
 ## Zero comparisons
 
-Enforce comparison with `!== 0` when checking for zero length.
+Enforce comparison with `=== 0` when checking for zero length.
 
 ### Fail
 
@@ -35,13 +35,13 @@ if (string.length < 1) {}
 ### Pass
 
 ```js
-if (array.length !== 0) {}
+if (array.length === 0) {}
 ```
 
 
 ## Non-zero comparisons
 
-You can define your preferred way of checking non-zero length by providing a `non-zero` option:
+You can define your preferred way of checking non-zero length by providing a `non-zero` option (`greater-than` by default):
 
 ```js
 {
@@ -53,9 +53,9 @@ You can define your preferred way of checking non-zero length by providing a `no
 
 The `non-zero` option can be configured with one of the following:
 
+- `greater-than` (default)
+	- Enforces non-zero to be checked with: `array.length > 0`
 - `not-equal`
 	- Enforces non-zero to be checked with: `array.length !== 0`
-- `greater-than`
-	- Enforces non-zero to be checked with: `array.length > 0`
 - `greater-than-or-equal`
 	- Enforces non-zero to be checked with: `array.length >= 1`

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -164,7 +164,7 @@ const create = context => {
 		JSXElement: () => {
 			// Turn off this rule if we see a JSX element because scope
 			// references does not include JSXElement nodes.
-			if (functions.length !== 0) {
+			if (functions.length > 0) {
 				functions[functions.length - 1] = true;
 			}
 		},

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -43,7 +43,7 @@ function checkZeroType(context, node) {
 	}
 }
 
-function checkNonZeroType(context, node, type) {
+function checkNonZeroType(context, node, type = 'greater-than') {
 	const {value} = node.right;
 	const {operator} = node;
 
@@ -162,7 +162,8 @@ const schema = [
 		type: 'object',
 		properties: {
 			'non-zero': {
-				enum: ['not-equal', 'greater-than', 'greater-than-or-equal']
+				enum: ['not-equal', 'greater-than', 'greater-than-or-equal'],
+				default: 'greater-than'
 			}
 		}
 	}

--- a/rules/prefer-optional-catch-binding.js
+++ b/rules/prefer-optional-catch-binding.js
@@ -19,7 +19,7 @@ const create = context => {
 			const scope = context.getScope();
 			const variable = findVariable(scope, node);
 
-			if (variable.references.length !== 0) {
+			if (variable.references.length > 0) {
 				return;
 			}
 

--- a/rules/utils/method-selector.js
+++ b/rules/utils/method-selector.js
@@ -28,7 +28,7 @@ module.exports = options => {
 		selector.push(`[${prefix}callee.property.name="${name}"]`);
 	}
 
-	if (Array.isArray(names) && names.length !== 0) {
+	if (Array.isArray(names) && names.length > 0) {
 		selector.push(
 			':matches(' +
 			names.map(name => `[${prefix}callee.property.name="${name}"]`).join(', ') +

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -33,8 +33,6 @@ ruleTester.run('explicit-length-check', rule, {
 		testCase('if ("".length > 0) {}'),
 		testCase('if (array.length === 0) {}'),
 		testCase('if (array.length == 0) {}'),
-		testCase('if (array.length !== 0) {}'),
-		testCase('if (array.length !== 0 && array[0] === 1) {}'),
 		testCase('if (array.length === 1) {}'),
 		testCase('if (array.length <= 1) {}'),
 		testCase('if (array.length > 1) {}'),
@@ -116,6 +114,18 @@ ruleTester.run('explicit-length-check', rule, {
 			undefined,
 			['zeroEqual'],
 			'if (array.length === 0) {}'
+		),
+		testCase(
+			'if (array.length !== 0) {}',
+			undefined,
+			['nonZeroGreater'],
+			'if (array.length > 0) {}'
+		),
+		testCase(
+			'if (array.length !== 0 && array[0] === 1) {}',
+			undefined,
+			['nonZeroGreater'],
+			'if (array.length > 0 && array[0] === 1) {}'
 		),
 		testCase(
 			'if (array.length > 0) {}',


### PR DESCRIPTION
Note that this is a breaking change since the rule wasn't enforcing any non-zero comparison style by default before, but now it enforces the `greater-than` style.

Fixes #702 