### PR TITLE
`new-for-builtins`: Ignore `Object(x) === x` and `Object(x) !== x`

### DIFF
--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -17,6 +17,16 @@ const create = context => {
 			const {callee} = node;
 			const {name} = callee;
 
+			if (
+				name === 'Object' &&
+				node.parent &&
+				node.parent.type === 'BinaryExpression' &&
+				(node.parent.operator === '===' || node.parent.operator === '!==') &&
+				(node.parent.left === node || node.parent.right === node)
+			) {
+				return;
+			}
+
 			if (enforceNew.has(name) && !isShadowed(context.getScope(), callee)) {
 				context.report({
 					node,

--- a/test/new-for-builtins.js
+++ b/test/new-for-builtins.js
@@ -108,7 +108,10 @@ test({
 		`,
 		// Not builtin
 		'new Foo();Bar();',
-		'Foo();new Bar();'
+		'Foo();new Bar();',
+		// Ignored
+		'const isObject = v => Object(v) === v;',
+		'(x) !== Object(x)'
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Fixes #917