### PR TITLE
Update options for `@babel/eslint-parser`

### DIFF
--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -19,12 +19,16 @@ module.exports = {
 		babelOptions: {
 			babelrc: false,
 			configFile: false,
+			allowAwaitOutsideFunction: true,
 			parserOpts: {
 				plugins: [
 					'jsx',
 					'classProperties',
 					'doExpressions',
-					'exportDefaultFrom'
+					'exportDefaultFrom',
+          'classPrivateProperties',
+          'classPrivateMethods',
+          'importMeta',
 				]
 			}
 		}

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -50,6 +50,10 @@ class Tester {
 			['estree', {classFeatures: true}],
 			'jsx',
 			'classProperties',
+			'exportDefaultFrom',
+			'classPrivateProperties',
+			'classPrivateMethods',
+			'importMeta',
 			...babelPlugins
 		];
 
@@ -65,6 +69,9 @@ class Tester {
 					allowImportExportEverywhere: true,
 					...testerOptions.parserOptions,
 					babelOptions: {
+						babelrc: false,
+						configFile: false,
+						allowAwaitOutsideFunction: true,
 						...testerOptions.parserOptions.babelOptions,
 						parserOpts: {
 							...testerOptions.parserOptions.babelOptions.parserOpts,


### PR DESCRIPTION
Should be able to fix the integration test