### PR TITLE
`prevent-abbreviations`: Rewrite tests

### DIFF
--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -5,21 +5,6 @@ import {getTester, avoidTestTitleConflict} from './utils/test.mjs';
 
 const {test: runTest, rule} = getTester(import.meta);
 
-const ruleTester = avaRuleTester(test, {
-	env: {
-		es6: true
-	}
-});
-
-const browserES5RuleTester = avaRuleTester(test, {
-	parserOptions: {
-		ecmaVersion: 5
-	},
-	env: {
-		browser: true
-	}
-});
-
 const noFixingTestCase = test => ({...test, output: test.code});
 
 const createErrors = message => {
@@ -1251,7 +1236,15 @@ runTest(tests);
 runTest.babel(avoidTestTitleConflict(tests, 'babel'));
 runTest.typescript(avoidTestTitleConflict(tests, 'typescript'));
 
-browserES5RuleTester.run('prevent-abbreviations', rule, {
+runTest({
+	testerOptions: {
+	parserOptions: {
+		ecmaVersion: 5
+	},
+	env: {
+		browser: true
+	}
+	},
 	valid: [],
 	invalid: [
 		{

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1,9 +1,7 @@
-import test from 'ava';
-import avaRuleTester from 'eslint-ava-rule-tester';
 import outdent from 'outdent';
 import {getTester, avoidTestTitleConflict} from './utils/test.mjs';
 
-const {test: runTest, rule} = getTester(import.meta);
+const {test} = getTester(import.meta);
 
 const noFixingTestCase = test => ({...test, output: test.code});
 
@@ -1232,18 +1230,18 @@ const tests = {
 	]
 };
 
-runTest(tests);
-runTest.babel(avoidTestTitleConflict(tests, 'babel'));
-runTest.typescript(avoidTestTitleConflict(tests, 'typescript'));
+test(tests);
+test.babel(avoidTestTitleConflict(tests, 'babel'));
+test.typescript(avoidTestTitleConflict(tests, 'typescript'));
 
-runTest({
+test({
 	testerOptions: {
-	parserOptions: {
-		ecmaVersion: 5
-	},
-	env: {
-		browser: true
-	}
+		parserOptions: {
+			ecmaVersion: 5
+		},
+		env: {
+			browser: true
+		}
 	},
 	valid: [],
 	invalid: [
@@ -1291,7 +1289,7 @@ runTest({
 	]
 });
 
-runTest({
+test({
 	valid: [
 		'import {err as foo} from "foo"',
 
@@ -1606,7 +1604,7 @@ runTest({
 	]
 });
 
-runTest.babel({
+test.babel({
 	valid: [
 		// Allowed names
 		'Foo.defaultProps = {}',
@@ -1705,7 +1703,7 @@ runTest.babel({
 	]
 });
 
-runTest.typescript({
+test.typescript({
 	valid: [],
 	invalid: [
 		// Types
@@ -1808,12 +1806,12 @@ runTest.typescript({
 				export type PreloadProps<TExtraProperties = null> = {};
 			`,
 			errors: [...createErrors(), ...createErrors()]
-		},
+		}
 	]
 });
 
 // Filename
-runTest({
+test({
 	valid: [
 		{
 			code: 'foo();',
@@ -1822,7 +1820,7 @@ runTest({
 		{
 			code: 'foo();',
 			filename: 'http-err.js',
-			options: [{checkFilenames: false,}]
+			options: [{checkFilenames: false}]
 		},
 		{
 			code: 'foo();',

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1,7 +1,7 @@
 import test from 'ava';
 import avaRuleTester from 'eslint-ava-rule-tester';
 import outdent from 'outdent';
-import {getTester} from './utils/test.mjs';
+import {getTester, avoidTestTitleConflict} from './utils/test.mjs';
 
 const {test: runTest, rule} = getTester(import.meta);
 
@@ -123,7 +123,7 @@ const noExtendDefaultAllowListOptions = [
 	}
 ];
 
-ruleTester.run('prevent-abbreviations', rule, {
+const tests = {
 	valid: [
 		'let x',
 		'({x: 1})',
@@ -309,6 +309,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 					}
 				}
 			],
+
 			errors: createErrors('Please rename the variable `a`. Suggested names are: `const_`, `used_`, `var__`. A more descriptive name will do too.')
 		},
 
@@ -401,18 +402,18 @@ ruleTester.run('prevent-abbreviations', rule, {
 		// Testing that options apply
 		{
 			code: 'let args',
-			output: 'let arguments',
+			output: 'let arguments_',
 			errors: createErrors()
 		},
 		{
 			code: 'let args',
-			output: 'let arguments',
+			output: 'let arguments_',
 			options: extendedOptions,
 			errors: createErrors()
 		},
 		{
 			code: 'let args',
-			output: 'let arguments',
+			output: 'let arguments_',
 			options: customOptions,
 			errors: createErrors()
 		},
@@ -894,7 +895,7 @@ ruleTester.run('prevent-abbreviations', rule, {
 		// `package` is a reserved word in strict mode
 		{
 			code: 'let pkg',
-			output: 'let package',
+			output: 'let package_',
 			errors: createErrors()
 		},
 		{
@@ -1065,8 +1066,8 @@ ruleTester.run('prevent-abbreviations', rule, {
 				}
 			`,
 			output: outdent`
-				const f = (...arguments) => {
-					return arguments;
+				const f = (...arguments_) => {
+					return arguments_;
 				}
 			`,
 			errors: createErrors()
@@ -1079,9 +1080,9 @@ ruleTester.run('prevent-abbreviations', rule, {
 				}
 			`,
 			output: outdent`
-				let arguments;
+				let arguments_;
 				const f = () => {
-					return arguments;
+					return arguments_;
 				}
 			`,
 			errors: createErrors()
@@ -1244,7 +1245,11 @@ ruleTester.run('prevent-abbreviations', rule, {
 			errors: createErrors()
 		}
 	]
-});
+};
+
+runTest(tests);
+runTest.babel(avoidTestTitleConflict(tests, 'babel'));
+runTest.typescript(avoidTestTitleConflict(tests, 'typescript'));
 
 browserES5RuleTester.run('prevent-abbreviations', rule, {
 	valid: [],
@@ -1703,24 +1708,7 @@ runTest.babel({
 			`,
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
-		{
-			code: 'import {err as err} from "err";//2',
-			output: 'import {err as error} from "err";//2',
-			options: customOptions,
-			errors: createErrors()
-		},
-		{
-			code: outdent`
-				let err;
-				export {err as err};//2
-			`,
-			output: outdent`
-				let error;
-				export {error as err};//2
-			`,
-			errors: createErrors()
-		}
+		})
 	]
 });
 
@@ -1828,24 +1816,6 @@ runTest.typescript({
 			`,
 			errors: [...createErrors(), ...createErrors()]
 		},
-
-		{
-			code: 'import {err as err} from "err";//',
-			output: 'import {err as error} from "err";//',
-			options: customOptions,
-			errors: createErrors()
-		},
-		{
-			code: outdent`
-				let err;
-				export {err as err};//
-			`,
-			output: outdent`
-				let error;
-				export {error as err};//
-			`,
-			errors: createErrors()
-		}
 	]
 });
 
@@ -1885,7 +1855,6 @@ runTest({
 		}
 	],
 	invalid: [
-		// `checkFilenames` option
 		{
 			code: 'foo();',
 			filename: 'err/http-err.js',

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -67,8 +67,6 @@ const customOptions = [
 		checkShorthandImports: true,
 		checkShorthandProperties: true,
 
-		checkFilenames: false,
-
 		extendDefaultReplacements: false,
 		replacements: {
 			args: {
@@ -122,17 +120,6 @@ const noExtendDefaultAllowListOptions = [
 			err: true
 		},
 		extendDefaultAllowList: false
-	}
-];
-
-const ignoreOptions = [
-	{
-		ignore: [
-			/^e_/,
-			// eslint-disable-next-line prefer-regex-literals
-			new RegExp('_e$', 'i'),
-			'\\.e2e\\.'
-		]
 	}
 ];
 
@@ -260,35 +247,11 @@ ruleTester.run('prevent-abbreviations', rule, {
 			code: '({__proto__: null})',
 			options: customOptions
 		},
-		// `checkFilenames` option
-		{
-			code: 'foo();',
-			filename: 'http-error.js'
-		},
-		{
-			code: 'foo();',
-			filename: 'http-err.js',
-			options: customOptions
-		},
-		{
-			code: 'foo();',
-			filename: 'err/http-error.js'
-		},
 
 		// `extendDefaultAllowList` option
 		{
 			code: 'const propTypes = 2;const err = 2;',
 			options: extendDefaultAllowListOptions
-		},
-
-		// `ignore` option
-		{
-			code: outdent`
-				const e_at_start = 1;
-				const end_with_e = 2;
-			`,
-			filename: 'some.spec.e2e.test.js',
-			options: ignoreOptions
 		}
 	],
 
@@ -1272,44 +1235,6 @@ ruleTester.run('prevent-abbreviations', rule, {
 			`,
 			errors: createErrors()
 		},
-		// `checkFilenames` option
-		{
-			code: 'foo();',
-			filename: 'err/http-err.js',
-			errors: createErrors()
-		},
-		{
-			code: 'foo();',
-			filename: 'http-err.js',
-			errors: createErrors()
-		},
-		{
-			code: 'foo();',
-			filename: '/path/to/doc/__prev-Attr$1Err__.conf.js',
-			errors: createErrors('The filename `/path/to/doc/__prev-Attr$1Err__.conf.js` should be named `__previous-Attribute$1Error__.config.js`. A more descriptive name will do too.')
-		},
-		{
-			code: 'foo();',
-			filename: '.http.err.js',
-			errors: createErrors('The filename `.http.err.js` should be named `.http.error.js`. A more descriptive name will do too.')
-		},
-		{
-			code: 'foo();',
-			filename: 'e.js',
-			errors: createErrors('Please rename the filename `e.js`. Suggested names are: `error.js`, `event.js`. A more descriptive name will do too.')
-		},
-		{
-			code: 'foo();',
-			filename: 'c.js',
-			options: extendedOptions,
-			errors: createErrors('The filename `c.js` should be named `custom.js`. A more descriptive name will do too.')
-		},
-		{
-			code: 'foo();',
-			filename: 'cb.js',
-			options: extendedOptions,
-			errors: createErrors('The filename `cb.js` should be named `circuitBreacker.js`. A more descriptive name will do too.')
-		},
 
 		// `extendDefaultAllowList` option
 		{
@@ -1678,21 +1603,8 @@ runTest({
 			`,
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
+		})
 
-		// `ignore` option
-		{
-			code: outdent`
-				const e_at_start = 1;
-				const end_with_e = 2;
-			`,
-			filename: 'some.spec.e2e.test.js',
-			errors: [
-				...createErrors('Please rename the filename `some.spec.e2e.test.js`. Suggested names are: `some.spec.error2error.test.js`, `some.spec.error2event.test.js`, `some.spec.event2error.test.js`, ... (1 more omitted). A more descriptive name will do too.'),
-				...createErrors('Please rename the variable `e_at_start`. Suggested names are: `error_at_start`, `event_at_start`. A more descriptive name will do too.'),
-				...createErrors('Please rename the variable `end_with_e`. Suggested names are: `end_with_error`, `end_with_event`. A more descriptive name will do too.')
-			]
-		}
 	]
 });
 
@@ -1935,4 +1847,95 @@ runTest.typescript({
 			errors: createErrors()
 		}
 	]
+});
+
+// Filename
+runTest({
+	valid: [
+		{
+			code: 'foo();',
+			filename: 'http-error.js'
+		},
+		{
+			code: 'foo();',
+			filename: 'http-err.js',
+			options: [{checkFilenames: false,}]
+		},
+		{
+			code: 'foo();',
+			filename: 'err/http-error.js'
+		},
+		// `ignore` option
+		{
+			code: outdent`
+				const e_at_start = 1;
+				const end_with_e = 2;
+			`,
+			filename: 'some.spec.e2e.test.js',
+			options: [
+				{
+					ignore: [
+						/^e_/,
+						// eslint-disable-next-line prefer-regex-literals
+						new RegExp('_e$', 'i'),
+						'\\.e2e\\.'
+					]
+				}
+			]
+		}
+	],
+	invalid: [
+		// `checkFilenames` option
+		{
+			code: 'foo();',
+			filename: 'err/http-err.js',
+			errors: createErrors()
+		},
+		{
+			code: 'foo();',
+			filename: 'http-err.js',
+			errors: createErrors()
+		},
+		{
+			code: 'foo();',
+			filename: '/path/to/doc/__prev-Attr$1Err__.conf.js',
+			errors: createErrors('The filename `/path/to/doc/__prev-Attr$1Err__.conf.js` should be named `__previous-Attribute$1Error__.config.js`. A more descriptive name will do too.')
+		},
+		{
+			code: 'foo();',
+			filename: '.http.err.js',
+			errors: createErrors('The filename `.http.err.js` should be named `.http.error.js`. A more descriptive name will do too.')
+		},
+		{
+			code: 'foo();',
+			filename: 'e.js',
+			errors: createErrors('Please rename the filename `e.js`. Suggested names are: `error.js`, `event.js`. A more descriptive name will do too.')
+		},
+		{
+			code: 'foo();',
+			filename: 'c.js',
+			options: extendedOptions,
+			errors: createErrors('The filename `c.js` should be named `custom.js`. A more descriptive name will do too.')
+		},
+		{
+			code: 'foo();',
+			filename: 'cb.js',
+			options: extendedOptions,
+			errors: createErrors('The filename `cb.js` should be named `circuitBreacker.js`. A more descriptive name will do too.')
+		},
+		// `ignore` option
+		{
+			code: outdent`
+				const e_at_start = 1;
+				const end_with_e = 2;
+			`,
+			filename: 'some.spec.e2e.test.js',
+			errors: [
+				...createErrors('Please rename the filename `some.spec.e2e.test.js`. Suggested names are: `some.spec.error2error.test.js`, `some.spec.error2event.test.js`, `some.spec.event2error.test.js`, ... (1 more omitted). A more descriptive name will do too.'),
+				...createErrors('Please rename the variable `e_at_start`. Suggested names are: `error_at_start`, `event_at_start`. A more descriptive name will do too.'),
+				...createErrors('Please rename the variable `end_with_e`. Suggested names are: `end_with_error`, `end_with_event`. A more descriptive name will do too.')
+			]
+		}
+	]
+
 });

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -113,11 +113,15 @@ const addComment = (test, comment) => {
 	}
 
 	const {code, output} = test;
-	return {
+	const fixedTest = {
 		...test,
 		code: `${code}\n/* ${comment} */`,
-		output: `${output}\n/* ${comment} */`
 	};
+	if (fixedTest.hasOwnProperty('output') && typeof output === 'string') {
+		fixedTest.output = `${output}\n/* ${comment} */`
+	}
+
+	return fixedTest;
 };
 
 const avoidTestTitleConflict = (tests, comment) => {

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -115,10 +115,10 @@ const addComment = (test, comment) => {
 	const {code, output} = test;
 	const fixedTest = {
 		...test,
-		code: `${code}\n/* ${comment} */`,
+		code: `${code}\n/* ${comment} */`
 	};
-	if (fixedTest.hasOwnProperty('output') && typeof output === 'string') {
-		fixedTest.output = `${output}\n/* ${comment} */`
+	if (Object.prototype.hasOwnProperty.call(fixedTest, 'output') && typeof output === 'string') {
+		fixedTest.output = `${output}\n/* ${comment} */`;
 	}
 
 	return fixedTest;


### PR DESCRIPTION
- Move `filename` tests to a seperate one
- Run tests on all 3 parsers (There are AST differences, I'm working on it, hard to test on all of them before.)