### PR TITLE
`prevent-abbreviations`: Fix shorthand import/export detection

### DIFF
--- a/rules/utils/is-shorthand-export-local.js
+++ b/rules/utils/is-shorthand-export-local.js
@@ -1,8 +1,9 @@
 'use strict';
+const hasSameRange = require('./has-same-range');
 
-const isShorthandExportLocal = identifier =>
-	identifier.parent.type === 'ExportSpecifier' &&
-	identifier.parent.exported === identifier &&
-	identifier.parent.local === identifier;
+const isShorthandExportLocal = node => {
+	const {type, local, exported} = node.parent;
+	return type === 'ExportSpecifier' && hasSameRange(local, exported) && local === node;
+};
 
 module.exports = isShorthandExportLocal;

--- a/rules/utils/is-shorthand-import-local.js
+++ b/rules/utils/is-shorthand-import-local.js
@@ -1,8 +1,9 @@
 'use strict';
+const hasSameRange = require('./has-same-range');
 
-const isShorthandImportIdentifier = identifier =>
-	identifier.parent.type === 'ImportSpecifier' &&
-	identifier.parent.imported === identifier &&
-	identifier.parent.local === identifier;
+const isShorthandImportLocal = node => {
+	const {type, local, imported} = node.parent;
+	return type === 'ImportSpecifier' && hasSameRange(local, imported) && local === node;
+};
 
-module.exports = isShorthandImportIdentifier;
+module.exports = isShorthandImportLocal;

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -235,7 +235,7 @@ const tests = {
 		{
 			code: 'const propTypes = 2;const err = 2;',
 			options: extendDefaultAllowListOptions
-		},
+		}
 	],
 
 	invalid: [

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -235,7 +235,7 @@ const tests = {
 		{
 			code: 'const propTypes = 2;const err = 2;',
 			options: extendDefaultAllowListOptions
-		}
+		},
 	],
 
 	invalid: [
@@ -1322,7 +1322,7 @@ test({
 	]
 });
 
-test({
+const importExportTests = {
 	valid: [
 		'import {err as foo} from "foo"',
 
@@ -1635,7 +1635,10 @@ test({
 		})
 
 	]
-});
+};
+test(importExportTests);
+test.babel(avoidTestTitleConflict(importExportTests, 'babel'));
+test.typescript(avoidTestTitleConflict(importExportTests, 'typescript'));
 
 test.babel({
 	valid: [


### PR DESCRIPTION
This fixes the incorrect fix introduced in #1215

Fixes #1251