### PR TITLE
`prevent-abbreviations`: Add `ignore` option

### DIFF
--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -8,7 +8,6 @@ You can find the default replacements [here](https://github.com/sindresorhus/esl
 
 This rule is fixable only for variable names with exactly one replacement defined.
 
-
 ## Fail
 
 ```js
@@ -22,7 +21,6 @@ const e = document.createEvent('Event');
 ```js
 class Btn {}
 ```
-
 
 ## Pass
 
@@ -59,7 +57,6 @@ const levels = {
 // Property is not checked by default
 this.evt = 'click';
 ```
-
 
 ## Options
 
@@ -105,7 +102,7 @@ The example below:
 
 ### extendDefaultReplacements
 
-Type: `boolean`<br>
+Type: `boolean`\
 Default: `true`
 
 Pass `"extendDefaultReplacements": false` to override the default `replacements` completely.
@@ -149,14 +146,14 @@ For example, if you want to report `props` → `properties` (enabled by default)
 
 ### extendDefaultWhitelist
 
-Type: `boolean`<br>
+Type: `boolean`\
 Default: `true`
 
 Pass `"extendDefaultWhitelist": false` to override the default `whitelist` completely.
 
 ### checkDefaultAndNamespaceImports
 
-Type: `'internal' | boolean`<br>
+Type: `'internal' | boolean`\
 Default: `'internal'`
 
 - `'internal'` - Check variables declared in default or namespace import, **but only for internal modules**.
@@ -189,7 +186,7 @@ const err = require('err');
 
 ### checkShorthandImports
 
-Type: `'internal'` | `boolean`<br>
+Type: `'internal'` | `boolean`\
 Default: `'internal'`
 
 - `'internal'` - Check variables declared in shorthand import, **but only for internal modules**.
@@ -210,7 +207,7 @@ import {prop} from 'ramda';
 
 ### checkShorthandProperties
 
-Type: `boolean`<br>
+Type: `boolean`\
 Default: `false`
 
 Pass `"checkShorthandProperties": true` to check variables declared as shorhand properties in object destructuring.
@@ -231,21 +228,21 @@ function f({err}) {}
 
 ### checkProperties
 
-Type: `boolean`<br>
+Type: `boolean`\
 Default: `false`
 
 Pass `"checkProperties": true` to enable checking property names.
 
 ### checkVariables
 
-Type: `boolean`<br>
+Type: `boolean`\
 Default: `true`
 
 Pass `"checkVariables": false` to disable checking variable names.
 
 ### checkFilenames
 
-Type: `boolean`<br>
+Type: `boolean`\
 Default: `true`
 
 Pass `"checkFilenames": false` to disable checking file names.
@@ -259,7 +256,6 @@ This option lets you specify a regex pattern for matches to ignore.
 
 When a string is given, it's interpreted as a regular expressions inside a string. Needed for ESLint config in JSON.
 
-
 ```js
 "unicorn/prevent-abbreviations": [
 	"error",
@@ -272,4 +268,4 @@ When a string is given, it's interpreted as a regular expressions inside a strin
 ]
 ```
 
-When checking filenames, only basename is tested, file named `foo.e2e.js`,with `ignore: [/\.e2e$/]` would pass, with `ignore: [/\.e2e\.js/]` would fail, .
+When checking filenames, only the basename is tested. For example, with a file named `foo.e2e.js`, `ignore: [/\.e2e$/]` would pass and `ignore: [/\.e2e\.js/]` would fail.

--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -249,3 +249,27 @@ Type: `boolean`<br>
 Default: `true`
 
 Pass `"checkFilenames": false` to disable checking file names.
+
+### ignore
+
+Type: `Array<string | RegExp>`\
+Default: `[]`
+
+This option lets you specify a regex pattern for matches to ignore.
+
+When a string is given, it's interpreted as a regular expressions inside a string. Needed for ESLint config in JSON.
+
+
+```js
+"unicorn/prevent-abbreviations": [
+	"error",
+	{
+		"ignore": [
+			"\\.e2e$",
+			/^ignore/i
+		]
+	}
+]
+```
+
+When checking filenames, only basename is tested, file named `foo.e2e.js`,with `ignore: [/\.e2e$/]` would pass, with `ignore: [/\.e2e\.js/]` would fail, .

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -257,7 +257,9 @@ const prepareOptions = ({
 	replacements = {},
 
 	extendDefaultWhitelist = true,
-	whitelist = {}
+	whitelist = {},
+
+	ignore = []
 } = {}) => {
 	const mergedReplacements = extendDefaultReplacements ?
 		defaultsDeep({}, replacements, defaultReplacements) :
@@ -266,6 +268,10 @@ const prepareOptions = ({
 	const mergedWhitelist = extendDefaultWhitelist ?
 		defaultsDeep({}, whitelist, defaultWhitelist) :
 		whitelist;
+
+	ignore = ignore.map(
+		pattern => pattern instanceof RegExp ? pattern : new RegExp(pattern, 'u')
+	);
 
 	return {
 		checkProperties,
@@ -283,7 +289,9 @@ const prepareOptions = ({
 					[discouragedName, new Map(Object.entries(replacements))]
 			)
 		),
-		whitelist: new Map(Object.entries(mergedWhitelist))
+		whitelist: new Map(Object.entries(mergedWhitelist)),
+
+		ignore
 	};
 };
 
@@ -309,10 +317,10 @@ const getWordReplacements = (word, {replacements, whitelist}) => {
 };
 
 const getNameReplacements = (name, options, limit = 3) => {
-	const {whitelist} = options;
+	const {whitelist, ignore} = options;
 
 	// Skip constants and whitelist
-	if (isUpperCase(name) || whitelist.get(name)) {
+	if (isUpperCase(name) || whitelist.get(name) || ignore.some(regexp => regexp.test(name))) {
 		return {total: 0};
 	}
 
@@ -712,7 +720,6 @@ const create = context => {
 
 			const extension = path.extname(filenameWithExtension);
 			const filename = path.basename(filenameWithExtension, extension);
-
 			const filenameReplacements = getNameReplacements(filename, options);
 
 			if (filenameReplacements.total === 0) {
@@ -778,6 +785,10 @@ const schema = [
 			},
 			whitelist: {
 				$ref: '#/items/0/definitions/booleanObject'
+			},
+			ignore: {
+				type: 'array',
+				uniqueItems: true
 			}
 		},
 		additionalProperties: false,

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -124,6 +124,17 @@ const noExtendDefaultWhitelistOptions = [
 	}
 ];
 
+const ignoreOptions = [
+	{
+		ignore: [
+			/^e_/,
+			// eslint-disable-next-line prefer-regex-literals
+			new RegExp('_e$', 'i'),
+			'\\.e2e\\.'
+		]
+	}
+];
+
 ruleTester.run('prevent-abbreviations', rule, {
 	valid: [
 		'let x',
@@ -267,6 +278,16 @@ ruleTester.run('prevent-abbreviations', rule, {
 		{
 			code: 'const propTypes = 2;const err = 2;',
 			options: extendDefaultWhitelistOptions
+		},
+
+		// `ignore` option
+		{
+			code: outdent`
+				const e_at_start = 1;
+				const end_with_e = 2;
+			`,
+			filename: 'some.spec.e2e.test.js',
+			options: ignoreOptions
 		}
 	],
 
@@ -1631,7 +1652,21 @@ runTest({
 			`,
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		})
+		}),
+
+		// `ignore` option
+		{
+			code: outdent`
+				const e_at_start = 1;
+				const end_with_e = 2;
+			`,
+			filename: 'some.spec.e2e.test.js',
+			errors: [
+				...createErrors('Please rename the filename `some.spec.e2e.test.js`. Suggested names are: `some.spec.error2error.test.js`, `some.spec.error2event.test.js`, `some.spec.event2error.test.js`, ... (1 more omitted). A more descriptive name will do too.'),
+				...createErrors('Please rename the variable `e_at_start`. Suggested names are: `error_at_start`, `event_at_start`. A more descriptive name will do too.'),
+				...createErrors('Please rename the variable `end_with_e`. Suggested names are: `end_with_error`, `end_with_event`. A more descriptive name will do too.')
+			]
+		}
 	]
 });
 


### PR DESCRIPTION
Fixes #567
Fixes #752

Maybe we can remove `whitelist` option later.
