### PR TITLE
Drop support for Node.js v10 and `babel-eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
 		"@lubien/fixture-beta-package": "^1.0.0-beta.1",
 		"@typescript-eslint/parser": "^4.21.0",
 		"ava": "^3.15.0",
-		"babel-eslint": "^10.1.0",
 		"chalk": "^4.1.0",
 		"enquirer": "2.3.6",
 		"eslint": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=12"
 	},
 	"scripts": {
 		"test": "xo && nyc ava",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
 		"clean-regexp": "^1.0.0",
 		"eslint-template-visitor": "^2.3.2",
 		"eslint-utils": "^2.1.0",
-		"eslint-visitor-keys": "^2.0.0",
 		"import-modules": "^2.1.0",
 		"is-builtin-module": "^3.1.0",
 		"lodash": "^4.17.21",

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -95,9 +95,7 @@ const create = context => {
 			);
 			const lastProperty = objectPattern.properties[objectPattern.properties.length - 1];
 
-			// TODO: Remove `ExperimentalRestProperty` check when we drop support for `babel-eslint` #1040
-			const hasRest = lastProperty &&
-				(lastProperty.type === 'RestElement' || lastProperty.type === 'ExperimentalRestProperty');
+			const hasRest = lastProperty && lastProperty.type === 'RestElement'
 
 			const expression = source.getText(node);
 			const member = source.getText(node.property);

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -95,7 +95,7 @@ const create = context => {
 			);
 			const lastProperty = objectPattern.properties[objectPattern.properties.length - 1];
 
-			const hasRest = lastProperty && lastProperty.type === 'RestElement'
+			const hasRest = lastProperty && lastProperty.type === 'RestElement';
 
 			const expression = source.getText(node);
 			const member = source.getText(node.property);

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -81,7 +81,7 @@ const getActualAssignmentTargetImportStyles = assignmentTarget => {
 		const styles = new Set();
 
 		for (const property of assignmentTarget.properties) {
-			if (property.type === 'RestElement' || property.type === 'ExperimentalRestProperty') {
+			if (property.type === 'RestElement') {
 				styles.add('named');
 				continue;
 			}

--- a/rules/no-static-only-class.js
+++ b/rules/no-static-only-class.js
@@ -69,7 +69,7 @@ function * switchClassMemberToObjectProperty(node, sourceCode, fixer) {
 	assertToken(staticToken, {
 		expected: [
 			{type: 'Keyword', value: 'static'},
-			// `babel-eslint` and `@babel/eslint-parser` use `{type: 'Identifier', value: 'static'}`
+			// `@babel/eslint-parser` use `{type: 'Identifier', value: 'static'}`
 			{type: 'Identifier', value: 'static'}
 		],
 		ruleId: 'no-static-only-class'

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -62,7 +62,7 @@ const propertyKeysEqual = (keyA, keyB) => {
 
 const objectPatternMatchesObjectExprPropertyKey = (pattern, key) => {
 	return pattern.properties.some(property => {
-		if (property.type === 'ExperimentalRestProperty' || property.type === 'RestElement') {
+		if (property.type === 'RestElement') {
 			return true;
 		}
 

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -1,5 +1,4 @@
 'use strict';
-const eslintVisitorKeys = require('eslint-visitor-keys');
 const {findVariable} = require('eslint-utils');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 
@@ -34,10 +33,7 @@ const containsCallExpression = (source, node) => {
 		return true;
 	}
 
-	// The Babel AST doesn't have visitor keys for certain types of nodes
-	// Use `eslint-visitor-keys` in those cases
-	// TODO: Remove this when we drop support for `babel-eslint` #1040
-	const keys = source.visitorKeys[node.type] || eslintVisitorKeys.KEYS[node.type];
+	const keys = source.visitorKeys[node.type];
 
 	for (const key of keys) {
 		const value = node[key];

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -432,13 +432,6 @@ const isExportedIdentifier = identifier => {
 		return identifier.parent.parent.type === 'ExportNamedDeclaration';
 	}
 
-	if (
-		identifier.parent.type === 'TypeAlias' &&
-		identifier.parent.id === identifier
-	) {
-		return identifier.parent.parent.type === 'ExportNamedDeclaration';
-	}
-
 	return false;
 };
 
@@ -558,7 +551,6 @@ const create = context => {
 	const {ecmaVersion} = context.parserOptions;
 	const options = prepareOptions(context.options[0]);
 	const filenameWithExtension = context.getFilename();
-	const sourceCode = context.getSourceCode();
 
 	// A `class` declaration produces two variables in two scopes:
 	// the inner class scope, and the outer one (whereever the class is declared).
@@ -681,7 +673,7 @@ const create = context => {
 
 			problem.fix = function * (fixer) {
 				for (const identifier of getVariableIdentifiers(variable)) {
-					yield renameIdentifier(identifier, replacement, fixer, sourceCode);
+					yield renameIdentifier(identifier, replacement, fixer);
 				}
 			};
 		}

--- a/rules/utils/is-assignment-pattern-shorthand-property-identifier.js
+++ b/rules/utils/is-assignment-pattern-shorthand-property-identifier.js
@@ -8,8 +8,9 @@ module.exports = identifier =>
 	identifier.parent.parent.type === 'Property' &&
 	(
 		identifier === identifier.parent.parent.key ||
-		// TODO: Report this to `@babel/eslint-parser`
-		// Original issue on `babel-eslint` https://github.com/babel/babel-eslint/issues/809
+		// In `@babel/eslint-parser` the `variable.reference.identifier` 
+		// is neither reference of `identifier.parent.key` nor `identifier.parent.value`
+		// https://github.com/babel/babel/issues/13205
 		hasSameRange(identifier, identifier.parent.parent.key)
 	) &&
 	identifier.parent.parent.value === identifier.parent &&

--- a/rules/utils/is-assignment-pattern-shorthand-property-identifier.js
+++ b/rules/utils/is-assignment-pattern-shorthand-property-identifier.js
@@ -8,7 +8,7 @@ module.exports = identifier =>
 	identifier.parent.parent.type === 'Property' &&
 	(
 		identifier === identifier.parent.parent.key ||
-		// In `@babel/eslint-parser` the `variable.reference.identifier` 
+		// In `@babel/eslint-parser` the `variable.reference.identifier`
 		// is neither reference of `identifier.parent.key` nor `identifier.parent.value`
 		// https://github.com/babel/babel/issues/13205
 		hasSameRange(identifier, identifier.parent.parent.key)

--- a/rules/utils/is-assignment-pattern-shorthand-property-identifier.js
+++ b/rules/utils/is-assignment-pattern-shorthand-property-identifier.js
@@ -8,8 +8,8 @@ module.exports = identifier =>
 	identifier.parent.parent.type === 'Property' &&
 	(
 		identifier === identifier.parent.parent.key ||
-		// In `babel-eslint` parent.key is not reference of identifier, #444
-		// issue https://github.com/babel/babel-eslint/issues/809
+		// TODO: Report this to `@babel/eslint-parser`
+		// Original issue on `babel-eslint` https://github.com/babel/babel-eslint/issues/809
 		hasSameRange(identifier, identifier.parent.parent.key)
 	) &&
 	identifier.parent.parent.value === identifier.parent &&

--- a/rules/utils/is-shorthand-property-identifier.js
+++ b/rules/utils/is-shorthand-property-identifier.js
@@ -7,7 +7,8 @@ module.exports = identifier =>
 	identifier.parent.shorthand &&
 	(
 		identifier === identifier.parent.key ||
-		// TODO: Report this to `@babel/eslint-parser`
-		// Original issue on `babel-eslint` https://github.com/babel/babel-eslint/issues/809
+		// In `@babel/eslint-parser` the `variable.reference.identifier` 
+		// is neither reference of `identifier.parent.key` nor `identifier.parent.value`
+		// https://github.com/babel/babel/issues/13205
 		hasSameRange(identifier, identifier.parent.key)
 	);

--- a/rules/utils/is-shorthand-property-identifier.js
+++ b/rules/utils/is-shorthand-property-identifier.js
@@ -7,7 +7,7 @@ module.exports = identifier =>
 	identifier.parent.shorthand &&
 	(
 		identifier === identifier.parent.key ||
-		// In `babel-eslint` parent.key is not reference of identifier, #444
-		// issue https://github.com/babel/babel-eslint/issues/809
+		// TODO: Report this to `@babel/eslint-parser`
+		// Original issue on `babel-eslint` https://github.com/babel/babel-eslint/issues/809
 		hasSameRange(identifier, identifier.parent.key)
 	);

--- a/rules/utils/is-shorthand-property-identifier.js
+++ b/rules/utils/is-shorthand-property-identifier.js
@@ -7,7 +7,7 @@ module.exports = identifier =>
 	identifier.parent.shorthand &&
 	(
 		identifier === identifier.parent.key ||
-		// In `@babel/eslint-parser` the `variable.reference.identifier` 
+		// In `@babel/eslint-parser` the `variable.reference.identifier`
 		// is neither reference of `identifier.parent.key` nor `identifier.parent.value`
 		// https://github.com/babel/babel/issues/13205
 		hasSameRange(identifier, identifier.parent.key)

--- a/rules/utils/rename-identifier.js
+++ b/rules/utils/rename-identifier.js
@@ -5,7 +5,7 @@ const isAssignmentPatternShorthandPropertyIdentifier = require('./is-assignment-
 const isShorthandImportIdentifier = require('./is-shorthand-import-identifier');
 const isShorthandExportIdentifier = require('./is-shorthand-export-identifier');
 
-function renameIdentifier(identifier, name, fixer, sourceCode) {
+function renameIdentifier(identifier, name, fixer) {
 	if (
 		isShorthandPropertyIdentifier(identifier) ||
 		isAssignmentPatternShorthandPropertyIdentifier(identifier)
@@ -19,11 +19,6 @@ function renameIdentifier(identifier, name, fixer, sourceCode) {
 
 	if (isShorthandExportIdentifier(identifier)) {
 		return fixer.replaceText(identifier, `${name} as ${identifier.name}`);
-	}
-
-	// `TypeParameter` default value
-	if (identifier.default) {
-		return fixer.replaceText(identifier, `${name} = ${sourceCode.getText(identifier.default)}`);
 	}
 
 	// `typeAnnotation`

--- a/test/consistent-destructuring.mjs
+++ b/test/consistent-destructuring.mjs
@@ -471,7 +471,7 @@ test({
 	]
 });
 
-test.babelLegacy({
+test.babel({
 	valid: [
 		outdent`
 			const {a, ...b} = bar;

