### PR TITLE
`no-array-callback-reference`: Improve suggestions for `Array#forEach()`

### DIFF
--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -25,7 +25,11 @@ const iteratorMethods = [
 	['find'],
 	['findIndex'],
 	['flatMap'],
-	['forEach'],
+	[
+		'forEach', {
+			returnsUndefined: true
+		}
+	],
 	['map'],
 	[
 		'reduce', {
@@ -58,6 +62,7 @@ const iteratorMethods = [
 		ignore: ['Boolean'],
 		minParameters: 1,
 		extraSelector: '',
+		returnsUndefined: false,
 		...options
 	};
 	return [method, options];
@@ -105,7 +110,7 @@ function check(context, node, method, options) {
 		suggest: []
 	};
 
-	const {parameters, minParameters} = options;
+	const {parameters, minParameters, returnsUndefined} = options;
 	for (let parameterLength = minParameters; parameterLength <= parameters.length; parameterLength++) {
 		const suggestionParameters = parameters.slice(0, parameterLength).join(', ');
 
@@ -124,7 +129,9 @@ function check(context, node, method, options) {
 
 				return fixer.replaceText(
 					node,
-					`(${suggestionParameters}) => ${nodeText}(${suggestionParameters})`
+					returnsUndefined ?
+						`(${suggestionParameters}) => { ${nodeText}(${suggestionParameters}); }` :
+						`(${suggestionParameters}) => ${nodeText}(${suggestionParameters})`
 				);
 			}
 		};

--- a/test/no-array-callback-reference.js
+++ b/test/no-array-callback-reference.js
@@ -17,6 +17,8 @@ const simpleMethods = [
 	'map'
 ];
 
+const simpleMethodsExceptForEach = simpleMethods.filter(name => name !== 'forEach');
+
 const reduceLikeMethods = [
 	'reduce',
 	'reduceRight'
@@ -125,7 +127,7 @@ ruleTester.run('no-array-callback-reference', rule, {
 	],
 	invalid: [
 		// Suggestions
-		...simpleMethods.map(
+		...simpleMethodsExceptForEach.map(
 			method => invalidTestCase({
 				code: `foo.${method}(fn)`,
 				method,
@@ -137,6 +139,16 @@ ruleTester.run('no-array-callback-reference', rule, {
 				]
 			})
 		),
+		invalidTestCase({
+			code: 'foo.forEach(fn)',
+			method: 'forEach',
+			name: 'fn',
+			suggestions: [
+				'foo.forEach((element) => { fn(element); })',
+				'foo.forEach((element, index) => { fn(element, index); })',
+				'foo.forEach((element, index, array) => { fn(element, index, array); })'
+			]
+		}),
 		...reduceLikeMethods.map(
 			method => invalidTestCase({
 				code: `foo.${method}(fn)`,
@@ -151,7 +163,7 @@ ruleTester.run('no-array-callback-reference', rule, {
 		),
 
 		// 2 arguments
-		...simpleMethods.map(
+		...simpleMethodsExceptForEach.map(
 			method => invalidTestCase({
 				code: `foo.${method}(fn, thisArgument)`,
 				method,
@@ -163,6 +175,16 @@ ruleTester.run('no-array-callback-reference', rule, {
 				]
 			})
 		),
+		invalidTestCase({
+			code: 'foo.forEach(fn, thisArgument)',
+			method: 'forEach',
+			name: 'fn',
+			suggestions: [
+				'foo.forEach((element) => { fn(element); }, thisArgument)',
+				'foo.forEach((element, index) => { fn(element, index); }, thisArgument)',
+				'foo.forEach((element, index, array) => { fn(element, index, array); }, thisArgument)'
+			]
+		}),
 		...reduceLikeMethods.map(
 			method => invalidTestCase({
 				code: `foo.${method}(fn, initialValue)`,
@@ -191,7 +213,7 @@ ruleTester.run('no-array-callback-reference', rule, {
 		),
 
 		// Not `Identifier`
-		...simpleMethods.map(
+		...simpleMethodsExceptForEach.map(
 			method => invalidTestCase({
 				code: `foo.${method}(lib.fn)`,
 				method,


### PR DESCRIPTION
Should not return value in `forEach` callback.

```diff
- foo.forEach((element) => fn(element), thisArgument)
+ foo.forEach((element) => { fn(element); }, thisArgument)
```