### PR TITLE
Test: Better `output` assertion

### DIFF
--- a/test/consistent-destructuring.mjs
+++ b/test/consistent-destructuring.mjs
@@ -7,7 +7,6 @@ const invalidTestCase = ({code, suggestions}) => {
 	if (!suggestions) {
 		return {
 			code,
-			output: code,
 			errors: [{
 				messageId: 'consistentDestructuring'
 			}]
@@ -16,7 +15,6 @@ const invalidTestCase = ({code, suggestions}) => {
 
 	return {
 		code,
-		output: code,
 		errors: suggestions.map(suggestion => ({
 			messageId: 'consistentDestructuring',
 			suggestions: [{

--- a/test/custom-error-definition.mjs
+++ b/test/custom-error-definition.mjs
@@ -516,15 +516,6 @@ runTest.babel({
 					}
 				}
 			`,
-			output: outdent`
-				const name = 'computed-name';
-				class FooError extends Error {
-					[name] = 'FooError';
-					constructor(message) {
-						super(message);
-					}
-				}
-			`,
 			errors: [invalidNameError('FooError')]
 		}
 	]

--- a/test/expiring-todo-comments.mjs
+++ b/test/expiring-todo-comments.mjs
@@ -190,8 +190,7 @@ test({
 		},
 		{
 			code: '// TODO [2200-12-12, 2200-12-12]: Multiple dates',
-			errors: [avoidMultipleDatesError('2200-12-12, 2200-12-12', 'Multiple dates')],
-			output: '// TODO [2200-12-12, 2200-12-12]: Multiple dates'
+			errors: [avoidMultipleDatesError('2200-12-12, 2200-12-12', 'Multiple dates')]
 		},
 		{
 			code: '// TODO [>1]: if your package.json version is >1',

--- a/test/explicit-length-check.mjs
+++ b/test/explicit-length-check.mjs
@@ -11,7 +11,6 @@ const suggestionCase = ({code, output, desc, options = []}) => {
 
 	return {
 		code,
-		output: code,
 		options,
 		errors: [
 			{suggestions: [suggestion]}

--- a/test/new-for-builtins.mjs
+++ b/test/new-for-builtins.mjs
@@ -254,23 +254,19 @@ test({
 		},
 		{
 			code: 'const foo = new Boolean()',
-			errors: [disallowNewError('Boolean')],
-			output: 'const foo = new Boolean()'
+			errors: [disallowNewError('Boolean')]
 		},
 		{
 			code: 'const foo = new Number()',
-			errors: [disallowNewError('Number')],
-			output: 'const foo = new Number()'
+			errors: [disallowNewError('Number')]
 		},
 		{
 			code: 'const foo = new Number(\'123\')',
-			errors: [disallowNewError('Number')],
-			output: 'const foo = new Number(\'123\')'
+			errors: [disallowNewError('Number')]
 		},
 		{
 			code: 'const foo = new String()',
-			errors: [disallowNewError('String')],
-			output: 'const foo = new String()'
+			errors: [disallowNewError('String')]
 		},
 		{
 			code: 'const foo = new Symbol()',

--- a/test/no-array-for-each.mjs
+++ b/test/no-array-for-each.mjs
@@ -419,7 +419,6 @@ test({
 		},
 		{
 			code: 'foo.forEach(function(element, element) {})',
-			output: 'foo.forEach(function(element, element) {})',
 			errors: 1,
 			parserOptions: {
 				sourceType: 'script'
@@ -427,7 +426,6 @@ test({
 		},
 		{
 			code: 'foo.forEach(function element(element, element) {})',
-			output: 'foo.forEach(function element(element, element) {})',
 			errors: 1,
 			parserOptions: {
 				sourceType: 'script'
@@ -468,23 +466,11 @@ test.typescript({
 					}
 				)
 			`,
-			output: outdent`
-				const actions: Array<IRemoveStaleJobAction> = []
-
-				state.jobsV2.complete.forEach(
-					(job: IGatsbyCompleteJobV2, contentDigest: string): void => {
-						if (isJobStale(job)) {
-							actions.push(internalActions.removeStaleJob(contentDigest))
-						}
-					}
-				)
-			`,
 			errors: 1
 		},
 		// https://github.com/microsoft/fluentui/blob/20f3d664a36c93174dc32786a9d465dd343dabe5/apps/todo-app/src/DataProvider.ts#L157
 		{
 			code: 'this._listeners.forEach((listener: () => void) => listener());',
-			output: 'this._listeners.forEach((listener: () => void) => listener());',
 			errors: 1
 		},
 		// https://github.com/angular/angular/blob/4e8198d60f421ce120e3a6b57afe60a9332d2692/packages/animations/browser/src/render/transition_animation_engine.ts#L1636

--- a/test/no-new-array.mjs
+++ b/test/no-new-array.mjs
@@ -10,7 +10,6 @@ const MESSAGE_ID_SPREAD = 'spread';
 
 const suggestionCase = ({code, suggestions}) => ({
 	code,
-	output: code,
 	errors: [
 		{
 			messageId: MESSAGE_ID_ERROR,

--- a/test/no-new-array.mjs
+++ b/test/no-new-array.mjs
@@ -92,7 +92,6 @@ test({
 			const code = `const array = new Array(${argumentText})`;
 			return {
 				code,
-				output: code,
 				errors: [
 					{
 						messageId: MESSAGE_ID_ERROR,

--- a/test/no-null.mjs
+++ b/test/no-null.mjs
@@ -46,7 +46,6 @@ const invalidTestCase = testCase => {
 
 	return {
 		code,
-		output: code,
 		options,
 		errors: [
 			{

--- a/test/no-null.mjs
+++ b/test/no-null.mjs
@@ -20,7 +20,6 @@ const invalidTestCase = testCase => {
 	if (suggestions) {
 		return {
 			code,
-			output: code,
 			options,
 			errors: [
 				{

--- a/test/no-static-only-class.mjs
+++ b/test/no-static-only-class.mjs
@@ -68,7 +68,6 @@ test.snapshot({
 
 const noFixingCase = code => ({
 	code,
-	output: code,
 	errors: 1
 });
 

--- a/test/prefer-array-flat-map.mjs
+++ b/test/prefer-array-flat-map.mjs
@@ -220,12 +220,10 @@ test({
 		},
 		{
 			code: 'const foo = [].concat(...bar.map((i) => i));',
-			output: 'const foo = [].concat(...bar.map((i) => i));',
 			errors: [errorSpread]
 		},
 		{
 			code: 'const foo = [].concat(...[1,2,3].map((i) => i));',
-			output: 'const foo = [].concat(...[1,2,3].map((i) => i));',
 			errors: [errorSpread]
 		}
 	]

--- a/test/prefer-array-some.mjs
+++ b/test/prefer-array-some.mjs
@@ -8,7 +8,6 @@ const MESSAGE_ID_SUGGESTION = 'suggestion';
 
 const invalidCase = ({code, suggestionOutput}) => ({
 	code,
-	output: code,
 	errors: [
 		{
 			messageId: MESSAGE_ID_ERROR,

--- a/test/prefer-array-some.mjs
+++ b/test/prefer-array-some.mjs
@@ -75,7 +75,6 @@ test({
 		// Actual messages
 		{
 			code: 'if (foo.find(fn)) {}',
-			output: 'if (foo.find(fn)) {}',
 			errors: [
 				{
 					message: 'Prefer `.some(…)` over `.find(…)`.',

--- a/test/prefer-default-parameters.mjs
+++ b/test/prefer-default-parameters.mjs
@@ -7,7 +7,6 @@ const invalidTestCase = ({code, suggestions}) => {
 	if (!suggestions) {
 		return {
 			code,
-			output: code,
 			errors: [{
 				messageId: 'preferDefaultParameters'
 			}]
@@ -16,7 +15,6 @@ const invalidTestCase = ({code, suggestions}) => {
 
 	return {
 		code,
-		output: code,
 		errors: suggestions.map(suggestion => ({
 			messageId: 'preferDefaultParameters',
 			suggestions: [{

--- a/test/prefer-dom-node-append.mjs
+++ b/test/prefer-dom-node-append.mjs
@@ -62,12 +62,10 @@ test({
 		},
 		{
 			code: 'const foo = node.appendChild(child);',
-			output: 'const foo = node.appendChild(child);',
 			errors: [error]
 		},
 		{
 			code: 'console.log(node.appendChild(child));',
-			output: 'console.log(node.appendChild(child));',
 			errors: [error]
 		},
 		{
@@ -77,57 +75,46 @@ test({
 		},
 		{
 			code: 'node.appendChild(child) || "foo";',
-			output: 'node.appendChild(child) || "foo";',
 			errors: [error]
 		},
 		{
 			code: 'node.appendChild(child) + 0;',
-			output: 'node.appendChild(child) + 0;',
 			errors: [error]
 		},
 		{
 			code: 'node.appendChild(child) + 0;',
-			output: 'node.appendChild(child) + 0;',
 			errors: [error]
 		},
 		{
 			code: '+node.appendChild(child);',
-			output: '+node.appendChild(child);',
 			errors: [error]
 		},
 		{
 			code: 'node.appendChild(child) ? "foo" : "bar";',
-			output: 'node.appendChild(child) ? "foo" : "bar";',
 			errors: [error]
 		},
 		{
 			code: 'if (node.appendChild(child)) {}',
-			output: 'if (node.appendChild(child)) {}',
 			errors: [error]
 		},
 		{
 			code: 'const foo = [node.appendChild(child)]',
-			output: 'const foo = [node.appendChild(child)]',
 			errors: [error]
 		},
 		{
 			code: 'const foo = { bar: node.appendChild(child) }',
-			output: 'const foo = { bar: node.appendChild(child) }',
 			errors: [error]
 		},
 		{
 			code: 'function foo() { return node.appendChild(child); }',
-			output: 'function foo() { return node.appendChild(child); }',
 			errors: [error]
 		},
 		{
 			code: 'const foo = () => { return node.appendChild(child); }',
-			output: 'const foo = () => { return node.appendChild(child); }',
 			errors: [error]
 		},
 		{
 			code: 'foo(bar = node.appendChild(child))',
-			output: 'foo(bar = node.appendChild(child))',
 			errors: [error]
 		}
 	]

--- a/test/prefer-dom-node-remove.mjs
+++ b/test/prefer-dom-node-remove.mjs
@@ -11,7 +11,6 @@ const invalidTestCase = ({code, output, suggestionOutput}) => {
 	if (suggestionOutput) {
 		return {
 			code,
-			output: code,
 			errors: [
 				{
 					messageId: ERROR_MESSAGE_ID,

--- a/test/prefer-keyboard-event-key.mjs
+++ b/test/prefer-keyboard-event-key.mjs
@@ -190,11 +190,6 @@ test({
 					if (!event.keyCode) {}
 				});
 			`,
-			output: outdent`
-				foo.addEventListener('click', event => {
-					if (!event.keyCode) {}
-				});
-			`,
 			errors: [error('keyCode')]
 		},
 		{
@@ -510,15 +505,7 @@ test({
 					if (keyCode === 32) return 4;
 				});
 			`,
-			errors: [error('which'), error('keyCode')],
-			output: outdent`
-				foo.addEventListener('click', function(b) {
-					if (b.which > 27) {
-					}
-					const {keyCode} = b;
-					if (keyCode === 32) return 4;
-				});
-			`
+			errors: [error('which'), error('keyCode')]
 		},
 		{
 			code: outdent`
@@ -536,22 +523,7 @@ test({
 				}
 			});
 			`,
-			errors: [error('charCode'), error('keyCode')],
-			output: outdent`
-			const e = {}
-			foo.addEventListener('click', (e, r, fg) => {
-				function a() {
-					if (true) {
-						{
-							{
-								const { charCode } = e;
-								console.log(e.keyCode, charCode);
-							}
-						}
-					}
-				}
-			});
-			`
+			errors: [error('charCode'), error('keyCode')]
 		},
 		{
 			code: outdent`
@@ -569,22 +541,7 @@ test({
 				}
 			});
 			`,
-			errors: [error('charCode'), error('keyCode')],
-			output: outdent`
-			const e = {}
-			foo.addEventListener('click', (e, r, fg) => {
-				function a() {
-					if (true) {
-						{
-							{
-								const { charCode } = e;
-								console.log(e.keyCode, charCode);
-							}
-						}
-					}
-				}
-			});
-			`
+			errors: [error('charCode'), error('keyCode')]
 		},
 		{
 			code: outdent`

--- a/test/prefer-modern-dom-apis.mjs
+++ b/test/prefer-modern-dom-apis.mjs
@@ -107,7 +107,7 @@ test({
 					message:
 						'Prefer `oldChildNode.replaceWith(newChildNode)` over `parentNode.replaceChild(newChildNode, oldChildNode)`.'
 				}
-			],
+			]
 		},
 		{
 			code: 'foo = parentNode.replaceChild(newChildNode, oldChildNode);',
@@ -116,7 +116,7 @@ test({
 					message:
 						'Prefer `oldChildNode.replaceWith(newChildNode)` over `parentNode.replaceChild(newChildNode, oldChildNode)`.'
 				}
-			],
+			]
 		},
 		// Tests for .insertBefore()
 		{

--- a/test/prefer-modern-dom-apis.mjs
+++ b/test/prefer-modern-dom-apis.mjs
@@ -108,7 +108,6 @@ test({
 						'Prefer `oldChildNode.replaceWith(newChildNode)` over `parentNode.replaceChild(newChildNode, oldChildNode)`.'
 				}
 			],
-			output: 'const foo = parentNode.replaceChild(newChildNode, oldChildNode);'
 		},
 		{
 			code: 'foo = parentNode.replaceChild(newChildNode, oldChildNode);',
@@ -118,7 +117,6 @@ test({
 						'Prefer `oldChildNode.replaceWith(newChildNode)` over `parentNode.replaceChild(newChildNode, oldChildNode)`.'
 				}
 			],
-			output: 'foo = parentNode.replaceChild(newChildNode, oldChildNode);'
 		},
 		// Tests for .insertBefore()
 		{
@@ -138,8 +136,7 @@ test({
 					message:
 						'Prefer `beta.before(alfa)` over `parentNode.insertBefore(alfa, beta)`.'
 				}
-			],
-			output: 'parentNode.insertBefore(alfa, beta).insertBefore(charlie, delta);'
+			]
 		},
 		{
 			code: 'const foo = parentNode.insertBefore(alfa, beta);',
@@ -148,8 +145,7 @@ test({
 					message:
 						'Prefer `beta.before(alfa)` over `parentNode.insertBefore(alfa, beta)`.'
 				}
-			],
-			output: 'const foo = parentNode.insertBefore(alfa, beta);'
+			]
 		},
 		{
 			code: 'foo = parentNode.insertBefore(alfa, beta);',
@@ -158,8 +154,7 @@ test({
 					message:
 						'Prefer `beta.before(alfa)` over `parentNode.insertBefore(alfa, beta)`.'
 				}
-			],
-			output: 'foo = parentNode.insertBefore(alfa, beta);'
+			]
 		},
 		{
 			code: 'new Dom(parentNode.insertBefore(alfa, beta))',
@@ -168,8 +163,7 @@ test({
 					message:
 					'Prefer `beta.before(alfa)` over `parentNode.insertBefore(alfa, beta)`.'
 				}
-			],
-			output: 'new Dom(parentNode.insertBefore(alfa, beta))'
+			]
 		},
 		{
 			/* eslint-disable no-template-curly-in-string */
@@ -179,8 +173,7 @@ test({
 					message:
 					'Prefer `beta.before(alfa)` over `parentNode.insertBefore(alfa, beta)`.'
 				}
-			],
-			output: '`${parentNode.insertBefore(alfa, beta)}`'
+			]
 			/* eslint-enable no-template-curly-in-string */
 		},
 		// Tests for .insertAdjacentText()
@@ -322,8 +315,7 @@ test({
 					message:
 					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
 				}
-			],
-			output: 'const foo = referenceNode.insertAdjacentElement("beforebegin", newNode);'
+			]
 		},
 		{
 			code: 'foo = referenceNode.insertAdjacentElement("beforebegin", newNode);',
@@ -332,8 +324,7 @@ test({
 					message:
 					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
 				}
-			],
-			output: 'foo = referenceNode.insertAdjacentElement("beforebegin", newNode);'
+			]
 		},
 		{
 			code: 'const foo = [referenceNode.insertAdjacentElement("beforebegin", newNode)]',
@@ -342,8 +333,7 @@ test({
 					message:
 					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
 				}
-			],
-			output: 'const foo = [referenceNode.insertAdjacentElement("beforebegin", newNode)]'
+			]
 		},
 		{
 			code: 'foo(bar = referenceNode.insertAdjacentElement("beforebegin", newNode))',
@@ -352,8 +342,7 @@ test({
 					message:
 					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
 				}
-			],
-			output: 'foo(bar = referenceNode.insertAdjacentElement("beforebegin", newNode))'
+			]
 		},
 		{
 			code: 'const foo = () => { return referenceNode.insertAdjacentElement("beforebegin", newNode); }',
@@ -362,8 +351,7 @@ test({
 					message:
 					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
 				}
-			],
-			output: 'const foo = () => { return referenceNode.insertAdjacentElement("beforebegin", newNode); }'
+			]
 		},
 		{
 			code: 'if (referenceNode.insertAdjacentElement("beforebegin", newNode)) {}',
@@ -372,8 +360,7 @@ test({
 					message:
 					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
 				}
-			],
-			output: 'if (referenceNode.insertAdjacentElement("beforebegin", newNode)) {}'
+			]
 		},
 		{
 			code: 'const foo = { bar: referenceNode.insertAdjacentElement("beforebegin", newNode) }',
@@ -382,8 +369,7 @@ test({
 					message:
 					'Prefer `referenceNode.before(newNode)` over `referenceNode.insertAdjacentElement("beforebegin", newNode)`.'
 				}
-			],
-			output: 'const foo = { bar: referenceNode.insertAdjacentElement("beforebegin", newNode) }'
+			]
 		}
 	]
 });

--- a/test/prefer-module.mjs
+++ b/test/prefer-module.mjs
@@ -48,11 +48,6 @@ test({
 					return;
 				}
 			`,
-			output: outdent`
-				if (foo) {
-					return;
-				}
-			`,
 			errors: 1,
 			parserOptions: {
 				sourceType: 'script',

--- a/test/prefer-number-properties.mjs
+++ b/test/prefer-number-properties.mjs
@@ -63,6 +63,7 @@ const invalidMethodTest = ({code, output, name, suggestionOutput}) => {
 	if (safe) {
 		test.output = output;
 	}
+
 	return test;
 };
 

--- a/test/prefer-number-properties.mjs
+++ b/test/prefer-number-properties.mjs
@@ -54,14 +54,16 @@ const createError = (name, suggestionOutput) => {
 
 const invalidMethodTest = ({code, output, name, suggestionOutput}) => {
 	const {safe} = methods[name];
-
-	return {
+	const test = {
 		code,
-		output: safe ? output : code,
 		errors: [
 			createError(name, suggestionOutput)
 		]
 	};
+	if (safe) {
+		test.output = output;
+	}
+	return test;
 };
 
 // Methods

--- a/test/prefer-set-has.mjs
+++ b/test/prefer-set-has.mjs
@@ -26,11 +26,6 @@ const methodsReturnsArray = [
 	'splice'
 ];
 
-const noFixCase = testCase => ({
-	...testCase,
-	output: testCase.code
-});
-
 test({
 	valid: [
 		outdent`
@@ -961,7 +956,7 @@ test.typescript({
 		`
 	],
 	invalid: [
-		noFixCase({
+		{
 			code: outdent`
 				const a: Array<'foo' | 'bar'> = ['foo', 'bar']
 
@@ -990,6 +985,6 @@ test.typescript({
 					]
 				}
 			]
-		})
+		}
 	]
 });

--- a/test/prefer-string-slice.mjs
+++ b/test/prefer-string-slice.mjs
@@ -94,7 +94,6 @@ test({
 		},
 		{
 			code: '"foo".substr(1, length)',
-			output: '"foo".substr(1, length)',
 			errors: errorsSubstr
 		},
 		{
@@ -104,15 +103,10 @@ test({
 		},
 		{
 			code: '"foo".substr("1", 2)',
-			output: '"foo".substr("1", 2)',
 			errors: errorsSubstr
 		},
 		{
 			code: outdent`
-				const length = 123;
-				"foo".substr(1, length)
-			`,
-			output: outdent`
 				const length = 123;
 				"foo".substr(1, length)
 			`,
@@ -134,10 +128,6 @@ test({
 				const length = 123;
 				"foo".substr('0', length)
 			`,
-			output: outdent`
-				const length = 123;
-				"foo".substr('0', length)
-			`,
 			errors: errorsSubstr
 		},
 		{
@@ -152,10 +142,6 @@ test({
 		},
 		{
 			code: outdent`
-				const length = 123;
-				"foo".substr(1, length - 4)
-			`,
-			output: outdent`
 				const length = 123;
 				"foo".substr(1, length - 4)
 			`,
@@ -185,7 +171,6 @@ test({
 		},
 		{
 			code: 'foo.substr(start, length)',
-			output: 'foo.substr(start, length)',
 			errors: errorsSubstr
 		},
 		{
@@ -196,7 +181,6 @@ test({
 		// Extra arguments
 		{
 			code: 'foo.substr(1, 2, 3)',
-			output: 'foo.substr(1, 2, 3)',
 			errors: errorsSubstr
 		},
 		// #700
@@ -274,7 +258,6 @@ test({
 		},
 		{
 			code: 'foo.substring(start, end)',
-			output: 'foo.substring(start, end)',
 			errors: errorsSubstring
 		},
 		{
@@ -285,7 +268,6 @@ test({
 		// Extra arguments
 		{
 			code: 'foo.substring(1, 2, 3)',
-			output: 'foo.substring(1, 2, 3)',
 			errors: errorsSubstring
 		}
 	]

--- a/test/prefer-switch.mjs
+++ b/test/prefer-switch.mjs
@@ -468,11 +468,6 @@ test.typescript({
 				else if (foo === 2) {}
 				else if (foo === 3) {break;}
 			`,
-			output: outdent`
-				if (foo === 1) {}
-				else if (foo === 2) {}
-				else if (foo === 3) {break;}
-			`,
 			errors: 1
 		}
 	]

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -3,8 +3,6 @@ import {getTester, avoidTestTitleConflict} from './utils/test.mjs';
 
 const {test} = getTester(import.meta);
 
-const noFixingTestCase = test => ({...test, output: test.code});
-
 const createErrors = message => {
 	const error = {};
 
@@ -239,39 +237,39 @@ const tests = {
 	],
 
 	invalid: [
-		noFixingTestCase({
+		{
 			code: 'let e',
 			errors: createErrors('Please rename the variable `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'let eCbOpts',
 			errors: createErrors('Please rename the variable `eCbOpts`. Suggested names are: `errorCallbackOptions`, `eventCallbackOptions`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: '({e: 1})',
 			options: checkPropertiesOptions,
 			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'this.e = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: '({e() {}})',
 			options: checkPropertiesOptions,
 			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: '(class {e() {}})',
 			options: checkPropertiesOptions,
 			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'this.eResDir = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors('Please rename the property `eResDir`. Suggested names are: `errorResponseDirection`, `errorResponseDirectory`, `errorResultDirection`, ... (5 more omitted). A more descriptive name will do too.')
-		}),
+		},
 
 		// All suggested names should avoid capture
 		{
@@ -311,31 +309,31 @@ const tests = {
 			output: 'let standardDeviation',
 			errors: createErrors('The variable `stdDev` should be named `standardDeviation`. A more descriptive name will do too.')
 		},
-		noFixingTestCase({
+		{
 			code: '({err: 1})',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'this.err = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: '({err() {}})',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: '(class {err() {}})',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'this.errCbOptsObj = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `errCbOptsObj` should be named `errorCallbackOptionsObject`. A more descriptive name will do too.')
-		}),
+		},
 
 		{
 			code: 'let successCb',
@@ -348,16 +346,16 @@ const tests = {
 			errors: createErrors()
 		},
 
-		noFixingTestCase({
+		{
 			code: 'this.successCb = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'this.btnColor = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
+		},
 
 		// This tests that the rule does not hang up on combinatoric explosion of possible replacements
 		{
@@ -371,16 +369,16 @@ const tests = {
 			output: 'let event',
 			errors: createErrors('The variable `evt` should be named `event`. A more descriptive name will do too.')
 		},
-		noFixingTestCase({
+		{
 			code: '({evt: 1})',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `evt` should be named `event`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'foo.evt = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `evt` should be named `event`. A more descriptive name will do too.')
-		}),
+		},
 
 		// Testing that options apply
 		{
@@ -420,15 +418,15 @@ const tests = {
 			errors: createErrors()
 		},
 
-		noFixingTestCase({
+		{
 			code: 'let e',
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'let e',
 			options: customOptions,
 			errors: createErrors()
-		}),
+		},
 
 		{
 			code: 'let err',
@@ -448,11 +446,11 @@ const tests = {
 			errors: createErrors()
 		},
 
-		noFixingTestCase({
+		{
 			code: '({err: 1})',
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
+		},
 
 		{
 			code: 'let errCb',
@@ -515,13 +513,13 @@ const tests = {
 			errors: createErrors()
 		},
 
-		noFixingTestCase({
+		{
 			code: outdent`
 				let e;
 				console.log(e);
 			`,
 			errors: createErrors()
-		}),
+		},
 
 		{
 			code: outdent`
@@ -683,12 +681,12 @@ const tests = {
 			errors: createErrors()
 		},
 
-		noFixingTestCase({
+		{
 			code: 'const foo = {err: 1}',
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: outdent`
 				const foo = {
 					err() {}
@@ -696,24 +694,24 @@ const tests = {
 			`,
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'foo.err = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'foo.bar.err = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'this.err = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
+		},
 
-		noFixingTestCase({
+		{
 			code: outdent`
 				class C {
 					err() {}
@@ -721,23 +719,23 @@ const tests = {
 			`,
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		}),
+		},
 
-		noFixingTestCase({
+		{
 			code: 'this._err = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `_err` should be named `_error`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'this.__err__ = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `__err__` should be named `__error__`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'this.e_ = 1',
 			options: checkPropertiesOptions,
 			errors: createErrors('Please rename the property `e_`. Suggested names are: `error_`, `event_`. A more descriptive name will do too.')
-		}),
+		},
 
 		{
 			code: 'let err_',
@@ -749,10 +747,10 @@ const tests = {
 			output: 'let __error__',
 			errors: createErrors()
 		},
-		noFixingTestCase({
+		{
 			code: 'let _e',
 			errors: createErrors('Please rename the variable `_e`. Suggested names are: `_error`, `_event`. A more descriptive name will do too.')
-		}),
+		},
 
 		{
 			code: 'class Err {}',
@@ -764,10 +762,10 @@ const tests = {
 			output: 'class Callback {}',
 			errors: createErrors('The variable `Cb` should be named `Callback`. A more descriptive name will do too.')
 		},
-		noFixingTestCase({
+		{
 			code: 'class Res {}',
 			errors: createErrors('Please rename the variable `Res`. Suggested names are: `Response`, `Result`. A more descriptive name will do too.')
-		}),
+		},
 		{
 			code: 'const Err = 1;',
 			output: 'const Error_ = 1;',
@@ -778,16 +776,16 @@ const tests = {
 			output: 'const _Error_ = 1;',
 			errors: createErrors()
 		},
-		noFixingTestCase({
+		{
 			code: '({Err: 1})',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `Err` should be named `Error`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: '({Res: 1})',
 			options: checkPropertiesOptions,
 			errors: createErrors('Please rename the property `Res`. Suggested names are: `Response`, `Result`. A more descriptive name will do too.')
-		}),
+		},
 
 		{
 			code: 'let doc',
@@ -986,7 +984,7 @@ const tests = {
 		{
 			code: outdent`
 				let err;
-				({a: err = 1} = 2);
+				{a: err = 1} = 2);
 			`,
 			output: outdent`
 				let error;
@@ -1560,26 +1558,26 @@ const importExportTests = {
 			errors: createErrors()
 		},
 
-		noFixingTestCase({
+		{
 			code: 'export const err = {}',
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'export let err',
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'export var err',
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'export function err() {}',
 			errors: createErrors()
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: 'export class err {}',
 			errors: createErrors()
-		}),
+		},
 
 		{
 			code: outdent`
@@ -1625,14 +1623,14 @@ const importExportTests = {
 			errors: createErrors()
 		},
 
-		noFixingTestCase({
+		{
 			code: outdent`
 				let foo;
 				export {foo as err};
 			`,
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		})
+		}
 
 	]
 };
@@ -1717,17 +1715,17 @@ test.babel({
 			errors: createErrors()
 		},
 
-		noFixingTestCase({
+		{
 			code: '(class {e = 1})',
 			options: checkPropertiesOptions,
 			errors: createErrors('Please rename the property `e`. Suggested names are: `error`, `event`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: '(class {err = 1})',
 			options: checkPropertiesOptions,
 			errors: createErrors('The property `err` should be named `error`. A more descriptive name will do too.')
-		}),
-		noFixingTestCase({
+		},
+		{
 			code: outdent`
 				class C {
 					err = () => {}
@@ -1735,7 +1733,7 @@ test.babel({
 			`,
 			options: checkPropertiesOptions,
 			errors: createErrors()
-		})
+		}
 	]
 });
 
@@ -1792,10 +1790,10 @@ test.typescript({
 		},
 
 		// #1102
-		noFixingTestCase({
+		{
 			code: 'export type Props = string',
 			errors: createErrors()
-		}),
+		},
 
 		// #347
 		{

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -984,7 +984,7 @@ const tests = {
 		{
 			code: outdent`
 				let err;
-				{a: err = 1} = 2);
+				({a: err = 1} = 2);
 			`,
 			output: outdent`
 				let error;

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -10,11 +10,15 @@ const require = createRequire(import.meta.url);
 
 function normalizeInvalidTest(test) {
 	const {code, output} = test;
+
 	if (code === output) {
+		console.log(JSON.stringify(test, undefined, 2));
 		throw new Error('Remove output if your test do not fix code.');
 	}
 
 	return {
+		// Use `null` instead of `code` to get a better message
+		// See https://github.com/eslint/eslint/blob/8a77b661bc921c3408bae01b3aa41579edfc6e58/lib/rule-tester/rule-tester.js#L847-L853
 		// eslint-disable-next-line unicorn/no-null
 		output: null,
 		...test

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -8,6 +8,19 @@ import defaultParserOptions from './default-parser-options.mjs';
 
 const require = createRequire(import.meta.url);
 
+function normalizeInvalidTest(test) {
+	const {code, output} = test;
+	if (code === output) {
+		throw new Error('Remove output if your test do not fix code.');
+	}
+
+	return {
+		// eslint-disable-next-line unicorn/no-null
+		output: null,
+		...test
+	};
+}
+
 class Tester {
 	constructor(ruleId) {
 		this.ruleId = ruleId;
@@ -15,12 +28,19 @@ class Tester {
 	}
 
 	runTest(tests) {
-		const {testerOptions, invalid, valid} = tests;
+		const {testerOptions, valid, invalid} = tests;
 		const tester = avaRuleTester(test, {
 			parserOptions: defaultParserOptions,
 			...testerOptions
 		});
-		return tester.run(this.ruleId, this.rule, {invalid, valid});
+		return tester.run(
+			this.ruleId,
+			this.rule,
+			{
+				valid,
+				invalid: invalid.map(test => normalizeInvalidTest(test))
+			}
+		);
 	}
 
 	typescript(tests) {


### PR DESCRIPTION
1. Forbid use same `output` and `code` (hard to see difference when it's long)
1. If no `output`, auto add `output: null` (Make sure output didn't change)