### PR TITLE
Update `@babel/core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 	},
 	"devDependencies": {
 		"@babel/code-frame": "7.12.13",
-		"@babel/core": "7.13.14",
+		"@babel/core": "7.14.0",
 		"@babel/eslint-parser": "7.13.14",
 		"@lubien/fixture-beta-package": "^1.0.0-beta.1",
 		"@typescript-eslint/parser": "^4.21.0",

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -23,12 +23,8 @@ module.exports = {
 				allowAwaitOutsideFunction: true,
 				plugins: [
 					'jsx',
-					'classProperties',
 					'doExpressions',
-					'exportDefaultFrom',
-					'classPrivateProperties',
-					'classPrivateMethods',
-					'importMeta'
+					'exportDefaultFrom'
 				]
 			}
 		}

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -49,11 +49,7 @@ class Tester {
 		babelPlugins = [
 			['estree', {classFeatures: true}],
 			'jsx',
-			'classProperties',
 			'exportDefaultFrom',
-			'classPrivateProperties',
-			'classPrivateMethods',
-			'importMeta',
 			...babelPlugins
 		];
 


### PR DESCRIPTION
Those plugins are enabled by default now.