### PR TITLE
`prevent-abbreviations`: Add `ver` → `version` replacement

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -213,6 +213,9 @@ const defaultReplacements = {
 	},
 	val: {
 		value: true
+	},
+	ver: {
+		version: true
 	}
 };
 

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -547,7 +547,7 @@ const create = context => {
 				}
 
 				// Create a normal-looking variable (like a `var` or a `function`)
-				// For which a single `variable` holds all references, unline with `class`
+				// For which a single `variable` holds all references, unlike with a `class`
 				const combinedReferencesVariable = {
 					name: variable.name,
 					scope: variable.scope,


### PR DESCRIPTION
Found this abbreviation here:

https://github.com/mscdex/paclient/blob/e8c225b6097b4e3f38014d2721bc71ba9f8b3e7b/lib/client.js#L1533-L1539