### PR TITLE
`no-array-callback-reference`: Fix incorrect example

### DIFF
--- a/docs/rules/no-array-callback-reference.md
+++ b/docs/rules/no-array-callback-reference.md
@@ -151,12 +151,6 @@ const fn = (a, b) => a.concat(b);
 ```
 
 ```js
-const fn = (a, b) => a.concat(b);
-
-[1, 2, 3].reduceRight(fn, []);
-```
-
-```js
 [1, 2, 3].map(x => someFunction({foo: 'bar'})(x));
 ```
 


### PR DESCRIPTION
**Problem:** The `no-array-callback-reference-docs` list the following example under _both_ "pass" and "fail":
```
const fn = (a, b) => a.concat(b);

[1, 2, 3].reduceRight(fn, []);
```

**Solution:** In reality this example fails, so remove it from under the "pass" examples.