### PR TITLE
Use `@babel/eslint-parser` in integration tests

### DIFF
--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -17,6 +17,7 @@ module.exports = {
 		},
 		requireConfigFile: false,
 		babelOptions: {
+			babelrc: false,
 			configFile: false,
 			parserOpts: {
 				plugins: [

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -18,6 +18,7 @@ module.exports = {
 		requireConfigFile: false,
 		babelOptions: {
 			babelrc: false,
+			configFile: false,
 			parserOpts: {
 				plugins: [
 					'jsx',

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -29,7 +29,9 @@ module.exports = {
 			}
 		}
 	},
-	plugins: ['unicorn'],
+	plugins: [
+		'unicorn'
+	],
 	extends: 'plugin:unicorn/recommended',
 	rules: {
 		...enableAllRules,

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -18,7 +18,6 @@ module.exports = {
 		requireConfigFile: false,
 		babelOptions: {
 			babelrc: false,
-			configFile: false,
 			parserOpts: {
 				plugins: [
 					'jsx',

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -9,16 +9,27 @@ const enableAllRules = Object.fromEntries(
 
 module.exports = {
 	root: true,
-	parser: 'babel-eslint',
+	parser: '@babel/eslint-parser',
 	parserOptions: {
 		ecmaVersion: 2021,
 		ecmaFeatures: {
 			jsx: true
+		},
+		requireConfigFile: false,
+		babelOptions: {
+			babelrc: false,
+			configFile: false,
+			parserOpts: {
+				plugins: [
+					'jsx',
+					'classProperties',
+					'doExpressions',
+					'exportDefaultFrom'
+				]
+			}
 		}
 	},
-	plugins: [
-		'unicorn'
-	],
+	plugins: ['unicorn'],
 	extends: 'plugin:unicorn/recommended',
 	rules: {
 		...enableAllRules,

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -17,7 +17,6 @@ module.exports = {
 		},
 		requireConfigFile: false,
 		babelOptions: {
-			babelrc: false,
 			configFile: false,
 			parserOpts: {
 				plugins: [

--- a/test/integration/projects.js
+++ b/test/integration/projects.js
@@ -59,7 +59,6 @@ module.exports = [
 			'tests/**'
 		]
 	},
-	'https://github.com/facebook/react',
 	{
 		repository: 'https://github.com/angular/angular',
 		ignore: [
@@ -94,7 +93,13 @@ module.exports = [
 	'https://github.com/sindresorhus/capture-website',
 	'https://github.com/sindresorhus/file-type',
 	'https://github.com/sindresorhus/slugify',
-	'https://github.com/gatsbyjs/gatsby',
+	{
+		repository: 'https://github.com/gatsbyjs/gatsby',
+		ignore: [
+			// These files use `flow`
+			'**/*.js'
+		]
+	},
 	{
 		repository: 'https://github.com/puppeteer/puppeteer',
 		ignore: [
@@ -123,7 +128,6 @@ module.exports = [
 		]
 	},
 	'https://github.com/ReactTraining/react-router',
-	'https://github.com/facebook/relay',
 	'https://github.com/mozilla/pdf.js',
 	// #912
 	{


### PR DESCRIPTION
Removed `react` and `relay` project since they use `flow`, and I don't think we should enable `flow` plugin for `babel` parser.