### PR TITLE
`no-keyword-prefix`: Add some test

### DIFF
--- a/test/no-keyword-prefix.js
+++ b/test/no-keyword-prefix.js
@@ -1,3 +1,4 @@
+import {outdent} from 'outdent';
 import {test} from './utils/test.js';
 
 const errorNew = {
@@ -85,6 +86,23 @@ test({
 		{
 			code: 'const newFoo = "foo"',
 			options: [{blacklist: ['old']}]
+		},
+		outdent`
+			function Foo() {
+				console.log(new.target, new.target.name);
+			}
+		`,
+		outdent`
+			class Foo {
+				constructor() {
+					console.log(new.target, new.target.name);
+				}
+			}
+		`,
+		'const foo = {new: 1};',
+		{
+			code: 'var foo = {new: 1}',
+			options: [{checkProperties: false}]
 		}
 	],
 	invalid: [


### PR DESCRIPTION
I was checking if this rule report on `new` as `Identifier`, seems we are not reporting on it, better keep these tests.

Since `blacklist` is configurable, there will be bug if forbid prefix like `ne` or `impor`(import.meta) or `un`(undefined), let's not consider this.