### PR TITLE
`new-for-builtins`: Remove auto-fix for `new String`, `new Boolean()`, and `new Number()`

### DIFF
--- a/docs/rules/new-for-builtins.md
+++ b/docs/rules/new-for-builtins.md
@@ -39,13 +39,13 @@ Disallows the use of `new` for following builtins.
 
 > These should not use `new` as that would create object wrappers for the primitive values, which is not what you want. However, without `new` they can be useful for coercing a value to that type.
 
+This rule is fixable, except `new String()`, `new Number()`, and `new Boolean()`, [they returns wrapped object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#String_primitives_and_String_objects#String_primitives_and_String_objects).
 
 ## Fail
 
 ```js
 const list = Array(10);
 ```
-
 
 ```js
 const now = Date();
@@ -56,7 +56,6 @@ const map = Map([
 	['foo', 'bar']
 ]);
 ```
-
 
 ## Pass
 

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ Configure it in `package.json`.
 - [filename-case](docs/rules/filename-case.md) - Enforce a case style for filenames.
 - [import-index](docs/rules/import-index.md) - Enforce importing index files with `.`. *(fixable)*
 - [import-style](docs/rules/import-style.md) - Enforce specific import styles per module.
-- [new-for-builtins](docs/rules/new-for-builtins.md) - Enforce the use of `new` for all builtins, except `String`, `Number`, `Boolean`, `Symbol` and `BigInt`. *(fixable)*
+- [new-for-builtins](docs/rules/new-for-builtins.md) - Enforce the use of `new` for all builtins, except `String`, `Number`, `Boolean`, `Symbol` and `BigInt`. *(partly fixable)*
 - [no-abusive-eslint-disable](docs/rules/no-abusive-eslint-disable.md) - Enforce specifying rules to disable in `eslint-disable` comments.
 - [no-array-instanceof](docs/rules/no-array-instanceof.md) - Require `Array.isArray()` instead of `instanceof Array`. *(fixable)*
 - [no-console-spaces](docs/rules/no-console-spaces.md) - Do not use leading/trailing space between `console.log` parameters. *(fixable)*

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -31,15 +31,20 @@ const create = context => {
 			const {name} = callee;
 
 			if (disallowNew.has(name) && !isShadowed(context.getScope(), callee)) {
-				context.report({
+				const problem = {
 					node,
 					messageId: 'disallow',
-					data: {name},
-					fix: fixer => fixer.removeRange([
+					data: {name}
+				}
+
+				if (name !=== 'String' && name !== 'Boolean' && name !== 'Number') {
+					problem.fix = fixer => fixer.removeRange([
 						node.range[0],
 						node.callee.range[0]
-					])
-				});
+					]);
+				}
+
+				context.report(problem);
 			}
 		}
 	};

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -37,7 +37,7 @@ const create = context => {
 					data: {name}
 				}
 
-				if (name !=== 'String' && name !== 'Boolean' && name !== 'Number') {
+				if (name !== 'String' && name !== 'Boolean' && name !== 'Number') {
 					problem.fix = fixer => fixer.removeRange([
 						node.range[0],
 						node.callee.range[0]

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -35,7 +35,7 @@ const create = context => {
 					node,
 					messageId: 'disallow',
 					data: {name}
-				}
+				};
 
 				if (name !== 'String' && name !== 'Boolean' && name !== 'Number') {
 					problem.fix = fixer => fixer.removeRange([

--- a/test/new-for-builtins.js
+++ b/test/new-for-builtins.js
@@ -249,22 +249,22 @@ test({
 		{
 			code: 'const foo = new Boolean()',
 			errors: [disallowNewError('Boolean')],
-			output: 'const foo = Boolean()'
+			output: 'const foo = new Boolean()'
 		},
 		{
 			code: 'const foo = new Number()',
 			errors: [disallowNewError('Number')],
-			output: 'const foo = Number()'
+			output: 'const foo = new Number()'
 		},
 		{
 			code: 'const foo = new Number(\'123\')',
 			errors: [disallowNewError('Number')],
-			output: 'const foo = Number(\'123\')'
+			output: 'const foo = new Number(\'123\')'
 		},
 		{
 			code: 'const foo = new String()',
 			errors: [disallowNewError('String')],
-			output: 'const foo = String()'
+			output: 'const foo = new String()'
 		},
 		{
 			code: 'const foo = new Symbol()',


### PR DESCRIPTION
`new Symbol()` and `new BigInt()`  still auto-fix, they can't call with `new` anyway.

Fixes #901