### PR TITLE
Fixed example `prefer-math-trunc`'s `README.md`

### DIFF
--- a/docs/rules/prefer-math-trunc.md
+++ b/docs/rules/prefer-math-trunc.md
@@ -65,11 +65,11 @@ const foo = ~3.3;
 ```
 
 ```js
-const foo = 0 >> 3.3;
+const foo = 3.3 >> 0;
 ```
 
 ```js
-const foo = 0 << 3.3;
+const foo = 3.3 << 0;
 ```
 
 ```js


### PR DESCRIPTION
Fixed position of number:

```js
const foo = 0 >> 3.3; // 0
const foo = 3.3 >> 0; // 3
```


```js
const foo = 0 << 3.3; // 0
const foo = 3.3 << 0; // 3
```