### PR TITLE
`consistent-function-scoping`: Allow ignore arrow functions

### DIFF
--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -43,6 +43,14 @@ export function doFoo(foo) {
 }
 ```
 
+## Options
+
+### checkArrowFunctions
+
+Type: `boolean`\
+Default: `true`
+
+Pass `"checkArrowFunctions": false` to disable linting of arrow functions.
 
 ## Limitations
 

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -372,7 +372,16 @@ test({
 
 				inner();
 			}
-		`
+		`,
+		// Should ignore functions inside arrow functions
+		{
+			code: outdent`
+				function outer () {
+					const inner = () => {}
+				}
+			`,
+			options: [{checkArrowFunctions: false}]
+		}
 	],
 	invalid: [
 		{
@@ -729,6 +738,16 @@ test({
 				}
 			`,
 			errors: ['b', 'c', 'foo'].map(functionName => createError(`function '${functionName}'`))
+		},
+		// Should check functions inside arrow functions
+		{
+			code: outdent`
+				const outer = () => {
+					function inner() {}
+				}
+			`,
+			errors: [createError('function \'inner\'')],
+			options: [{checkArrowFunctions: false}]
 		}
 	]
 });


### PR DESCRIPTION
Fixes #596
