### PR TITLE
`no-for-loop`: Improve output when using the TypeScript parser

### DIFF
--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -371,8 +371,11 @@ const create = context => {
 						if (removeDeclaration) {
 							declarationType = element.type === 'VariableDeclarator' ? elementNode.kind : elementNode.parent.kind;
 							if (elementNode.id.typeAnnotation && shouldGenerateIndex) {
-								declarationElement = sourceCode.text.slice(elementNode.id.range[0], elementNode.id.typeAnnotation.range[0]);
-								typeAnnotation = sourceCode.getText(elementNode.id.typeAnnotation, -1).trim();
+								declarationElement = sourceCode.text.slice(elementNode.id.range[0], elementNode.id.typeAnnotation.range[0]).trim();
+								typeAnnotation = sourceCode.getText(
+									elementNode.id.typeAnnotation,
+									-1 // Skip leading `:`
+								).trim();
 							} else {
 								declarationElement = sourceCode.getText(elementNode.id);
 							}

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -746,12 +746,12 @@ runTest.typescript({
 		{
 			code: outdent`
 				for (let i = 0; i < positions.length; i++) {
-					const last /* comment */    : /* comment */ Position = positions[i];
+					const    last   /* comment */    : /* comment */ Position = positions[i];
 					console.log(i);
 				}
 			`,
 			output: outdent`
-				for (const [i, last /* comment */]: [number, /* comment */ Position] of positions.entries()) {
+				for (const [i, last   /* comment */]: [number, /* comment */ Position] of positions.entries()) {
 					console.log(i);
 				}
 			`,

--- a/test/no-for-loop.js
+++ b/test/no-for-loop.js
@@ -746,6 +746,20 @@ runTest.typescript({
 		{
 			code: outdent`
 				for (let i = 0; i < positions.length; i++) {
+					const last /* comment */    : /* comment */ Position = positions[i];
+					console.log(i);
+				}
+			`,
+			output: outdent`
+				for (const [i, last /* comment */]: [number, /* comment */ Position] of positions.entries()) {
+					console.log(i);
+				}
+			`,
+			errors: 1
+		},
+		{
+			code: outdent`
+				for (let i = 0; i < positions.length; i++) {
 					let last: vscode.Position | vscode.Range = positions[i];
 				}
 			`,


### PR DESCRIPTION
Space between `id` and `typeAnnotation` was not removed .
