### PR TITLE
Switch `run-rules-on-codebase` script to ES Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"test": "xo && nyc ava",
 		"create-rule": "node ./scripts/create-rule.js",
-		"run-rules-on-codebase": "node ./test/run-rules-on-codebase/lint.js",
+		"run-rules-on-codebase": "node ./test/run-rules-on-codebase/lint.mjs",
 		"integration": "node ./test/integration/test.js",
 		"smoke": "eslint-remote-tester --config ./test/smoke/eslint-remote-tester.config.js"
 	},

--- a/test/run-rules-on-codebase/lint.mjs
+++ b/test/run-rules-on-codebase/lint.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-'use strict';
-const {ESLint} = require('eslint');
-const unicorn = require('../..');
+import {ESLint} from 'eslint';
+import unicorn from '../../index.js';
 
 const {recommended} = unicorn.configs;
 const files = [process.argv[2] || '.'];
@@ -10,6 +9,7 @@ const fix = process.argv.includes('--fix');
 const eslint = new ESLint({
 	baseConfig: recommended,
 	useEslintrc: false,
+	extensions: ['.js', '.mjs'],
 	plugins: {
 		unicorn
 	},


### PR DESCRIPTION
- Switch to Module
- Fix `.mjs` file is not checked