### PR TITLE
`no-useless-undefined`: Ignore `toHaveBeenCalledWith`

### DIFF
--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -47,6 +47,7 @@ const compareFunctionNames = new Set([
 	'include',
 	'property',
 	'toBe',
+	'toHaveBeenCalledWith',
 	'toContain',
 	'toContainEqual',
 	'toEqual',

--- a/test/no-useless-undefined.js
+++ b/test/no-useless-undefined.js
@@ -40,7 +40,8 @@ test({
 		't.same(foo, undefined)',
 		't.notSame(foo, undefined)',
 		't.strictSame(foo, undefined)',
-		't.strictNotSame(foo, undefined)'
+		't.strictNotSame(foo, undefined)',
+		'expect(someFunction).toHaveBeenCalledWith(1, 2, undefined);'
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Fix #807