### PR TITLE
`consistent-destructuring`: Add `ExperimentalRestProperty` check

### DIFF
--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -92,6 +92,8 @@ const create = context => {
 				property.value.type === 'Identifier'
 			);
 			const lastProperty = objectPattern.properties[objectPattern.properties.length - 1];
+
+			// TODO: Remove `ExperimentalRestProperty` check when we drop support for `babel-eslint` #1040
 			const hasRest = lastProperty &&
 				(lastProperty.type === 'RestElement' || lastProperty.type === 'ExperimentalRestProperty');
 

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -92,7 +92,8 @@ const create = context => {
 				property.value.type === 'Identifier'
 			);
 			const lastProperty = objectPattern.properties[objectPattern.properties.length - 1];
-			const hasRest = lastProperty && lastProperty.type === 'RestElement';
+			const hasRest = lastProperty &&
+				(lastProperty.type === 'RestElement' || lastProperty.type === 'ExperimentalRestProperty');
 
 			const expression = source.getText(node);
 			const member = source.getText(node.property);

--- a/test/consistent-destructuring.js
+++ b/test/consistent-destructuring.js
@@ -1,13 +1,5 @@
-import test from 'ava';
-import avaRuleTester from 'eslint-ava-rule-tester';
 import {outdent} from 'outdent';
-import rule from '../rules/consistent-destructuring.js';
-
-const ruleTester = avaRuleTester(test, {
-	parserOptions: {
-		ecmaVersion: 2020
-	}
-});
+import {test} from './utils/test.js';
 
 const invalidTestCase = ({code, suggestions}) => {
 	if (!suggestions) {
@@ -33,7 +25,7 @@ const invalidTestCase = ({code, suggestions}) => {
 	};
 };
 
-ruleTester.run('consistent-destructuring', rule, {
+test({
 	valid: [
 		'console.log(foo.a, foo.b);',
 		'const foo = 10;',
@@ -474,5 +466,26 @@ ruleTester.run('consistent-destructuring', rule, {
 				}]
 			}]
 		}
+	]
+});
+
+test.babelLegacy({
+	valid: [
+		outdent`
+			const {a, ...b} = bar;
+			console.log(bar.c);
+		`
+	],
+	invalid: [
+		invalidTestCase({
+			code: outdent`
+				const {a, ...b} = bar;
+				console.log(bar.a);
+			`,
+			suggestions: [outdent`
+				const {a, ...b} = bar;
+				console.log(a);
+			`]
+		})
 	]
 });


### PR DESCRIPTION
Fixes the `hasRest` check when using Babel's `ExperimentalRestProperty`. See https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1013#issuecomment-759159860.