### PR TITLE
Remove workaround in `isShorthandPropertyIdentifier`

### DIFF
--- a/rules/utils/is-shorthand-property-identifier.js
+++ b/rules/utils/is-shorthand-property-identifier.js
@@ -1,14 +1,8 @@
 'use strict';
 
-const hasSameRange = require('./has-same-range');
-
-module.exports = identifier =>
+const isShorthandPropertyIdentifier = identifier =>
 	identifier.parent.type === 'Property' &&
 	identifier.parent.shorthand &&
-	(
-		identifier === identifier.parent.key ||
-		// In `@babel/eslint-parser` the `variable.reference.identifier`
-		// is neither reference of `identifier.parent.key` nor `identifier.parent.value`
-		// https://github.com/babel/babel/issues/13205
-		hasSameRange(identifier, identifier.parent.key)
-	);
+	identifier === identifier.parent.value;
+
+module.exports = isShorthandPropertyIdentifier;


### PR DESCRIPTION
[This one](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/6e773ad69034b22fe75f1fedb97fd6ff80564ba6/rules/utils/is-assignment-pattern-shorthand-property-identifier.js#L14) seems still needed, https://github.com/babel/babel/issues/13205#issuecomment-827265148