--- a/test/no-hex-escape.mjs
+++ b/test/no-hex-escape.mjs
@@ -1,4 +1,3 @@
-import {createRequire} from 'node:module';
 import {getTester} from './utils/test.mjs';
 
 const {test} = getTester(import.meta);
@@ -199,22 +198,24 @@ const tests = {
 
 const addComment = (test, comment) => {
 	if (typeof test === 'string') {
-		return `${test}\n/* ${comment} */`
+		return `${test}\n/* ${comment} */`;
 	}
+
 	const {code, output} = test;
 	return {
 		...test,
 		code: `${code}\n/* ${comment} */`,
 		output: `${output}\n/* ${comment} */`
-	}
+	};
 };
+
 const avoidTestTitleConflict = (tests, comment) => {
 	const {valid, invalid} = tests;
 	return {
 		...tests,
 		valid: valid.map(test => addComment(test, comment)),
 		invalid: invalid.map(test => addComment(test, comment))
-	}
+	};
 };
 
 test(tests);

--- a/test/no-hex-escape.mjs
+++ b/test/no-hex-escape.mjs
@@ -1,4 +1,4 @@
-import {getTester} from './utils/test.mjs';
+import {getTester, avoidTestTitleConflict} from './utils/test.mjs';
 
 const {test} = getTester(import.meta);
 
