### PR TITLE
`prevent-abbreviations`: Do not rename exported TypeScript types

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -424,6 +424,13 @@ const isExportedIdentifier = identifier => {
 		return identifier.parent.parent.type === 'ExportNamedDeclaration';
 	}
 
+	if (
+		identifier.parent.type === 'TSTypeAliasDeclaration' &&
+		identifier.parent.id === identifier
+	) {
+		return identifier.parent.parent.type === 'ExportNamedDeclaration';
+	}
+
 	return false;
 };
 

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1827,6 +1827,12 @@ runTest.typescript({
 			errors: 1
 		},
 
+		// #1102
+		noFixingTestCase({
+			code: 'export type Props = string',
+			errors: createErrors()
+		}),
+
 		// #347
 		{
 			code: outdent`
@@ -1858,7 +1864,7 @@ runTest.typescript({
 				export type PreloadProps<TExtraProps = null> = {}
 			`,
 			output: outdent`
-				export type PreloadProperties<TExtraProperties = null> = {}
+				export type PreloadProps<TExtraProperties = null> = {}
 			`,
 			errors: [...createErrors(), ...createErrors()]
 		}


### PR DESCRIPTION
Fixes #1102 

This required me to change the output of an existing test case. I have tried my best to see if I made a mistake there, but the only conclusion I could come to was that if you agree with my diagnosis in #1102 , you should also agree with the fix.

A similar test case did not have to be refactored. I'm really not sure why, but this is a test case for the babel-eslint parser, which I guess could be parsing the code as Flow – consequently without the same fixes.

Note: I could also add a fix for Flow types, if that's desirable.

```javascript
runTest.babelLegacy({
	valid: [],
	invalid: [
		// https://github.com/facebook/relay/blob/597d2a17aa29d401830407b6814a5f8d148f632d/packages/relay-experimental/EntryPointTypes.flow.js#L138
		{
			code: outdent`
				export type PreloadProps<TExtraProps = null> = {};
			`,
			output: outdent`
				export type PreloadProperties<TExtraProperties = null> = {};
			`,
			errors: [...createErrors(), ...createErrors()]
		}
	]
});
```