### PR TITLE
`prevent-abbreviations`: Fix shorthand import/export detection

### DIFF
--- a/rules/utils/is-shorthand-export-identifier.js
+++ b/rules/utils/is-shorthand-export-identifier.js
@@ -1,6 +1,8 @@
 'use strict';
 
-module.exports = identifier =>
+const isShorthandExportIdentifier = identifier =>
 	identifier.parent.type === 'ExportSpecifier' &&
-	identifier.parent.exported.name === identifier.name &&
-	identifier.parent.local.name === identifier.name;
+	identifier.parent.exported === identifier &&
+	identifier.parent.local === identifier;
+
+module.exports = isShorthandExportIdentifier;

--- a/rules/utils/is-shorthand-import-identifier.js
+++ b/rules/utils/is-shorthand-import-identifier.js
@@ -1,6 +1,8 @@
 'use strict';
 
-module.exports = identifier =>
+const isShorthandImportIdentifier = identifier =>
 	identifier.parent.type === 'ImportSpecifier' &&
-	identifier.parent.imported.name === identifier.name &&
-	identifier.parent.local.name === identifier.name;
+	identifier.parent.imported === identifier &&
+	identifier.parent.local === identifier;
+
+module.exports = isShorthandImportIdentifier;

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1492,6 +1492,12 @@ runTest({
 			errors: createErrors()
 		},
 		{
+			code: 'import {err as err} from "err";',
+			output: 'import {err as error} from "err";',
+			options: customOptions,
+			errors: createErrors()
+		},
+		{
 			code: outdent`
 				import {
 					bar,
@@ -1580,6 +1586,18 @@ runTest({
 			code: outdent`
 				let err;
 				export {err};
+			`,
+			output: outdent`
+				let error;
+				export {error as err};
+			`,
+			errors: createErrors()
+		},
+
+		{
+			code: outdent`
+				let err;
+				export {err as err};
 			`,
 			output: outdent`
 				let error;

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1791,7 +1791,24 @@ runTest.babel({
 			`,
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		})
+		}),
+		{
+			code: 'import {err as err} from "err";//2',
+			output: 'import {err as error} from "err";//2',
+			options: customOptions,
+			errors: createErrors()
+		},
+		{
+			code: outdent`
+				let err;
+				export {err as err};//2
+			`,
+			output: outdent`
+				let error;
+				export {error as err};//2
+			`,
+			errors: createErrors()
+		}
 	]
 });
 
@@ -1898,6 +1915,24 @@ runTest.typescript({
 				export type PreloadProps<TExtraProperties = null> = {};
 			`,
 			errors: [...createErrors(), ...createErrors()]
+		},
+
+		{
+			code: 'import {err as err} from "err";//',
+			output: 'import {err as error} from "err";//',
+			options: customOptions,
+			errors: createErrors()
+		},
+		{
+			code: outdent`
+				let err;
+				export {err as err};//
+			`,
+			output: outdent`
+				let error;
+				export {error as err};//
+			`,
+			errors: createErrors()
 		}
 	]
 });


### PR DESCRIPTION
`import {err as err} from 'err';`

was fixed to

`import {err as err as error} from 'err';`