### PR TITLE
Remove `unicorn/import-index` from recommended preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
 				'unicorn/expiring-todo-comments': 'error',
 				'unicorn/explicit-length-check': 'error',
 				'unicorn/filename-case': 'error',
-				'unicorn/import-index': 'error',
+				'unicorn/import-index': 'off',
 				'unicorn/import-style': 'error',
 				'unicorn/new-for-builtins': 'error',
 				'unicorn/no-abusive-eslint-disable': 'error',


### PR DESCRIPTION
It's not compatible with ESM which requires a filename. In April, Node.js packages can target Node.js 12 which supports ESM, so I think it makes sense to remove this from the recommended preset.