### PR TITLE
Update comments' accuracy in the default config

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ module.exports = {
 				'unicorn/no-useless-undefined': 'error',
 				'unicorn/no-zero-fractions': 'error',
 				'unicorn/number-literal-case': 'error',
-				'unicorn/numeric-separators-style': 'error',
+				// TODO: Enable this by default when NodeJS 10 is deprecated.
+				'unicorn/numeric-separators-style': 'off',
 				'unicorn/prefer-add-event-listener': 'error',
 				'unicorn/prefer-array-find': 'error',
 				'unicorn/prefer-dataset': 'error',

--- a/index.js
+++ b/index.js
@@ -49,8 +49,7 @@ module.exports = {
 				'unicorn/no-useless-undefined': 'error',
 				'unicorn/no-zero-fractions': 'error',
 				'unicorn/number-literal-case': 'error',
-				// TODO: Enable this by default when it's shipping in a Node.js LTS version.
-				'unicorn/numeric-separators-style': 'off',
+				'unicorn/numeric-separators-style': 'error',
 				'unicorn/prefer-add-event-listener': 'error',
 				'unicorn/prefer-array-find': 'error',
 				'unicorn/prefer-dataset': 'error',
@@ -67,7 +66,7 @@ module.exports = {
 				'unicorn/prefer-optional-catch-binding': 'error',
 				'unicorn/prefer-query-selector': 'error',
 				'unicorn/prefer-reflect-apply': 'error',
-				// TODO: Enable this by default when it's shipping in a Node.js LTS version.
+				// TODO: Enable this by default when it's shipping in a Node.js LTS version (v16.0.0).
 				'unicorn/prefer-replace-all': 'off',
 				'unicorn/prefer-set-has': 'error',
 				'unicorn/prefer-spread': 'error',

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = {
 				'unicorn/no-useless-undefined': 'error',
 				'unicorn/no-zero-fractions': 'error',
 				'unicorn/number-literal-case': 'error',
-				// TODO: Enable this by default when NodeJS 10 is deprecated.
+				// TODO: Enable this by default when targeting Node.js 12.
 				'unicorn/numeric-separators-style': 'off',
 				'unicorn/prefer-add-event-listener': 'error',
 				'unicorn/prefer-array-find': 'error',
@@ -67,7 +67,7 @@ module.exports = {
 				'unicorn/prefer-optional-catch-binding': 'error',
 				'unicorn/prefer-query-selector': 'error',
 				'unicorn/prefer-reflect-apply': 'error',
-				// TODO: Enable this by default when it's shipping in a Node.js LTS version (v16.0.0).
+				// TODO: Enable this by default when targeting Node.js 16.
 				'unicorn/prefer-replace-all': 'off',
 				'unicorn/prefer-set-has': 'error',
 				'unicorn/prefer-spread': 'error',


### PR DESCRIPTION
[NodeJS 14 just transitioned to Long Term Support!](https://github.com/nodejs/node/releases/tag/v14.15.0)

Hence, I've updated the default rules accordingly (`numeric-separators-style`: `off` -> `error`), and I've clarified the LTS version where the `String#replaceAll` method will be shipped.