### PR TITLE
`prevent-abbreviations`: Do not rename exported types when using @babel/eslint-parser

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -431,6 +431,13 @@ const isExportedIdentifier = identifier => {
 		return identifier.parent.parent.type === 'ExportNamedDeclaration';
 	}
 
+	if (
+		identifier.parent.type === 'TypeAlias' &&
+		identifier.parent.id === identifier
+	) {
+		return identifier.parent.parent.type === 'ExportNamedDeclaration';
+	}
+
 	return false;
 };
 

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1880,7 +1880,7 @@ runTest.babelLegacy({
 				export type PreloadProps<TExtraProps = null> = {};
 			`,
 			output: outdent`
-				export type PreloadProperties<TExtraProperties = null> = {};
+				export type PreloadProps<TExtraProperties = null> = {};
 			`,
 			errors: [...createErrors(), ...createErrors()]
 		}


### PR DESCRIPTION
A follow up task from #1103 