### PR TITLE
`prevent-abbreviations`: Fix crash when using TypeScript parser

### DIFF
--- a/rules/utils/rename-identifier.js
+++ b/rules/utils/rename-identifier.js
@@ -28,7 +28,10 @@ function renameIdentifier(identifier, name, fixer, sourceCode) {
 
 	// `typeAnnotation`
 	if (identifier.typeAnnotation) {
-		return fixer.replaceText(identifier, `${name}${identifier.optional ? '?' : ''}${sourceCode.getText(identifier.typeAnnotation)}`);
+		return fixer.replaceTextRange(
+			[identifier.range[0], identifier.typeAnnotation.range[0]],
+			`${name}${identifier.optional ? '?' : ''}`
+		);
 	}
 
 	return fixer.replaceText(identifier, name);

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1793,6 +1793,34 @@ runTest.typescript({
 			code: 'const foo = (extraParams?: string) => {}',
 			output: 'const foo = (extraParameters?: string) => {}',
 			errors: createErrors()
+		},
+		{
+			code: 'const foo = (extr\u0061Params     ?    :    string) => {}',
+			output: 'const foo = (extraParameters?:    string) => {}',
+			errors: 1
+		},
+
+		// #912
+		{
+			code: outdent`
+				interface Prop {
+						id: number;
+				}
+
+				const Prop: Prop = { id: 1 };
+
+				export default Prop;
+			`,
+			output: outdent`
+				interface Property {
+						id: number;
+				}
+
+				const Property: Property = { id: 1 };
+
+				export default Property;
+			`,
+			errors: 1
 		}
 	]
 });


### PR DESCRIPTION
Fixes #912