### PR TITLE
`import-style`: Fix crash on `babel-eslint` parser

### DIFF
--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -81,7 +81,7 @@ const getActualAssignmentTargetImportStyles = assignmentTarget => {
 		const styles = new Set();
 
 		for (const property of assignmentTarget.properties) {
-			if (property.type === 'RestElement') {
+			if (property.type === 'RestElement' || property.type === 'ExperimentalRestProperty') {
 				styles.add('named');
 				continue;
 			}

--- a/test/import-style.js
+++ b/test/import-style.js
@@ -598,6 +598,26 @@ test({
 	].map(test => addDefaultOptions(test))
 });
 
+test.babel({
+	valid: [
+		'const {...rest2} = require("named")'
+	],
+	invalid: [
+		{
+			code: 'const {...rest2} = require("unassigned")',
+			errors: [unassignedError]
+		},
+		{
+			code: 'const {...rest2} = require("default")',
+			errors: [defaultError]
+		},
+		{
+			code: 'const {...rest2} = require("namespace")',
+			errors: [namespaceError]
+		},
+	].map(test => addDefaultOptions(test))
+})
+
 test.visualize([
 	'import util from \'util\'',
 	'import * as util from \'util\'',

--- a/test/import-style.js
+++ b/test/import-style.js
@@ -614,9 +614,9 @@ test.babel({
 		{
 			code: 'const {...rest2} = require("namespace")',
 			errors: [namespaceError]
-		},
+		}
 	].map(test => addDefaultOptions(test))
-})
+});
 
 test.visualize([
 	'import util from \'util\'',


### PR DESCRIPTION
Same as #904, but this is for babel parser, it's `ExperimentalRestProperty` not `RestElement`.