### PR TITLE
`better-regex`: Disable  broken `combineRepeatingPatterns` transform

### DIFF
--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -12,7 +12,10 @@ const messages = {
 const create = context => {
 	const {sortCharacterClasses} = context.options[0] || {};
 
-	const ignoreList = ['combineRepeatingPatterns'];
+	const ignoreList = [
+		// #994
+		'combineRepeatingPatterns'
+	];
 
 	if (sortCharacterClasses === false) {
 		ignoreList.push('charClassClassrangesMerge');

--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -12,7 +12,7 @@ const messages = {
 const create = context => {
 	const {sortCharacterClasses} = context.options[0] || {};
 
-	const ignoreList = [];
+	const ignoreList = ['combineRepeatingPatterns'];
 
 	if (sortCharacterClasses === false) {
 		ignoreList.push('charClassClassrangesMerge');

--- a/test/better-regex.js
+++ b/test/better-regex.js
@@ -70,7 +70,10 @@ test({
 		'new RegExp()',
 
 		// #472
-		'/[ ;-]/g'
+		'/[ ;-]/g',
+
+		// #994
+		'/\\s?\\s?/'
 	],
 	invalid: [
 		// Literal regex


### PR DESCRIPTION
This is a temporary fix for #994 until this can be resolved upstream. I considered adding an option to the rule to enable/disable this transform, but since this is likely to just be a temporary fix, didn't think it was worth it.

I added a quick test case as from the original issue, but let me know if there's anything else you'd like to see here.

Closes #994
