### PR TITLE
Add repository failing smoke tests

### DIFF
--- a/test/smoke/repositories.json
+++ b/test/smoke/repositories.json
@@ -1,4 +1,5 @@
 [
+	"astrofox-io/astrofox",
 	"AriPerkkio/js-framework-playground",
 	"oldboyxx/jira_clone",
 	"reach/reach-ui",


### PR DESCRIPTION
Hello, I've encountered a repository which crashes with v24 of this plugin. Let's add this to weekly smoke tests.

FYI, I'm testing this plugin weekly with 14K repositories. This CI run will test as many repositories it can in 6 hours. This week it was fast enough to test ~7k repositories. `[INFO/STATUS] Repositories (7484/14502)` 

CI run:
https://github.com/AriPerkkio/eslint-remote-tester/runs/1608289014?check_suite_focus=true

Crash report:
## Rule: prefer-query-selector
- Message: `node.value.trim is not a function Occurred while linting <text>:23`
- Path: `astrofox-io/astrofox/__tests__/core/EntityList.spec.js`
- [Link](https://github.com/astrofox-io/astrofox/blob/HEAD/__tests__/core/EntityList.spec.js#L23)

```js
    expect(e.getElementById(obj1.id)).toEqual(obj1);
  });

  test('invalid id', () => {
    expect(e.getElementById(3)).toBeUndefined();
  });
});

describe('hasElement method works properly', () => {
  test('valid object', () => {
```

```
TypeError: node.value.trim is not a function
Occurred while linting <text>:23
    at canBeFixed (/home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint-plugin-unicorn/rules/prefer-query-selector.js:70:52)
    at [type="CallExpression"][callee.type="MemberExpression"][callee.computed=false][callee.property.type="Identifier"]:matches([callee.property.name="getElementById"], [callee.property.name="getElementsByClassName"],[callee.property.name="getElementsByTagName"])[arguments.length=1][arguments.0.type!="SpreadElement"][callee.object.type!="ArrayExpression"][callee.object.type!="ArrowFunctionExpression"][callee.object.type!="ClassExpression"][callee.object.type!="FunctionExpression"][callee.object.type!="Literal"][callee.object.type!="ObjectExpression"][callee.object.type!="TemplateLiteral"]:not([callee.object.type="Identifier"][callee.object.name="undefined"])(/home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint-plugin-unicorn/rules/prefer-query-selector.js:122:8)
    at /home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector(/home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint/lib/linter/node-event-generator.js:254:26)
    at NodeEventGenerator.applySelectors(/home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint/lib/linter/node-event-generator.js:281:22)
    at NodeEventGenerator.enterNode(/home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint/lib/linter/node-event-generator.js:297:14)
    at CodePathAnalyzer.enterNode(/home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:711:23)
    at /home/runner/work/eslint-remote-tester/eslint-remote-tester/ci/node_modules/eslint/lib/linter/linter.js:952:32
```
