### PR TITLE
`prefer-ternary`: Refactor to use ESLint recommended way to extend fix range

### DIFF
--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -244,7 +244,7 @@ const create = context => {
 					yield fixer.replaceText(node, fixed);
 
 					if (generateNewVariables) {
-						yield * extendFixRange(fixer, sourceCode.ast.range);
+						yield * extendFixRange();
 					}
 				}
 			});

--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -244,7 +244,7 @@ const create = context => {
 					yield fixer.replaceText(node, fixed);
 
 					if (generateNewVariables) {
-						yield * extendFixRange();
+						yield * extendFixRange(fixer, sourceCode.ast.range);
 					}
 				}
 			});

--- a/rules/utils/extend-fix-range.js
+++ b/rules/utils/extend-fix-range.js
@@ -3,11 +3,13 @@
 /**
 Extend fix range to prevent changes from other rules
 https://github.com/eslint/eslint/pull/13748/files#diff-c692f3fde09eda7c89f1802c908511a3fb59f5d207fe95eb009cb52e46a99e84R348
+
+@param {ruleFixer} fixer The fixer to fix.
+@param {int[]} node The extended range node.
 */
-function * extendFixRange(range = []) {
-	const [start = 0, end = Infinity] = range;
-	yield {range: [start, start], text: ''};
-	yield {range: [end, end], text: ''};
+function * extendFixRange(fixer, range) {
+	yield fixer.insertTextBeforeRange(range, '');
+	yield fixer.insertTextAfterRange(range, '');
 }
 
 module.exports = extendFixRange;

--- a/rules/utils/extend-fix-range.js
+++ b/rules/utils/extend-fix-range.js
@@ -5,7 +5,7 @@ Extend fix range to prevent changes from other rules
 https://github.com/eslint/eslint/pull/13748/files#diff-c692f3fde09eda7c89f1802c908511a3fb59f5d207fe95eb009cb52e46a99e84R348
 
 @param {ruleFixer} fixer The fixer to fix.
-@param {int[]} node The extended range node.
+@param {int[]} range The extended range node.
 */
 function * extendFixRange(fixer, range) {
 	yield fixer.insertTextBeforeRange(range, '');

--- a/rules/utils/extend-fix-range.js
+++ b/rules/utils/extend-fix-range.js
@@ -3,13 +3,11 @@
 /**
 Extend fix range to prevent changes from other rules
 https://github.com/eslint/eslint/pull/13748/files#diff-c692f3fde09eda7c89f1802c908511a3fb59f5d207fe95eb009cb52e46a99e84R348
-
-@param {ruleFixer} fixer The fixer to fix.
-@param {int[]} node The extended range node.
 */
-function * extendFixRange(fixer, range) {
-	yield fixer.insertTextBeforeRange(range, '');
-	yield fixer.insertTextAfterRange(range, '');
+function * extendFixRange(range = []) {
+	const [start = 0, end = Infinity] = range;
+	yield {range: [start, start], text: ''};
+	yield {range: [end, end], text: ''};
 }
 
 module.exports = extendFixRange;

--- a/rules/utils/extend-fix-range.js
+++ b/rules/utils/extend-fix-range.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+Extend fix range to prevent changes from other rules
+https://github.com/eslint/eslint/pull/13748/files#diff-c692f3fde09eda7c89f1802c908511a3fb59f5d207fe95eb009cb52e46a99e84R348
+
+@param {ruleFixer} fixer The fixer to fix.
+@param {int[]} node The extended range node.
+*/
+function * extendFixRange(fixer, range) {
+	yield fixer.insertTextBeforeRange(range, '');
+	yield fixer.insertTextAfterRange(range, '');
+}
+
+module.exports = extendFixRange;

--- a/rules/utils/extend-fix-range.js
+++ b/rules/utils/extend-fix-range.js
@@ -1,11 +1,11 @@
 'use strict';
 
 /**
-Extend fix range to prevent changes from other rules
+Extend fix range to prevent changes from other rules.
 https://github.com/eslint/eslint/pull/13748/files#diff-c692f3fde09eda7c89f1802c908511a3fb59f5d207fe95eb009cb52e46a99e84R348
 
-@param {ruleFixer} fixer The fixer to fix.
-@param {int[]} range The extended range node.
+@param {ruleFixer} fixer - The fixer to fix.
+@param {int[]} range - The extended range node.
 */
 function * extendFixRange(fixer, range) {
 	yield fixer.insertTextBeforeRange(range, '');


### PR DESCRIPTION
ESLint [recommended a new way](https://github.com/eslint/eslint/pull/13748) to extend fix range.