### PR TITLE
Exclude folders like `test` from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.github/
+scripts/
+test/


### PR DESCRIPTION
A lot of extra files are being included in the npm package unnecessarily.
