### PR TITLE
`no-for-loop`: Ignore known non-array loop variables

### DIFF
--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -4,6 +4,7 @@ const {isClosingParenToken} = require('eslint-utils');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const isLiteralValue = require('./utils/is-literal-value');
 const avoidCapture = require('./utils/avoid-capture');
+const {getStaticValue} = require('eslint-utils');
 
 const MESSAGE_ID = 'no-for-loop';
 const messages = {
@@ -59,7 +60,7 @@ const getStrictComparisonOperands = binaryExpression => {
 	}
 };
 
-const getArrayIdentifierNameFromBinaryExpression = (binaryExpression, indexIdentifierName) => {
+const getArrayIdentifierFromBinaryExpression = (binaryExpression, indexIdentifierName) => {
 	const operands = getStrictComparisonOperands(binaryExpression);
 
 	if (!operands) {
@@ -87,17 +88,17 @@ const getArrayIdentifierNameFromBinaryExpression = (binaryExpression, indexIdent
 		return;
 	}
 
-	return greater.object.name;
+	return greater.object;
 };
 
-const getArrayIdentifierName = (forStatement, indexIdentifierName) => {
+const getArrayIdentifier = (forStatement, indexIdentifierName) => {
 	const {test} = forStatement;
 
 	if (!test || test.type !== 'BinaryExpression') {
 		return;
 	}
 
-	return getArrayIdentifierNameFromBinaryExpression(test, indexIdentifierName);
+	return getArrayIdentifierFromBinaryExpression(test, indexIdentifierName);
 };
 
 const isLiteralOnePlusIdentifierWithName = (node, identifierName) => {
@@ -292,9 +293,17 @@ const create = context => {
 				return;
 			}
 
-			const arrayIdentifierName = getArrayIdentifierName(node, indexIdentifierName);
+			const arrayIdentifier = getArrayIdentifier(node, indexIdentifierName);
+			if (!arrayIdentifier) {
+				return;
+			}
 
-			if (!arrayIdentifierName) {
+			const arrayIdentifierName = arrayIdentifier.name;
+
+			const scope = context.getScope();
+			const staticResult = getStaticValue(arrayIdentifier, scope);
+			if (staticResult && !Array.isArray(staticResult.value)) {
+				// Bail out if we can tell that the array variable has a non-array value (i.e. we're looping through the characters of a string constant).
 				return;
 			}
 

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -1,11 +1,10 @@
 'use strict';
-const {isClosingParenToken} = require('eslint-utils');
+const {isClosingParenToken,getStaticValue} = require('eslint-utils');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const isLiteralValue = require('./utils/is-literal-value');
 const avoidCapture = require('./utils/avoid-capture');
 const getChildScopesRecursive = require('./utils/get-child-scopes-recursive');
 const singular = require('./utils/singular');
-const {getStaticValue} = require('eslint-utils');
 
 const MESSAGE_ID = 'no-for-loop';
 const messages = {

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -1,5 +1,5 @@
 'use strict';
-const {isClosingParenToken,getStaticValue} = require('eslint-utils');
+const {isClosingParenToken, getStaticValue} = require('eslint-utils');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const isLiteralValue = require('./utils/is-literal-value');
 const avoidCapture = require('./utils/avoid-capture');

--- a/test/no-for-loop.mjs
+++ b/test/no-for-loop.mjs
@@ -193,7 +193,12 @@ ruleTester.run('no-for-loop', rule, {
 					console.log(cities)
 				}
 			}
-		`
+		`,
+
+		// With variable containing static, non-array value.
+		'const notArray = "abc"; for (let i = 0; i < notArray.length; i++) { console.log(notArray[i]); }',
+		'const notArray = 123; for (let i = 0; i < notArray.length; i++) { console.log(notArray[i]); }',
+		'const notArray = true; for (let i = 0; i < notArray.length; i++) { console.log(notArray[i]); }'
 	],
 
 	invalid: [
@@ -710,6 +715,32 @@ ruleTester.run('no-for-loop', rule, {
 		`, outdent`
 			for (const [i, city] of cities.entries()) {
 				console.log(i, city);
+			}
+		`),
+
+		// With static array variable.
+		testCase(outdent`
+			const someArray = [1,2,3];
+			for (let i = 0; i < someArray.length; i++) {
+				console.log(someArray[i]);
+			}
+		`, outdent`
+			const someArray = [1,2,3];
+			for (const element of someArray) {
+				console.log(element);
+			}
+		`),
+
+		// With non-static variable.
+		testCase(outdent`
+			const someArray = getSomeArray();
+			for (let i = 0; i < someArray.length; i++) {
+				console.log(someArray[i]);
+			}
+		`, outdent`
+			const someArray = getSomeArray();
+			for (const element of someArray) {
+				console.log(element);
 			}
 		`)
 	]


### PR DESCRIPTION
In situations like this where we can tell that a variable being iterated is not an array (i.e. a string), we should not convert the loop to use the `.entries()` function which would not exist on non-arrays.

Fixes #738.