### PR TITLE
`prefer-query-selector`: Fix crash on calling without argument

### DIFF
--- a/rules/prefer-query-selector.js
+++ b/rules/prefer-query-selector.js
@@ -105,6 +105,11 @@ const create = context => {
 				return;
 			}
 
+			const [firstArgument] = node.arguments;
+			if (node.arguments.length !== 1 || firstArgument.type === 'SpreadElement') {
+				return;
+			}
+
 			const report = {
 				node,
 				messageId: MESSAGE_ID,

--- a/test/prefer-query-selector.js
+++ b/test/prefer-query-selector.js
@@ -7,6 +7,11 @@ const createError = (method, replacement) => ({
 
 test({
 	valid: [
+		// More or less arguments
+		'document.getElementById();',
+		'document.getElementsByClassName("foo", "bar");',
+		'document.getElementById(...["id"]);',
+
 		'document.querySelector("#foo");',
 		'document.querySelector(".bar");',
 		'document.querySelector("main #foo .bar");',


### PR DESCRIPTION
Make it only check calling with one argument, ignore `document.getElementsByClassName("foo", "bar");` and `document.getElementById(...["id"]);`

Fixes #903
 