@@ -194,28 +194,6 @@ const tests = {
 			output: 'const foo = `\\u00b1${foo}\\u00b1${foo}`'
 		}
 	]
-};
-
-const addComment = (test, comment) => {
-	if (typeof test === 'string') {
-		return `${test}\n/* ${comment} */`;
-	}
-
-	const {code, output} = test;
-	return {
-		...test,
-		code: `${code}\n/* ${comment} */`,
-		output: `${output}\n/* ${comment} */`
-	};
-};
-
-const avoidTestTitleConflict = (tests, comment) => {
-	const {valid, invalid} = tests;
-	return {
-		...tests,
-		valid: valid.map(test => addComment(test, comment)),
-		invalid: invalid.map(test => addComment(test, comment))
-	};
 };
 
 test(tests);

--- a/test/no-static-only-class.mjs
+++ b/test/no-static-only-class.mjs
@@ -211,14 +211,3 @@ test.babel({
 		}
 	]
 });
-
-test.babelLegacy({
-	valid: [],
-	invalid: [
-		{
-			code: 'class A2 { static a() {} }',
-			output: 'const A2 = { a() {}, };',
-			errors: 1
-		}
-	]
-});

--- a/test/number-literal-case.mjs
+++ b/test/number-literal-case.mjs
@@ -1,5 +1,5 @@
 import outdent from 'outdent';
-import {getTester} from './utils/test.mjs';
+import {getTester, avoidTestTitleConflict} from './utils/test.mjs';
 
 const {test} = getTester(import.meta);
 
@@ -10,10 +10,16 @@ const error = {
 };
 
 // Legacy octal literals
