### PR TITLE
Fix missing `eslint-visitor-keys` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"clean-regexp": "^1.0.0",
 		"eslint-template-visitor": "^2.2.2",
 		"eslint-utils": "^2.1.0",
+		"eslint-visitor-keys": "^2.0.0",
 		"import-modules": "^2.1.0",
 		"lodash": "^4.17.20",
 		"pluralize": "^8.0.0",


### PR DESCRIPTION
The dependency `eslint-visitor-keys`
was not declared in the `package.json`. This produced an error.

Closes: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1099