### PR TITLE
Report more specific error in `import-style` when no style is allowed

### DIFF
--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -3,9 +3,11 @@ const {defaultsDeep} = require('lodash');
 const {getStringIfConstant} = require('eslint-utils');
 const eslintTemplateVisitor = require('eslint-template-visitor');
 
-const MESSAGE_ID = 'importStyle';
+const MESSAGE_ID_IMPORT_STYLE = 'importStyle';
+const MESSAGE_ID_IMPORT_STYLE_NONE = 'importStyleNone';
 const messages = {
-	[MESSAGE_ID]: 'Use {{allowedStyles}} import for module `{{moduleName}}`.'
+	[MESSAGE_ID_IMPORT_STYLE]: 'Use {{allowedStyles}} import for module `{{moduleName}}`.',
+	[MESSAGE_ID_IMPORT_STYLE_NONE]: 'Importing module `{{moduleName}}` is not allowed.'
 };
 
 const getDocumentationUrl = require('./utils/get-documentation-url');
@@ -193,15 +195,28 @@ const create = context => {
 			return;
 		}
 
-		const data = {
-			allowedStyles: joinOr([...allowedImportStyles.keys()]),
-			moduleName
-		};
+		const allowedStyles = [...allowedImportStyles.keys()].filter(
+			style => allowedImportStyles.get(style)
+		);
+
+		if (allowedStyles.length === 0) {
+			context.report({
+				node,
+				messageId: MESSAGE_ID_IMPORT_STYLE_NONE,
+				data: {
+					moduleName
+				}
+			});
+			return;
+		}
 
 		context.report({
 			node,
-			messageId: MESSAGE_ID,
-			data
+			messageId: MESSAGE_ID_IMPORT_STYLE,
+			data: {
+				allowedStyles: joinOr(allowedStyles),
+				moduleName
+			}
 		});
 	};
 

--- a/test/import-style.js
+++ b/test/import-style.js
@@ -15,6 +15,12 @@ const options = {
 		},
 		named: {
 			named: true
+		},
+		none: {
+			unassigned: false,
+			default: false,
+			namespace: false,
+			named: false
 		}
 	}
 };
@@ -48,6 +54,13 @@ const namedError = {
 	data: {
 		allowedStyles: 'named',
 		moduleName: 'named'
+	}
+};
+
+const noneError = {
+	messageId: 'importStyleNone',
+	data: {
+		moduleName: 'none'
 	}
 };
 
@@ -494,6 +507,107 @@ test({
 		{
 			code: 'export {default} from \'named\'',
 			errors: [namedError]
+		},
+
+		{
+			code: 'require(\'none\')',
+			errors: [noneError]
+		},
+		{
+			code: 'const {} = require(\'none\')',
+			errors: [noneError]
+		},
+		{
+			code: 'import \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: 'import {} from \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: 'import(\'none\')',
+			errors: [noneError]
+		},
+		{
+			code: 'const x = require(\'none\')',
+			errors: [noneError]
+		},
+		{
+			code: 'const {default: x} = require(\'none\')',
+			errors: [noneError]
+		},
+		{
+			code: 'import x from \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: outdent`
+				async () => {
+					const {default: x} = await import('none');
+				}
+			`,
+			errors: [noneError]
+		},
+		{
+			code: 'import * as x from \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: outdent`
+				async () => {
+					const x = await import('none');
+				}
+			`,
+			errors: [noneError]
+		},
+		{
+			code: 'export * from \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: 'export {default} from \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: 'const {x} = require(\'none\')',
+			errors: [noneError]
+		},
+		{
+			code: 'const {x: y} = require(\'none\')',
+			errors: [noneError]
+		},
+		{
+			code: 'import {x} from \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: 'import {x as y} from \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: outdent`
+				async () => {
+					const {x} = await import('none');
+				}
+			`,
+			errors: [noneError]
+		},
+		{
+			code: outdent`
+				async () => {
+					const {x: y} = await import('none');
+				}
+			`,
+			errors: [noneError]
+		},
+		{
+			code: 'export {x} from \'none\'',
+			errors: [noneError]
+		},
+		{
+			code: 'export {x as y} from \'none\'',
+			errors: [noneError]
 		},
 
 		{


### PR DESCRIPTION
Given a configuration like this:

```js
  'unicorn/import-style': ['error', {
    styles: {
      fs: {
        unassigned: false,
        default: false,
        namespace: false,
        named: false,
      },
      'fs/promises': {
        named: true,
      },
    },
  }],
```

With this configuration, importing `fs` is effectively forbidden (in favor of `fs/promises` in this case). However, the reported error message is misleading:

```
Use unassigned, default, namespace or named import for module `fs`.
```

This PR adds a special error message for this case:

```
Importing module `fs` is not allowed.
```