-ruleTester.run('number-literal-case', rule, {
+test({
+	testerOptions: {
+		parserOptions: {
+			ecmaVersion: 5,
+			sourceType: 'script'
+		}
+	},
 	valid: [
-		'const foo = 0777',
-		'const foo = 0888'
+		'var foo = 0777',
+		'var foo = 0888'
 	],
 	invalid: []
 });

--- a/test/number-literal-case.mjs
+++ b/test/number-literal-case.mjs
@@ -1,27 +1,9 @@
-import {createRequire} from 'node:module';
-import test from 'ava';
-import avaRuleTester from 'eslint-ava-rule-tester';
 import outdent from 'outdent';
 import {getTester} from './utils/test.mjs';
 
-const {test: runTest, rule} = getTester(import.meta);
-const require = createRequire(import.meta.url);
+const {test} = getTester(import.meta);
 
 const MESSAGE_ID = 'number-literal-case';
-const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
-	},
-	parserOptions: {
-		ecmaVersion: 2021
-	}
-});
-const babelRuleTester = avaRuleTester(test, {
-	parser: require.resolve('babel-eslint')
-});
-const typescriptRuleTester = avaRuleTester(test, {
-	parser: require.resolve('@typescript-eslint/parser')
-});
 
 const error = {
 	messageId: MESSAGE_ID
@@ -168,11 +150,11 @@ const tests = {
 	]
 };
 
-ruleTester.run('number-literal-case', rule, tests);
-babelRuleTester.run('number-literal-case', rule, tests);
-typescriptRuleTester.run('number-literal-case', rule, tests);
+test(tests);
+test.babel(avoidTestTitleConflict(tests, 'babel'));
+test.typescript(avoidTestTitleConflict(tests, 'typescript'));
 
-runTest.snapshot({
+test.snapshot({
 	valid: [],
 	invalid: [
 		'console.log(BigInt(0B10 + 1.2E+3) + 0XdeEd_Beefn)'

--- a/test/prefer-default-parameters.mjs
+++ b/test/prefer-default-parameters.mjs
@@ -650,9 +650,8 @@ test({
 	]
 });
 
-test.babelLegacy({
+test.babel({
 	valid: [
-		// These tests verify that the fallback to `eslint-visitor-keys` is working correctly
 		outdent`
 			function abc(foo, bar) {
 				const { baz, ...rest } = bar;

--- a/test/prefer-ternary.mjs
+++ b/test/prefer-ternary.mjs
@@ -1317,23 +1317,3 @@ test({
 		}
 	]
 });
-
-test.babelLegacy({
-	valid: [],
-	invalid: [
-		// https://github.com/facebook/react/blob/7a1691cdff209249b49a4472ba87b542980a5f71/packages/react-dom/src/client/DOMPropertyOperations.js#L183
-		{
-			code: outdent`
-				if (enableTrustedTypesIntegration) {
-					attributeValue = (value: any);
-				} else {
-					attributeValue = '' + (value: any);
-				}
-			`,
-			output: outdent`
-				attributeValue = enableTrustedTypesIntegration ? (value: any) : '' + (value: any);
-			`,
-			errors
-		}
-	]
-});

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1869,13 +1869,8 @@ runTest.typescript({
 				export type PreloadProps<TExtraProperties = null> = {}
 			`,
 			errors: [...createErrors(), ...createErrors()]
-		}
-	]
-});
+		},
 
-runTest.babelLegacy({
-	valid: [],
-	invalid: [
 		// https://github.com/facebook/relay/blob/597d2a17aa29d401830407b6814a5f8d148f632d/packages/relay-experimental/EntryPointTypes.flow.js#L138
 		{
 			code: outdent`

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -89,13 +89,6 @@ class Tester {
 		});
 		return tester.run(this.ruleId, this.rule, tests);
 	}
-
-	babelLegacy(tests) {
-		return this.runTest({
-			...tests,
-			testerOptions: {parser: require.resolve('babel-eslint')}
-		});
-	}
 }
 
 function getTester(importMeta) {
@@ -106,7 +99,6 @@ function getTester(importMeta) {
 	test.typescript = tester.typescript.bind(tester);
 	test.babel = tester.babel.bind(tester);
 	test.snapshot = tester.snapshot.bind(tester);
-	test.babelLegacy = tester.babelLegacy.bind(tester);
 
 	return {
 		ruleId,

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -107,7 +107,30 @@ function getTester(importMeta) {
 	};
 }
 
+const addComment = (test, comment) => {
+	if (typeof test === 'string') {
+		return `${test}\n/* ${comment} */`;
+	}
+
+	const {code, output} = test;
+	return {
+		...test,
+		code: `${code}\n/* ${comment} */`,
+		output: `${output}\n/* ${comment} */`
+	};
+};
+
+const avoidTestTitleConflict = (tests, comment) => {
+	const {valid, invalid} = tests;
+	return {
+		...tests,
+		valid: valid.map(test => addComment(test, comment)),
+		invalid: invalid.map(test => addComment(test, comment))
+	};
+};
+
 export {
 	defaultParserOptions,
-	getTester
+	getTester,
+	avoidTestTitleConflict
 };


### PR DESCRIPTION
I think we can close #1040, see https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1040#issuecomment-826300148

