### PR TITLE
Refactor `explicit-length-check`

### DIFF
--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -18,9 +18,11 @@ const isLogicNotArgument = node =>
 	isLogicNot(node.parent) &&
 	node.parent.argument === node;
 const isCompareRight = (node, operator, value) =>
+	node.type === 'BinaryExpression' &&
 	node.operator === operator &&
 	isLiteralValue(node.right, value);
 const isCompareLeft = (node, operator, value) =>
+	node.type === 'BinaryExpression' &&
 	node.operator === operator &&
 	isLiteralValue(node.left, value);
 const nonZeroStyles = new Map([
@@ -70,12 +72,9 @@ function getBooleanAncestor(node) {
 
 function getLengthCheckNode(node) {
 	node = node.parent;
-	if (node.type !== 'BinaryExpression') {
-		return {};
-	}
 
+	// Zero length check
 	if (
-		// Zero length check
 		// `foo.length === 0`
 		isCompareRight(node, '===', 0) ||
 		// `foo.length == 0`
@@ -92,8 +91,8 @@ function getLengthCheckNode(node) {
 		return {isZeroLengthCheck: true, node};
 	}
 
+	// Non-Zero length check
 	if (
-		// Non-Zero length check
 		// `foo.length !== 0`
 		isCompareRight(node, '!==', 0) ||
 		// `foo.length != 0`

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -129,7 +129,6 @@ function create(context) {
 	};
 	const nonZeroStyle = nonZeroStyles.get(options['non-zero']);
 	const sourceCode = context.getSourceCode();
-	const reportedBinaryExpressions = new Set();
 
 	function reportProblem(node, {zeroLength, lengthNode}, isNegative) {
 		if (isNegative) {
@@ -158,7 +157,7 @@ function create(context) {
 		});
 	}
 
-	function checkBooleanNode(node, isNegative) {
+	function checkBooleanNode(node) {
 		if (node.type === 'LogicalExpression') {
 			checkBooleanNode(node.left);
 			checkBooleanNode(node.right);
@@ -170,7 +169,6 @@ function create(context) {
 		}
 	}
 
-	const binaryExpressions = [];
 	return {
 		// The outer `!` expression
 		'UnaryExpression[operator="!"]:not(UnaryExpression[operator="!"] > .argument)'(node) {
@@ -188,7 +186,6 @@ function create(context) {
 
 			if (isLengthProperty(expression)) {
 				reportProblem(node, {zeroLength: false, lengthNode: expression}, isNegative);
-				return;
 			}
 		},
 		[booleanNodeSelector](node) {

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -53,7 +53,7 @@ const zeroStyle = {
 	test: node => isCompareRight(node, '===', 0)
 };
 
-const lengthPropertySelector = [
+const lengthSelector = [
 	'MemberExpression',
 	'[computed=false]',
 	'[property.type="Identifier"]',
@@ -174,7 +174,7 @@ function create(context) {
 	}
 
 	return {
-		[lengthPropertySelector](lengthNode) {
+		[lengthSelector](lengthNode) {
 			let node;
 
 			let {isZeroLengthCheck, node: lengthCheckNode} = getLengthCheckNode(lengthNode);

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -122,14 +122,6 @@ function isBooleanNode(node) {
 	}
 
 	const {parent} = node;
-	if (!parent) {
-		return false;
-	}
-
-	if (parent.type === 'LogicalExpression') {
-		return isBooleanNode(parent);
-	}
-
 	if (
 		(
 			parent.type === 'IfStatement' ||
@@ -141,6 +133,10 @@ function isBooleanNode(node) {
 		parent.test === node
 	) {
 		return true;
+	}
+
+	if (parent.type === 'LogicalExpression') {
+		return isBooleanNode(parent);
 	}
 
 	return false;

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -17,6 +17,10 @@ const isLengthProperty = node =>
 const isLogicNot = node =>
 	node.type === 'UnaryExpression' &&
 	node.operator === '!';
+const isLogicNotArgument = node =>
+	node.parent &&
+	isLogicNot(node.parent) &&
+	node.parent.argument = node;
 const isLiteralNumber = (node, value) =>
 	node.type === 'Literal' &&
 	typeof node.value === 'number' &&
@@ -130,7 +134,7 @@ const lengthPropertySelector = [
 
 function getRemovableBooleanParent(node) {
 	let isNegative = false;
-	while (node.parent && isLogicNot(node.parent) && node.parent.argument === node) {
+	while (isLogicNotArgument(node)) {
 		isNegative = !isNegative;
 		node = node.parent;
 	}
@@ -186,7 +190,8 @@ function create(context) {
 	}
 
 	return {
-		[lengthPropertySelector](node) {
+		[lengthPropertySelector](lengthNode) {
+			const {isNegative, node} = getRemovableBooleanParent(lengthNode);
 
 		},
 

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -1,6 +1,7 @@
 'use strict';
 const {isParenthesized} = require('eslint-utils');
 const getDocumentationUrl = require('./utils/get-documentation-url');
+const isLiteralValue = require('./utils/is-literal-value');
 
 const TYPE_NON_ZERO = 'non-zero';
 const TYPE_ZERO = 'zero';
@@ -21,20 +22,12 @@ const isLogicNotArgument = node =>
 	node.parent &&
 	isLogicNot(node.parent) &&
 	node.parent.argument === node;
-const isLiteralNumber = (node, value) =>
-	node.type === 'Literal' &&
-	typeof node.value === 'number' &&
-	node.value === value;
 const isCompareRight = (node, operator, value) =>
-	node.type === 'BinaryExpression' &&
 	node.operator === operator &&
-	isLengthProperty(node.left) &&
-	isLiteralNumber(node.right, value);
+	isLiteralValue(node.right, value);
 const isCompareLeft = (node, operator, value) =>
-	node.type === 'BinaryExpression' &&
 	node.operator === operator &&
-	isLengthProperty(node.right) &&
-	isLiteralNumber(node.left, value);
+	isLiteralValue(node.left, value);
 const nonZeroStyles = new Map([
 	[
 		'greater-than',

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -180,8 +180,9 @@ function create(context) {
 
 	return {
 		[lengthPropertySelector](lengthNode) {
-			let {isZeroLengthCheck, node: lengthCheckNode} = getLengthCheckNode(lengthNode);
 			let node;
+
+			let {isZeroLengthCheck, node: lengthCheckNode} = getLengthCheckNode(lengthNode);
 			if (lengthCheckNode) {
 				const {isNegative, node: ancestor} = getBooleanAncestor(lengthCheckNode);
 				node = ancestor;


### PR DESCRIPTION
This PR simplify #943

Main change, we're switching check `if (foo.length) {}` from "outer-to-inner" to "inner-to-outer".
By changing the logic, we are able to simplify the rule.