### PR TITLE
Use `null` to assert no autofixes tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,14 @@
 				"parserOptions": {
 					"sourceType": "module"
 				}
+			},
+			{
+				"files": [
+					"test/*.mjs"
+				],
+				"rules": {
+					"unicorn/no-null": "off"
+				}
 			}
 		],
 		"rules": {

--- a/test/catch-error-name.mjs
+++ b/test/catch-error-name.mjs
@@ -21,7 +21,7 @@ function invalidTestCase(options) {
 	const {code, name, output, errors} = options;
 	return {
 		code,
-		output: output || code,
+		output: output || null,
 		options: name ? [{name}] : [],
 		errors
 	};

--- a/test/consistent-destructuring.mjs
+++ b/test/consistent-destructuring.mjs
@@ -16,7 +16,7 @@ const invalidTestCase = ({code, suggestions}) => {
 
 	return {
 		code,
-		output: code,
+		output: null,
 		errors: suggestions.map(suggestion => ({
 			messageId: 'consistentDestructuring',
 			suggestions: [{

--- a/test/consistent-function-scoping.mjs
+++ b/test/consistent-function-scoping.mjs
@@ -395,6 +395,7 @@ test({
 					return foo;
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -407,6 +408,7 @@ test({
 					return foo;
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -417,6 +419,7 @@ test({
 					}
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -427,6 +430,7 @@ test({
 					}
 				};
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -437,6 +441,7 @@ test({
 					};
 				};
 			`,
+			output: null,
 			errors: [createError('function')]
 		},
 		{
@@ -447,6 +452,7 @@ test({
 					};
 				}
 			`,
+			output: null,
 			errors: [createError('function')]
 		},
 		{
@@ -458,6 +464,7 @@ test({
 					doBar();
 				}
 			`,
+			output: null,
 			errors: [createError('function')]
 		},
 		{
@@ -468,12 +475,14 @@ test({
 					}
 				}
 			`,
+			output: null,
 			errors: [createError('arrow function \'doBar\'')]
 		},
 		{
 			code: outdent`
 				const doFoo = () => bar => bar;
 			`,
+			output: null,
 			errors: [createError('arrow function')]
 		},
 		// `this`
@@ -486,6 +495,7 @@ test({
 					return doBar();
 				};
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -495,6 +505,7 @@ test({
 					return doBar();
 				};
 			`,
+			output: null,
 			errors: [createError('arrow function \'doBar\'')]
 		},
 		{
@@ -504,6 +515,7 @@ test({
 					return doBar();
 				};
 			`,
+			output: null,
 			errors: [createError('arrow function \'doBar\'')]
 		},
 		// `arguments`
@@ -516,6 +528,7 @@ test({
 					return doBar();
 				};
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -525,6 +538,7 @@ test({
 					return doBar();
 				};
 			`,
+			output: null,
 			errors: [createError('arrow function \'doBar\'')]
 		},
 		{
@@ -536,6 +550,7 @@ test({
 					return foo;
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -547,6 +562,7 @@ test({
 					return doBar;
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -555,6 +571,7 @@ test({
 					function doBar() {}
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -570,6 +587,7 @@ test({
 					return foo;
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -582,6 +600,7 @@ test({
 					}
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		{
@@ -592,40 +611,49 @@ test({
 					}
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBar\'')]
 		},
 		// Function kinds and names, loc
 		{
 			code: 'function foo() { function bar() {} }',
+			output: null,
 			errors: [createError('function \'bar\'', {line: 1, column: 18, endLine: 1, endColumn: 30})]
 		},
 		{
 			code: 'function foo() { async function bar() {} }',
+			output: null,
 			errors: [createError('async function \'bar\'', {line: 1, column: 18, endLine: 1, endColumn: 36})]
 		},
 		{
 			code: 'function foo() { function* bar() {} }',
+			output: null,
 			errors: [createError('generator function \'bar\'', {line: 1, column: 18, endLine: 1, endColumn: 31})]
 		},
 		{
 			code: 'function foo() { async function* bar() {} }',
+			output: null,
 			errors: [createError('async generator function \'bar\'', {line: 1, column: 18, endLine: 1, endColumn: 37})]
 		},
 		{
 			code: 'function foo() { const bar = () => {} }',
+			output: null,
 			errors: [createError('arrow function \'bar\'', {line: 1, column: 33, endLine: 1, endColumn: 35})]
 		},
 		{
 			code: 'const doFoo = () => bar => bar;',
+			output: null,
 			errors: [createError('arrow function', {line: 1, column: 25, endLine: 1, endColumn: 27})]
 		},
 		{
 			code: 'function foo() { const bar = async () => {} }',
+			output: null,
 			errors: [createError('async arrow function \'bar\'', {line: 1, column: 39, endLine: 1, endColumn: 41})]
 		},
 		// Actual message
 		{
 			code: 'function foo() { async function* bar() {} }',
+			output: null,
 			errors: [{
 				message: 'Move async generator function \'bar\' to the outer scope.'
 			}]
@@ -640,6 +668,7 @@ test({
 					}
 				}, [])
 			`,
+			output: null,
 			errors: [createError('function \'bar\'')]
 		},
 		// IIFE
@@ -652,6 +681,7 @@ test({
 					}
 				})();
 			`,
+			output: null,
 			errors: [createError('function \'bar\'')]
 		},
 		// #770
@@ -664,6 +694,7 @@ test({
 					process.exitCode = returnsZero();
 				});
 			`,
+			output: null,
 			errors: [createError('function \'returnsZero\'')]
 		},
 		{
@@ -681,6 +712,7 @@ test({
 					})(),
 				)
 			`,
+			output: null,
 			errors: [createError('function \'bar\'')]
 		},
 		{
@@ -697,6 +729,7 @@ test({
 					},
 				)
 			`,
+			output: null,
 			errors: [createError('function \'baz\'')]
 		},
 		{
@@ -709,6 +742,7 @@ test({
 					return <div>{ doBaz() }</div>
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBaz\'')]
 		},
 		{
@@ -723,6 +757,7 @@ test({
 					return <div>{ doBaz() }</div>
 				}
 			`,
+			output: null,
 			errors: [createError('function \'doBaz\'')]
 		},
 		// JSX
@@ -739,6 +774,7 @@ test({
 					function foo() {}
 				}
 			`,
+			output: null,
 			errors: ['b', 'c', 'foo'].map(functionName => createError(`function '${functionName}'`))
 		},
 		// Should check functions inside arrow functions
@@ -748,6 +784,7 @@ test({
 					function inner() {}
 				}
 			`,
+			output: null,
 			errors: [createError('function \'inner\'')],
 			options: [{checkArrowFunctions: false}]
 		}

--- a/test/expiring-todo-comments.mjs
+++ b/test/expiring-todo-comments.mjs
@@ -114,6 +114,7 @@ test({
 	invalid: [
 		{
 			code: '// TODO [2000-01-01]: too old',
+			output: null,
 			errors: [expiredTodoError('2000-01-01', 'too old')],
 			options: [{ignoreDatesOnPullRequests: false}]
 		},
@@ -123,6 +124,7 @@ test({
 			* TODO [2000-01-01]: Another
 			* TODO [2000-01-01] Way
 			*/`,
+			output: null,
 			errors: [
 				expiredTodoError('2000-01-01', 'Yet'),
 				expiredTodoError('2000-01-01', 'Another'),
@@ -136,6 +138,7 @@ test({
 			* TODO [2200-01-01]: Valid
 			* TODO [2000-01-01]: Invalid
 			*/`,
+			output: null,
 			errors: [
 				expiredTodoError('2000-01-01', 'Invalid'),
 				expiredTodoError('2000-01-01', 'Invalid')
@@ -148,6 +151,7 @@ test({
 			* TODO [engine:node@>=8]: Invalid
 			* Also something here
 			*/`,
+			output: null,
 			errors: [
 				engineMatchesError('node>=8', 'Invalid')
 			],
@@ -155,157 +159,192 @@ test({
 		},
 		{
 			code: '// fixme [2000-01-01]: too old',
+			output: null,
 			errors: [expiredTodoError('2000-01-01', 'too old')],
 			options: [{ignoreDatesOnPullRequests: false}]
 		},
 		{
 			code: '// xxx [2000-01-01]: too old',
+			output: null,
 			errors: [expiredTodoError('2000-01-01', 'too old')],
 			options: [{ignoreDatesOnPullRequests: false}]
 		},
 		{
 			code: '// ToDo [2000-01-01]: too old',
+			output: null,
 			errors: [expiredTodoError('2000-01-01', 'too old')],
 			options: [{ignoreDatesOnPullRequests: false}]
 		},
 		{
 			code: '// fIxME [2000-01-01]: too old',
+			output: null,
 			errors: [expiredTodoError('2000-01-01', 'too old')],
 			options: [{ignoreDatesOnPullRequests: false}]
 		},
 		{
 			code: '// Todoist [2000-01-01]: too old',
+			output: null,
 			errors: [expiredTodoError('2000-01-01', 'too old')],
 			options: [{ignoreDatesOnPullRequests: false, terms: ['Todoist']}]
 		},
 		{
 			code: '// Expire Condition [2000-01-01]: too old',
+			output: null,
 			errors: [expiredTodoError('2000-01-01', 'too old')],
 			options: [{ignoreDatesOnPullRequests: false, terms: ['Expire Condition']}]
 		},
 		{
 			code: '// XxX [2000-01-01]: too old',
+			output: null,
 			errors: [expiredTodoError('2000-01-01', 'too old')],
 			options: [{ignoreDatesOnPullRequests: false}]
 		},
 		{
 			code: '// TODO [2200-12-12, 2200-12-12]: Multiple dates',
+			output: null,
 			errors: [avoidMultipleDatesError('2200-12-12, 2200-12-12', 'Multiple dates')],
 			output: '// TODO [2200-12-12, 2200-12-12]: Multiple dates'
 		},
 		{
 			code: '// TODO [>1]: if your package.json version is >1',
+			output: null,
 			errors: [reachedPackageVersionError('>1', 'if your package.json version is >1')]
 		},
 		{
 			code: '// TODO [>1, >2]: multiple package versions',
+			output: null,
 			errors: [avoidMultiplePackageVersionsError('>1, >2', 'multiple package versions')]
 		},
 		{
 			code: '// TODO [>=1]: if your package.json version is >=1',
+			output: null,
 			errors: [reachedPackageVersionError('>=1', 'if your package.json version is >=1')]
 		},
 		{
 			code: '// TODO [+read-pkg-up]: when you install `read-pkg-up`',
+			output: null,
 			errors: [havePackageError('read-pkg-up', 'when you install `read-pkg-up`')]
 		},
 		{
 			code: '// TODO [-popura]: when you uninstall `popura`',
+			output: null,
 			errors: [dontHavePackageError('popura', 'when you uninstall `popura`')]
 		},
 		{
 			code: '// TODO [read-pkg-up@>1]: when `read-pkg-up` version is > 1',
+			output: null,
 			errors: [versionMatchesError('read-pkg-up > 1', 'when `read-pkg-up` version is > 1')]
 		},
 		{
 			code: '// TODO [engine:node@>=8]: when support is for node >= 8',
+			output: null,
 			errors: [engineMatchesError('node>=8', 'when support is for node >= 8')]
 		},
 		{
 			code: '// TODO [read-pkg-up@>=5.1.1]: when `read-pkg-up` version is >= 5.1.1',
+			output: null,
 			errors: [versionMatchesError('read-pkg-up >= 5.1.1', 'when `read-pkg-up` version is >= 5.1.1')]
 		},
 		{
 			code: '// TODO [@lubien/fixture-beta-package@>=1.0.0-alfa.1]: when `@lubien/fixture-beta-package` version is >= 1.0.0-alfa.1',
+			output: null,
 			errors: [versionMatchesError('@lubien/fixture-beta-package >= 1.0.0-alfa.1', 'when `@lubien/fixture-beta-package` version is >= 1.0.0-alfa.1')]
 		},
 		{
 			code: '// TODO [@lubien/fixture-beta-package@>=1.0.0-beta.1]: when `@lubien/fixture-beta-package` version is >= 1.0.0-beta.1',
+			output: null,
 			errors: [versionMatchesError('@lubien/fixture-beta-package >= 1.0.0-beta.1', 'when `@lubien/fixture-beta-package` version is >= 1.0.0-beta.1')]
 		},
 		{
 			code: '// TODO [@lubien/fixture-beta-package@>=1.0.0-beta.0]: when `@lubien/fixture-beta-package` version is >= 1.0.0-beta.0',
+			output: null,
 			errors: [versionMatchesError('@lubien/fixture-beta-package >= 1.0.0-beta.0', 'when `@lubien/fixture-beta-package` version is >= 1.0.0-beta.0')]
 		},
 		{
 			code: '// TODO [semver>1]: Missing @.',
+			output: null,
 			errors: [missingAtSymbolError('semver>1', 'semver@>1', 'Missing @.')]
 		},
 		{
 			code: '// TODO [> 1]: Remove whitespace when it can fix.',
+			output: null,
 			errors: [removeWhitespaceError('> 1', 'Remove whitespace when it can fix.')]
 		},
 		{
 			code: '// TODO [semver@> 1]: Remove whitespace when it can fix.',
+			output: null,
 			errors: [removeWhitespaceError('semver@> 1', 'Remove whitespace when it can fix.')]
 		},
 		{
 			code: '// TODO [semver @>1]: Remove whitespace when it can fix.',
+			output: null,
 			errors: [removeWhitespaceError('semver @>1', 'Remove whitespace when it can fix.')]
 		},
 		{
 			code: '// TODO [semver@>= 1]: Remove whitespace when it can fix.',
+			output: null,
 			errors: [removeWhitespaceError('semver@>= 1', 'Remove whitespace when it can fix.')]
 		},
 		{
 			code: '// TODO [semver @>=1]: Remove whitespace when it can fix.',
+			output: null,
 			errors: [removeWhitespaceError('semver @>=1', 'Remove whitespace when it can fix.')]
 		},
 		{
 			code: '// TODO [engine:node @>=1]: Remove whitespace when it can fix.',
+			output: null,
 			errors: [removeWhitespaceError('engine:node @>=1', 'Remove whitespace when it can fix.')]
 		},
 		{
 			code: '// TODO [engine:node@>= 1]: Remove whitespace when it can fix.',
+			output: null,
 			errors: [removeWhitespaceError('engine:node@>= 1', 'Remove whitespace when it can fix.')]
 		},
 		{
 			code: '// TODO',
+			output: null,
 			errors: [noWarningCommentError('TODO')],
 			options: [{allowWarningComments: false}]
 		},
 		{
 			code: '// TODO []',
+			output: null,
 			errors: [noWarningCommentError('TODO []')],
 			options: [{allowWarningComments: false}]
 		},
 		{
 			code: '// TODO [no meaning at all]',
+			output: null,
 			errors: [noWarningCommentError('TODO [no meaning at all]')],
 			options: [{allowWarningComments: false}]
 		},
 		{
 			code: '// TODO [] might have [some] that [try [to trick] me]',
+			output: null,
 			errors: [noWarningCommentError('TODO [] might have [some] that [try [to...')],
 			options: [{allowWarningComments: false}]
 		},
 		{
 			code: '// TODO [but [it will]] [fallback] [[[ to the default ]]] rule [[[',
+			output: null,
 			errors: [noWarningCommentError('TODO [but [it will]] [fallback] [[[ to...')],
 			options: [{allowWarningComments: false}]
 		},
 		{
 			code: '// TODO [engine:npm@>=10000]: Unsupported engine',
+			output: null,
 			errors: [noWarningCommentError('TODO [engine:npm@>=10000]: Unsupported...')],
 			options: [{allowWarningComments: false}]
 		},
 		{
 			code: '// TODO [engine:somethingrandom@>=10000]: Unsupported engine',
+			output: null,
 			errors: [noWarningCommentError('TODO [engine:somethingrandom@>=10000]:...')],
 			options: [{allowWarningComments: false}]
 		},
 		{
 			code: '// TODO [2000-01-01, >1]: Combine date with package version',
+			output: null,
 			errors: [
 				expiredTodoError('2000-01-01', 'Combine date with package version'),
 				reachedPackageVersionError('>1', 'Combine date with package version')
@@ -314,6 +353,7 @@ test({
 		},
 		{
 			code: '// TODO [2200-12-12, >1, 2200-12-12, >2]: Multiple dates and package versions',
+			output: null,
 			errors: [
 				avoidMultipleDatesError('2200-12-12, 2200-12-12', 'Multiple dates and package versions'),
 				avoidMultiplePackageVersionsError('>1, >2', 'Multiple dates and package versions')
@@ -321,6 +361,7 @@ test({
 		},
 		{
 			code: '// TODO [-popura, read-pkg-up@>1]: Combine not having a package with version match',
+			output: null,
 			errors: [
 				dontHavePackageError('popura', 'Combine not having a package with version match'),
 				versionMatchesError('read-pkg-up > 1', 'Combine not having a package with version match')
@@ -328,6 +369,7 @@ test({
 		},
 		{
 			code: '// TODO [+read-pkg-up, -popura]: Combine presence/absence of packages',
+			output: null,
 			errors: [
 				havePackageError('read-pkg-up', 'Combine presence/absence of packages'),
 				dontHavePackageError('popura', 'Combine presence/absence of packages')
@@ -335,6 +377,7 @@ test({
 		},
 		{
 			code: '// Expire Condition [2000-01-01, semver>1]: Expired TODO and missing symbol',
+			output: null,
 			errors: [
 				expiredTodoError('2000-01-01', 'Expired TODO and missing symbol'),
 				missingAtSymbolError('semver>1', 'semver@>1', 'Expired TODO and missing symbol')
@@ -343,6 +386,7 @@ test({
 		},
 		{
 			code: '// TODO [semver @>=1, -popura]: Package uninstalled and whitespace error',
+			output: null,
 			errors: [
 				dontHavePackageError('popura', 'Package uninstalled and whitespace error'),
 				removeWhitespaceError('semver @>=1', 'Package uninstalled and whitespace error')
@@ -350,6 +394,7 @@ test({
 		},
 		{
 			code: '// HUGETODO [semver @>=1, engine:node@>=8, 2000-01-01, -popura, >1, +read-pkg-up, read-pkg-up@>1]: Big mix',
+			output: null,
 			errors: [
 				expiredTodoError('2000-01-01', 'Big mix'),
 				reachedPackageVersionError('>1', 'Big mix'),
@@ -363,6 +408,7 @@ test({
 		},
 		{
 			code: '// TODO [ISSUE-123] fix later',
+			output: null,
 			options: [{allowWarningComments: false, ignore: []}],
 			errors: [
 				noWarningCommentError('TODO [ISSUE-123] fix later')
@@ -373,6 +419,7 @@ test({
 			// TODO fix later
 			// TODO ISSUE-123 fix later
 			`,
+			output: null,
 			options: [{allowWarningComments: false, ignore: [/issue-\d+/i]}],
 			errors: [
 				noWarningCommentError('TODO fix later')
@@ -383,6 +430,7 @@ test({
 			TODO Invalid
 			TODO ISSUE-123 Valid
 			*/`,
+			output: null,
 			options: [{allowWarningComments: false, ignore: [/issue-\d+/i]}],
 			errors: [
 				noWarningCommentError('TODO Invalid')

--- a/test/expiring-todo-comments.mjs
+++ b/test/expiring-todo-comments.mjs
@@ -203,7 +203,6 @@ test({
 			code: '// TODO [2200-12-12, 2200-12-12]: Multiple dates',
 			output: null,
 			errors: [avoidMultipleDatesError('2200-12-12, 2200-12-12', 'Multiple dates')],
-			output: '// TODO [2200-12-12, 2200-12-12]: Multiple dates'
 		},
 		{
 			code: '// TODO [>1]: if your package.json version is >1',

--- a/test/explicit-length-check.mjs
+++ b/test/explicit-length-check.mjs
@@ -11,7 +11,7 @@ const suggestionCase = ({code, output, desc, options = []}) => {
 
 	return {
 		code,
-		output: code,
+		output: null,
 		options,
 		errors: [
 			{suggestions: [suggestion]}

--- a/test/filename-case.mjs
+++ b/test/filename-case.mjs
@@ -22,6 +22,7 @@ function testManyCases(filename, chosenCases, errorMessage) {
 function testCaseWithOptions(filename, errorMessage, options = []) {
 	return {
 		code: 'foo()',
+		output: null,
 		filename,
 		options,
 		errors: errorMessage && [

--- a/test/import-style.mjs
+++ b/test/import-style.mjs
@@ -65,6 +65,7 @@ const addDefaultOptions = test => {
 
 	return {
 		options: [options],
+		output: null,
 		...test
 	};
 };

--- a/test/no-abusive-eslint-disable.mjs
+++ b/test/no-abusive-eslint-disable.mjs
@@ -64,6 +64,7 @@ ruleTester.run('no-abusive-eslint-disable', rule, {
 				// eslint-disable-next-line @scopewithoutplugin
 				eval();
 			`,
+			output: null,
 			errors: 1
 		}
 	]

--- a/test/no-array-callback-reference.mjs
+++ b/test/no-array-callback-reference.mjs
@@ -47,7 +47,7 @@ const suggestionOutput = output => ({
 
 const invalidTestCase = (({code, method, name, suggestions}) => ({
 	code,
-	output: code,
+	output: null,
 	errors: [
 		{
 			...generateError(method, name),

--- a/test/no-array-for-each.mjs
+++ b/test/no-array-for-each.mjs
@@ -437,23 +437,13 @@ test.typescript({
 					}
 				)
 			`,
-			output: outdent`
-				const actions: Array<IRemoveStaleJobAction> = []
-
-				state.jobsV2.complete.forEach(
-					(job: IGatsbyCompleteJobV2, contentDigest: string): void => {
-						if (isJobStale(job)) {
-							actions.push(internalActions.removeStaleJob(contentDigest))
-						}
-					}
-				)
-			`,
+			output: null,
 			errors: 1
 		},
 		// https://github.com/microsoft/fluentui/blob/20f3d664a36c93174dc32786a9d465dd343dabe5/apps/todo-app/src/DataProvider.ts#L157
 		{
 			code: 'this._listeners.forEach((listener: () => void) => listener());',
-			output: 'this._listeners.forEach((listener: () => void) => listener());',
+			output: null,
 			errors: 1
 		},
 		// https://github.com/angular/angular/blob/4e8198d60f421ce120e3a6b57afe60a9332d2692/packages/animations/browser/src/render/transition_animation_engine.ts#L1636

--- a/test/no-for-loop.mjs
+++ b/test/no-for-loop.mjs
@@ -20,7 +20,7 @@ const ruleTesterEs5 = avaRuleTester(test, {
 function testCase(code, output) {
 	return {
 		code,
-		output: output || code,
+		output: output || null,
 		errors: [{messageId: 'no-for-loop'}]
 	};
 }

--- a/test/no-keyword-prefix.mjs
+++ b/test/no-keyword-prefix.mjs
@@ -110,163 +110,202 @@ test({
 	invalid: [
 		{
 			code: 'const newFoo = "foo"',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'const classFoo = "foo"',
+			output: null,
 			errors: [errorClass]
 		},
 		{
 			code: 'let newFoo = "foo"',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'var newFoo = "foo"',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'function newFoo(){}',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'foo.newFoo = function(){};',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'newFoo.foo = function(){};',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: '[newFoo.baz]',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'if (foo.newFoo === bar.newBar) { [newFoo.foo] }',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'foo.newFoo = bar.newBar',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'var foo = { newFoo: bar.newBar }',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'foo.foo.newFoo = { bar: bar.newBar }',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'var foo = {newFoo: 1}',
+			output: null,
 			options: [{checkProperties: true}],
 			errors: [errorNew]
 		},
 		{
 			code: 'foo.newFoo = 2;',
+			output: null,
 			options: [{checkProperties: true}],
 			errors: [errorNew]
 		},
 		{
 			code: 'var { newFoo: newBar } = foo;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'var { [newFoo]: bar } = foo;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'var { newFoo } = foo;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'var { newFoo: newFoo } = foo;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'var { newFoo = 1 } = foo;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import newFoo from "external-module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import * as newFoo from "external-module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import { newFoo } from "external-module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import { newFoo as newBar } from "external module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import { foo as newFoo } from "external module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import { foo, newBar } from "external-module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import { newFoo as foo, newBar } from "external-module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import foo, { newBar } from "external-module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'import newFoo, { newBar as bar } from "external-module";',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'function foo({ newBar }) {};',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'function foo({ newBar = \'default value\' }) {};',
+			output: null,
 			parserOptions: {ecmaVersion: 6},
 			errors: [errorNew]
 		},
 		{
 			code: 'const newFoo = 0; function foo({ newBar = newFoo}) {}',
+			output: null,
 			parserOptions: {ecmaVersion: 6},
 			errors: [errorNew, errorNew]
 		},
 		{
 			code: 'const { bar: newBar } = foo;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'function foo({ newBar: newFoo }) {}',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'function foo({ bar: newBar }) {};',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'var { foo: newBar = 1 } = bar;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'const { newFoo = false } = foo;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'const { newFoo = newBar } = foo;',
+			output: null,
 			errors: [errorNew]
 		},
 		{
 			code: 'const oldFoo = "foo"',
+			output: null,
 			options: [{disallowedPrefixes: ['old']}],
 			errors: [errorIgnoreList]
 		},
 		{
 			code: 'const new_foo = "foo"',
+			output: null,
 			options: [{onlyCamelCase: false}],
 			errors: [errorNew]
 		}

--- a/test/no-lonely-if.mjs
+++ b/test/no-lonely-if.mjs
@@ -3,7 +3,7 @@ import {getTester} from './utils/test.mjs';
 
 const {test} = getTester(import.meta);
 
-test({
+test.snapshot({
 	valid: [
 		outdent`
 			if (a) {
@@ -30,11 +30,6 @@ test({
 			}
 		`
 	],
-	invalid: []
-});
-
-test.snapshot({
-	valid: [],
 	invalid: [
 		outdent`
 			if (a) {

--- a/test/no-nested-ternary.mjs
+++ b/test/no-nested-ternary.mjs
@@ -16,10 +16,12 @@ test({
 	invalid: [
 		{
 			code: 'const foo = i > 5 ? true : (i < 100 ? true : (i < 1000 ? true : false));',
+			output: null,
 			errors: 1
 		},
 		{
 			code: 'const foo = i > 5 ? true : (i < 100 ? (i > 50 ? false : true) : false);',
+			output: null,
 			errors: 1
 		},
 		{

--- a/test/no-new-array.mjs
+++ b/test/no-new-array.mjs
@@ -10,7 +10,7 @@ const MESSAGE_ID_SPREAD = 'spread';
 
 const suggestionCase = ({code, suggestions}) => ({
 	code,
-	output: code,
+	output: null,
 	errors: [
 		{
 			messageId: MESSAGE_ID_ERROR,

--- a/test/no-null.mjs
+++ b/test/no-null.mjs
@@ -20,7 +20,7 @@ const invalidTestCase = testCase => {
 	if (suggestions) {
 		return {
 			code,
-			output: code,
+			output: null,
 			options,
 			errors: [
 				{
@@ -47,7 +47,7 @@ const invalidTestCase = testCase => {
 
 	return {
 		code,
-		output: code,
+		output: null,
 		options,
 		errors: [
 			{

--- a/test/no-object-as-default-parameter.mjs
+++ b/test/no-object-as-default-parameter.mjs
@@ -54,38 +54,47 @@ test({
 	invalid: [
 		{
 			code: 'function abc(foo = {a: 123}) {}',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'async function * abc(foo = {a: 123}) {}',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'function abc(foo = {a: false}) {}',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'function abc(foo = {a: "bar"}) {}',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'function abc(foo = {a: "bar", b: {c: true}}) {}',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const abc = (foo = {a: false}) => {};',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const abc = (foo = {a: 123, b: false}) => {};',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const abc = (foo = {a: false, b: 1, c: "test", d: null}) => {};',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const abc = function(foo = {a: 123}) {}',
+			output: null,
 			errors: [error]
 		},
 		{
@@ -94,6 +103,7 @@ test({
 					abc(foo = {a: 123}) {}
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -102,6 +112,7 @@ test({
 					constructor(foo = {a: 123}) {}
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -110,6 +121,7 @@ test({
 					set abc(foo = {a: 123}) {}
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -118,6 +130,7 @@ test({
 					static abc(foo = {a: 123}) {}
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -126,6 +139,7 @@ test({
 					* abc(foo = {a: 123}) {}
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -134,6 +148,7 @@ test({
 					static async * abc(foo = {a: 123}) {}
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -142,6 +157,7 @@ test({
 					[foo = {a: 123}](foo = {a: 123}) {}
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -150,6 +166,7 @@ test({
 					abc(foo = {a: 123}) {}
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -158,6 +175,7 @@ test({
 					abc(foo = {a: 123}) {}
 				};
 			`,
+			output: null,
 			errors: [error]
 		}
 	]

--- a/test/no-process-exit.mjs
+++ b/test/no-process-exit.mjs
@@ -96,7 +96,7 @@ test({
 		// `callee.object.type` is not a `Identifier`
 		'lib.process.on("SIGINT", function() { process.exit(1); })',
 		'lib.process.once("SIGINT", function() { process.exit(1); })'
-	].map(code => ({code, errors}))
+	].map(code => ({code, output: null, errors}))
 });
 
 test.snapshot({

--- a/test/no-unsafe-regex.mjs
+++ b/test/no-unsafe-regex.mjs
@@ -19,26 +19,32 @@ test({
 	invalid: [
 		{
 			code: 'const foo = /(x+x+)+y/',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const foo = /(x+x+)+y/g',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const foo = new RegExp(\'(x+x+)+y\')',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const foo = new RegExp(\'(x+x+)+y\', \'g\')',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const foo = new RegExp(/(x+x+)+y/)',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const foo = new RegExp(/(x+x+)+y/g)',
+			output: null,
 			errors: [error]
 		}
 	]

--- a/test/no-unused-properties.mjs
+++ b/test/no-unused-properties.mjs
@@ -274,6 +274,7 @@ test({
 				const foo = {a: 1, u: 2};
 				console.log(foo.a);
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -281,6 +282,7 @@ test({
 				const foo = {"a": 1, "u": 2};
 				console.log(foo.a);
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -288,6 +290,7 @@ test({
 				const foo = {a: 1, u: 2};
 				console.log(foo['a']);
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -297,6 +300,7 @@ test({
 					console.log(foo.a);
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 
@@ -305,6 +309,7 @@ test({
 				const foo = {a: 1, u: 2};
 				const {a} = foo;
 			`,
+			output: null,
 			errors: [error]
 		},
 
@@ -313,6 +318,7 @@ test({
 				const foo = {a: 1, u: 2};
 				({a} = foo);
 			`,
+			output: null,
 			errors: [error]
 		},
 
@@ -327,6 +333,7 @@ test({
 				};
 				console.log(foo.a);
 			`,
+			output: null,
 			errors: [error]
 		},
 
@@ -341,6 +348,7 @@ test({
 				};
 				console.log(foo.a, foo.b.c);
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -356,6 +364,7 @@ test({
 					console.log(foo.a, foo.b.c);
 				}
 			`,
+			output: null,
 			errors: [error]
 		},
 		{
@@ -368,6 +377,7 @@ test({
 				};
 				foo.a.f = function () { return this };
 			`,
+			output: null,
 			errors: [error]
 		},
 
@@ -379,6 +389,7 @@ test({
 				};
 				console.log(foo.a);
 			`,
+			output: null,
 			errors: [error]
 		},
 
@@ -391,6 +402,7 @@ test({
 				};
 				console.log(foo.b);
 			`,
+			output: null,
 			errors: [error]
 		},
 
@@ -400,6 +412,7 @@ test({
 					[foo.bar]: 1
 				};
 			`,
+			output: null,
 			errors: [error]
 		}
 	]

--- a/test/no-useless-undefined.mjs
+++ b/test/no-useless-undefined.mjs
@@ -338,7 +338,15 @@ test.typescript({
 					return nested();
 				}
 			`,
-			output: null,
+			output: outdent`
+				function foo():undefined {
+					function nested() {
+						return;
+					}
+
+					return nested();
+				}
+			`,
 			errors: 1
 		}
 	]

--- a/test/no-useless-undefined.mjs
+++ b/test/no-useless-undefined.mjs
@@ -338,15 +338,7 @@ test.typescript({
 					return nested();
 				}
 			`,
-			output: outdent`
-				function foo():undefined {
-					function nested() {
-						return;
-					}
-
-					return nested();
-				}
-			`,
+			output: null,
 			errors: 1
 		}
 	]

--- a/test/prefer-add-event-listener.mjs
+++ b/test/prefer-add-event-listener.mjs
@@ -5,7 +5,7 @@ const {test} = getTester(import.meta);
 
 const excludeFooOptions = [{excludedPackages: ['foo']}];
 
-test({
+test.snapshot({
 	valid: [
 		'foo.addEventListener(\'click\', () => {})',
 		'foo.removeEventListener(\'click\', onClick)',
@@ -64,11 +64,6 @@ test({
 			options: excludeFooOptions
 		}
 	],
-	invalid: []
-});
-
-test.snapshot({
-	valid: [],
 	invalid: [
 		'foo.onclick = () => {}',
 		'foo.onclick = 1',

--- a/test/prefer-array-find.mjs
+++ b/test/prefer-array-find.mjs
@@ -263,7 +263,7 @@ ruleTester.run('prefer-array-find', rule, {
 		// Suggestions
 		{
 			code: 'const [foo = baz] = array.filter(bar)',
-			output: 'const [foo = baz] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_DECLARATION,
 				suggestions: [
@@ -281,7 +281,7 @@ ruleTester.run('prefer-array-find', rule, {
 		// Default value is parenthesized
 		{
 			code: 'const [foo = (bar)] = array.filter(bar)',
-			output: 'const [foo = (bar)] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_DECLARATION,
 				suggestions: [
@@ -299,7 +299,7 @@ ruleTester.run('prefer-array-find', rule, {
 		// Default value has lower precedence
 		{
 			code: 'const [foo = a ? b : c] = array.filter(bar)',
-			output: 'const [foo = a ? b : c] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_DECLARATION,
 				suggestions: [
@@ -316,7 +316,7 @@ ruleTester.run('prefer-array-find', rule, {
 		},
 		{
 			code: 'const [foo = a ?? b] = array.filter(bar)',
-			output: 'const [foo = a ?? b] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_DECLARATION,
 				suggestions: [
@@ -333,7 +333,7 @@ ruleTester.run('prefer-array-find', rule, {
 		},
 		{
 			code: 'const [foo = a || b] = array.filter(bar)',
-			output: 'const [foo = a || b] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_DECLARATION,
 				suggestions: [
@@ -350,7 +350,7 @@ ruleTester.run('prefer-array-find', rule, {
 		},
 		{
 			code: 'const [foo = a && b] = array.filter(bar)',
-			output: 'const [foo = a && b] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_DECLARATION,
 				suggestions: [
@@ -458,7 +458,7 @@ ruleTester.run('prefer-array-find', rule, {
 		// Suggestions
 		{
 			code: '[foo = baz] = array.filter(bar)',
-			output: '[foo = baz] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_ASSIGNMENT,
 				suggestions: [
@@ -475,7 +475,7 @@ ruleTester.run('prefer-array-find', rule, {
 		},
 		{
 			code: '[{foo} = baz] = array.filter(bar)',
-			output: '[{foo} = baz] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_ASSIGNMENT,
 				suggestions: [
@@ -492,7 +492,7 @@ ruleTester.run('prefer-array-find', rule, {
 		},
 		{
 			code: ';([{foo} = baz] = array.filter(bar))',
-			output: ';([{foo} = baz] = array.filter(bar))',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_ASSIGNMENT,
 				suggestions: [
@@ -510,7 +510,7 @@ ruleTester.run('prefer-array-find', rule, {
 		// Default value is parenthesized
 		{
 			code: '[foo = (bar)] = array.filter(bar)',
-			output: '[foo = (bar)] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_ASSIGNMENT,
 				suggestions: [
@@ -528,7 +528,7 @@ ruleTester.run('prefer-array-find', rule, {
 		// Default value has lower precedence
 		{
 			code: '[foo = a ? b : c] = array.filter(bar)',
-			output: '[foo = a ? b : c] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_ASSIGNMENT,
 				suggestions: [
@@ -545,7 +545,7 @@ ruleTester.run('prefer-array-find', rule, {
 		},
 		{
 			code: '[foo = a || b] = array.filter(bar)',
-			output: '[foo = a || b] = array.filter(bar)',
+			output: null,
 			errors: [{
 				messageId: ERROR_DESTRUCTURING_ASSIGNMENT,
 				suggestions: [

--- a/test/prefer-array-flat-map.mjs
+++ b/test/prefer-array-flat-map.mjs
@@ -220,12 +220,12 @@ test({
 		},
 		{
 			code: 'const foo = [].concat(...bar.map((i) => i));',
-			output: 'const foo = [].concat(...bar.map((i) => i));',
+			output: null,
 			errors: [errorSpread]
 		},
 		{
 			code: 'const foo = [].concat(...[1,2,3].map((i) => i));',
-			output: 'const foo = [].concat(...[1,2,3].map((i) => i));',
+			output: null,
 			errors: [errorSpread]
 		}
 	]

--- a/test/prefer-array-some.mjs
+++ b/test/prefer-array-some.mjs
@@ -8,7 +8,7 @@ const MESSAGE_ID_SUGGESTION = 'suggestion';
 
 const invalidCase = ({code, suggestionOutput}) => ({
 	code,
-	output: code,
+	output: null,
 	errors: [
 		{
 			messageId: MESSAGE_ID_ERROR,

--- a/test/prefer-default-parameters.mjs
+++ b/test/prefer-default-parameters.mjs
@@ -16,7 +16,7 @@ const invalidTestCase = ({code, suggestions}) => {
 
 	return {
 		code,
-		output: code,
+		output: null,
 		errors: suggestions.map(suggestion => ({
 			messageId: 'preferDefaultParameters',
 			suggestions: [{

--- a/test/prefer-dom-node-append.mjs
+++ b/test/prefer-dom-node-append.mjs
@@ -77,57 +77,57 @@ test({
 		},
 		{
 			code: 'node.appendChild(child) || "foo";',
-			output: 'node.appendChild(child) || "foo";',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'node.appendChild(child) + 0;',
-			output: 'node.appendChild(child) + 0;',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'node.appendChild(child) + 0;',
-			output: 'node.appendChild(child) + 0;',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: '+node.appendChild(child);',
-			output: '+node.appendChild(child);',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'node.appendChild(child) ? "foo" : "bar";',
-			output: 'node.appendChild(child) ? "foo" : "bar";',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'if (node.appendChild(child)) {}',
-			output: 'if (node.appendChild(child)) {}',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const foo = [node.appendChild(child)]',
-			output: 'const foo = [node.appendChild(child)]',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const foo = { bar: node.appendChild(child) }',
-			output: 'const foo = { bar: node.appendChild(child) }',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'function foo() { return node.appendChild(child); }',
-			output: 'function foo() { return node.appendChild(child); }',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'const foo = () => { return node.appendChild(child); }',
-			output: 'const foo = () => { return node.appendChild(child); }',
+			output: null,
 			errors: [error]
 		},
 		{
 			code: 'foo(bar = node.appendChild(child))',
-			output: 'foo(bar = node.appendChild(child))',
+			output: null,
 			errors: [error]
 		}
 	]

--- a/test/prefer-dom-node-remove.mjs
+++ b/test/prefer-dom-node-remove.mjs
@@ -11,7 +11,7 @@ const invalidTestCase = ({code, output, suggestionOutput}) => {
 	if (suggestionOutput) {
 		return {
 			code,
-			output: code,
+			output: null,
 			errors: [
 				{
 					messageId: ERROR_MESSAGE_ID,
@@ -174,6 +174,7 @@ test({
 		// Value of `parentNode.removeChild` call is use
 		{
 			code: 'if (parentNode.removeChild(foo)) {}',
+			output: null,
 			suggestionOutput: 'if (foo.remove()) {}'
 		},
 		{

--- a/test/prefer-keyboard-event-key.mjs
+++ b/test/prefer-keyboard-event-key.mjs
@@ -112,6 +112,7 @@ test({
 					console.log(e.keyCode);
 				})
 			`,
+			output: null,
 			errors: [error('keyCode')]
 		},
 		{
@@ -120,6 +121,7 @@ test({
 					console.log(keyCode);
 				})
 			`,
+			output: null,
 			errors: [error('keyCode')]
 		},
 		{
@@ -130,6 +132,7 @@ test({
 					}
 				})
 			`,
+			output: null,
 			errors: [error('which')]
 		},
 		{
@@ -140,6 +143,7 @@ test({
 					}
 				})
 			`,
+			output: null,
 			errors: [error('which')]
 		},
 		{
@@ -263,6 +267,7 @@ test({
 					const {keyCode, a, b} = e;
 				});
 			`,
+			output: null,
 			errors: [error('keyCode')]
 		},
 		{
@@ -271,6 +276,7 @@ test({
 					const {a: keyCode, a, b} = e;
 				});
 			`,
+			output: null,
 			errors: [error('keyCode')]
 		},
 		{
@@ -282,6 +288,7 @@ test({
 					})
 				})
 			`,
+			output: null,
 			errors: [error('keyCode')]
 		},
 		{
@@ -290,6 +297,7 @@ test({
 					console.log(e.charCode);
 				})
 			`,
+			output: null,
 			errors: [error('charCode')]
 		},
 		{
@@ -373,6 +381,7 @@ test({
 					const {charCode, a, b} = e;
 				});
 			`,
+			output: null,
 			errors: [error('charCode')]
 		},
 		{
@@ -381,6 +390,7 @@ test({
 					const {a: charCode, a, b} = e;
 				});
 			`,
+			output: null,
 			errors: [error('charCode')]
 		},
 		{
@@ -389,6 +399,7 @@ test({
 					console.log(e.which);
 				})
 			`,
+			output: null,
 			errors: [error('which')]
 		},
 		{
@@ -472,6 +483,7 @@ test({
 					const {which, a, b} = e;
 				});
 			`,
+			output: null,
 			errors: [error('which')]
 		},
 		{
@@ -480,6 +492,7 @@ test({
 					const {a: which, a, b} = e;
 				});
 			`,
+			output: null,
 			errors: [error('which')]
 		},
 		{

--- a/test/prefer-module.mjs
+++ b/test/prefer-module.mjs
@@ -48,11 +48,7 @@ test({
 					return;
 				}
 			`,
-			output: outdent`
-				if (foo) {
-					return;
-				}
-			`,
+			output: null,
 			errors: 1,
 			parserOptions: {
 				sourceType: 'script',

--- a/test/prefer-number-properties.mjs
+++ b/test/prefer-number-properties.mjs
@@ -57,7 +57,7 @@ const invalidMethodTest = ({code, output, name, suggestionOutput}) => {
 
 	return {
 		code,
-		output: safe ? output : code,
+		output: safe ? output : null,
 		errors: [
 			createError(name, suggestionOutput)
 		]

--- a/test/prefer-regexp-test.mjs
+++ b/test/prefer-regexp-test.mjs
@@ -3,7 +3,7 @@ import {getTester} from './utils/test.mjs';
 
 const {test} = getTester(import.meta);
 
-test({
+test.snapshot({
 	valid: [
 		'const bar = !re.test(foo)',
 		// Not `boolean`
@@ -41,11 +41,6 @@ test({
 		'if (foo.match(1n)) {}',
 		'if (foo.match(true)) {}'
 	],
-	invalid: []
-});
-
-test.snapshot({
-	valid: [],
 	invalid: [
 		// `String#match()`
 		'const bar = !foo.match(re)',

--- a/test/prefer-set-has.mjs
+++ b/test/prefer-set-has.mjs
@@ -28,7 +28,7 @@ const methodsReturnsArray = [
 
 const noFixCase = testCase => ({
 	...testCase,
-	output: testCase.code
+	output: null
 });
 
 test({

--- a/test/prefer-string-slice.mjs
+++ b/test/prefer-string-slice.mjs
@@ -104,7 +104,7 @@ test({
 		},
 		{
 			code: '"foo".substr("1", 2)',
-			output: '"foo".substr("1", 2)',
+			output: null,
 			errors: errorsSubstr
 		},
 		{
@@ -112,10 +112,7 @@ test({
 				const length = 123;
 				"foo".substr(1, length)
 			`,
-			output: outdent`
-				const length = 123;
-				"foo".substr(1, length)
-			`,
+			output: null,
 			errors: errorsSubstr
 		},
 		{
@@ -134,10 +131,7 @@ test({
 				const length = 123;
 				"foo".substr('0', length)
 			`,
-			output: outdent`
-				const length = 123;
-				"foo".substr('0', length)
-			`,
+			output: null,
 			errors: errorsSubstr
 		},
 		{
@@ -155,10 +149,7 @@ test({
 				const length = 123;
 				"foo".substr(1, length - 4)
 			`,
-			output: outdent`
-				const length = 123;
-				"foo".substr(1, length - 4)
-			`,
+			output: null,
 			errors: errorsSubstr
 		},
 		{
@@ -185,7 +176,7 @@ test({
 		},
 		{
 			code: 'foo.substr(start, length)',
-			output: 'foo.substr(start, length)',
+			output: null,
 			errors: errorsSubstr
 		},
 		{
@@ -196,7 +187,7 @@ test({
 		// Extra arguments
 		{
 			code: 'foo.substr(1, 2, 3)',
-			output: 'foo.substr(1, 2, 3)',
+			output: null,
 			errors: errorsSubstr
 		},
 		// #700
@@ -285,7 +276,7 @@ test({
 		// Extra arguments
 		{
 			code: 'foo.substring(1, 2, 3)',
-			output: 'foo.substring(1, 2, 3)',
+			output: null,
 			errors: errorsSubstring
 		}
 	]

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -20,7 +20,7 @@ const browserES5RuleTester = avaRuleTester(test, {
 	}
 });
 
-const noFixingTestCase = test => ({...test, output: test.code});
+const noFixingTestCase = test => ({...test, output: null});
 
 const createErrors = message => {
 	const error = {};

--- a/test/run-rules-on-codebase/lint.mjs
+++ b/test/run-rules-on-codebase/lint.mjs
@@ -45,6 +45,15 @@ const eslint = new ESLint({
 				rules: {
 					'unicorn/prefer-module': 'off'
 				}
+			},
+			// EslintRuleTester use `null` to assert no autofixes tests
+			{
+				files: [
+					'test/*.mjs'
+				],
+				rules: {
+					'unicorn/no-null': 'off'
+				}
 			}
 		]
 	}

--- a/test/string-content.mjs
+++ b/test/string-content.mjs
@@ -130,6 +130,7 @@ test({
 		// Not fix
 		{
 			code: 'const foo = "unicorn"',
+			output: null,
 			options: [{patterns: {unicorn: {...patterns.unicorn, fix: false}}}],
 			errors: createSuggestionError(
 				'unicorn',


### PR DESCRIPTION
It's more clear and has a better message, https://github.com/eslint/eslint/blob/8a77b661bc921c3408bae01b3aa41579edfc6e58/lib/rule-tester/rule-tester.js#L846-L852.

Used for core rules https://github.com/eslint/eslint/search?q=output%3A+null