### PR TITLE
Fix `isLiteralValue`

### DIFF
--- a/rules/utils/is-literal-value.js
+++ b/rules/utils/is-literal-value.js
@@ -1,2 +1,12 @@
 'use strict';
-module.exports = (node, value) => node && node.type === 'Literal' && node.value === value;
+module.exports = (node, value) => {
+	if (!node || node.type !== 'Literal') {
+		return false;
+	}
+
+	if (value === null) {
+		return node.raw === 'null';
+	}
+
+	return node.value === value;
+};


### PR DESCRIPTION
Fix potential bug on checking `null` Literal, [value of `BigInt` Literal can be `null`](https://github.com/estree/estree/blob/390a050fd2d6a7b69688f1434e0929d7c7455d05/es2020.md#bigintliteral) if runtime don't support `BigInt`, also there might be [`Decimal` Literal](https://github.com/estree/estree/blob/390a050fd2d6a7b69688f1434e0929d7c7455d05/experimental/decimal.md#decimal)