### PR TITLE
Smoke tests: Switch custom setup to pre-configured GitHub action

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,7 +13,12 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 14
-    - run: npm install
-    - run: npm link
-    - run: npm link eslint-plugin-unicorn
-    - run: npm run smoke
+    - run: |
+        npm install
+        npm link
+        npm link eslint-plugin-unicorn
+    - uses: AriPerkkio/eslint-remote-tester-run-action@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-title: "Results of weekly scheduled smoke test"
+        eslint-remote-tester-config: test/smoke/eslint-remote-tester.config.js

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"eslint": "^7.15.0",
 		"eslint-ava-rule-tester": "^4.0.0",
 		"eslint-plugin-eslint-plugin": "^2.3.0",
-		"eslint-remote-tester": "^0.4.0",
+		"eslint-remote-tester": "^1.1.0",
 		"execa": "^5.0.0",
 		"listr": "^0.14.3",
 		"mem": "8.0.0",

--- a/test/smoke/repositories.json
+++ b/test/smoke/repositories.json
@@ -1,4 +1,6 @@
 [
+	"luisFebro/studio-love-beauty",
+	"uiwjs/uiw",
 	"astrofox-io/astrofox",
 	"AriPerkkio/js-framework-playground",
 	"oldboyxx/jira_clone",


### PR DESCRIPTION
This PR replaces old custom smoke test workflow setup with pre-configured github action. https://github.com/marketplace/actions/eslint-remote-tester-runner

This Github CI action will run `eslint-remote-tester` exactly as before. The only addition is that results of the test run are now reported in Github issue in this repository. See example report from here: https://github.com/AriPerkkio/eslint-plugin-unicorn/issues/4 and here https://github.com/AriPerkkio/eslint-remote-tester/issues.

Results of action run are posted in new Github issue. If old issue has not been closed it will re-use that one and report results in issue comment. If run is successfull (no crashes) no issues or comments are posted. 

I also included two repositories which are currently crashing some rule in a separate commit. 

Also make sure to check out `eslint-remote-tester-pr-comparator` which is used for comparing changes of PR: https://github.com/marketplace/actions/eslint-remote-tester-pr-comparator
Let me know if you want to try this one out too - I can setup PR. 

