### PR TITLE
Revert "`error-message`: Check `AggregateError` too (#921)"

### DIFF
--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -9,16 +9,14 @@ const messages = {
 };
 
 const errorConstructors = new Set([
-	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 	'Error',
 	'EvalError',
+	'InternalError',
 	'RangeError',
 	'ReferenceError',
 	'SyntaxError',
 	'TypeError',
-	'URIError',
-	'AggregateError',
-	'InternalError'
+	'URIError'
 ]);
 
 const isReferenceAssigned = expression => {

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -9,14 +9,15 @@ const messages = {
 };
 
 const errorConstructors = new Set([
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 	'Error',
 	'EvalError',
-	'InternalError',
 	'RangeError',
 	'ReferenceError',
 	'SyntaxError',
 	'TypeError',
-	'URIError'
+	'URIError',
+	'InternalError'
 ]);
 
 const isReferenceAssigned = expression => {


### PR DESCRIPTION
Sorry, #921 is a mistake, [`AggregateError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError/AggregateError) accept `message` as second argument, not first.