### PR TITLE
`no-keyword-prefix`: Rename `blacklist` option to `disallowedPrefixes`

### DIFF
--- a/docs/rules/no-keyword-prefix.md
+++ b/docs/rules/no-keyword-prefix.md
@@ -22,15 +22,15 @@ const fooNew = 'foo';
 
 ## Options
 
-### `blacklist`
+### `keywords`
 
-If you want a custom list of forbidden prefixes you can set them with `blacklist`:
+If you want a custom list of forbidden prefixes you can set them with `keywords`:
 
 ```js
-// eslint unicorn/no-keyword-prefix: ["error", {"blacklist": ["new", "for"]}]
+// eslint unicorn/no-keyword-prefix: ["error", {"keywords": ["new", "for"]}]
 const classFoo = "a"; // pass
 
-// eslint unicorn/no-keyword-prefix: ["error", {"blacklist": ["new", "for"]}]
+// eslint unicorn/no-keyword-prefix: ["error", {"keywords": ["new", "for"]}]
 const forFoo = "a"; // fail
 ```
 

--- a/docs/rules/no-keyword-prefix.md
+++ b/docs/rules/no-keyword-prefix.md
@@ -22,15 +22,15 @@ const fooNew = 'foo';
 
 ## Options
 
-### `keywords`
+### `disallowedPrefixes`
 
-If you want a custom list of forbidden prefixes you can set them with `keywords`:
+If you want a custom list of forbidden prefixes you can set them with `disallowedPrefixes`:
 
 ```js
-// eslint unicorn/no-keyword-prefix: ["error", {"keywords": ["new", "for"]}]
+// eslint unicorn/no-keyword-prefix: ["error", {"disallowedPrefixes": ["new", "for"]}]
 const classFoo = "a"; // pass
 
-// eslint unicorn/no-keyword-prefix: ["error", {"keywords": ["new", "for"]}]
+// eslint unicorn/no-keyword-prefix: ["error", {"disallowedPrefixes": ["new", "for"]}]
 const forFoo = "a"; // fail
 ```
 

--- a/rules/no-keyword-prefix.js
+++ b/rules/no-keyword-prefix.js
@@ -8,12 +8,12 @@ const messages = {
 };
 
 const prepareOptions = ({
-	keywords,
+	disallowedPrefixes,
 	checkProperties = true,
 	onlyCamelCase = true
 } = {}) => {
 	return {
-		keywords: (keywords || [
+		disallowedPrefixes: (disallowedPrefixes || [
 			'new',
 			'class'
 		]),
@@ -23,7 +23,7 @@ const prepareOptions = ({
 };
 
 function findKeywordPrefix(name, options) {
-	return options.keywords.find(keyword => {
+	return options.disallowedPrefixes.find(keyword => {
 		const suffix = options.onlyCamelCase ? '[A-Z]' : '.';
 		const regex = new RegExp(`^${keyword}${suffix}`);
 		return name.match(regex);
@@ -170,7 +170,7 @@ const schema = [
 	{
 		type: 'object',
 		properties: {
-			keywords: {
+			disallowedPrefixes: {
 				type: 'array',
 				items: [
 					{

--- a/rules/no-keyword-prefix.js
+++ b/rules/no-keyword-prefix.js
@@ -8,12 +8,12 @@ const messages = {
 };
 
 const prepareOptions = ({
-	blacklist,
+	keywords,
 	checkProperties = true,
 	onlyCamelCase = true
 } = {}) => {
 	return {
-		blacklist: (blacklist || [
+		keywords: (keywords || [
 			'new',
 			'class'
 		]),
@@ -23,7 +23,7 @@ const prepareOptions = ({
 };
 
 function findKeywordPrefix(name, options) {
-	return options.blacklist.find(keyword => {
+	return options.keywords.find(keyword => {
 		const suffix = options.onlyCamelCase ? '[A-Z]' : '.';
 		const regex = new RegExp(`^${keyword}${suffix}`);
 		return name.match(regex);
@@ -170,7 +170,7 @@ const schema = [
 	{
 		type: 'object',
 		properties: {
-			blacklist: {
+			keywords: {
 				type: 'array',
 				items: [
 					{

--- a/test/no-keyword-prefix.mjs
+++ b/test/no-keyword-prefix.mjs
@@ -87,7 +87,7 @@ test({
 		},
 		{
 			code: 'const newFoo = "foo"',
-			options: [{blacklist: ['old']}]
+			options: [{keywords: ['old']}]
 		},
 		outdent`
 			function Foo() {
@@ -262,7 +262,7 @@ test({
 		},
 		{
 			code: 'const oldFoo = "foo"',
-			options: [{blacklist: ['old']}],
+			options: [{keywords: ['old']}],
 			errors: [errorIgnoreList]
 		},
 		{

--- a/test/no-keyword-prefix.mjs
+++ b/test/no-keyword-prefix.mjs
@@ -87,7 +87,7 @@ test({
 		},
 		{
 			code: 'const newFoo = "foo"',
-			options: [{keywords: ['old']}]
+			options: [{disallowedPrefixes: ['old']}]
 		},
 		outdent`
 			function Foo() {
@@ -262,7 +262,7 @@ test({
 		},
 		{
 			code: 'const oldFoo = "foo"',
-			options: [{keywords: ['old']}],
+			options: [{disallowedPrefixes: ['old']}],
 			errors: [errorIgnoreList]
 		},
 		{


### PR DESCRIPTION
Fixes #942