### PR TITLE
`prefer-ternary`: Refactor

### DIFF
--- a/rules/utils/should-add-parentheses-to-conditional-expression-child.js
+++ b/rules/utils/should-add-parentheses-to-conditional-expression-child.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 /**
 Check if parentheses should be added to a `node` when it's used as `argument` of `SpreadElement`.
 

--- a/rules/utils/should-add-parentheses-to-conditional-expression-child.js
+++ b/rules/utils/should-add-parentheses-to-conditional-expression-child.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
-Check if parentheses should be added to a `node` when it's used as `argument` of `SpreadElement`.
+Check if parentheses should be added to a `node` when it's used as child of `ConditionalExpression`.
 
 @param {Node} node - The AST node to check.
 @returns {boolean}

--- a/rules/utils/should-add-parentheses-to-conditional-expression-child.js
+++ b/rules/utils/should-add-parentheses-to-conditional-expression-child.js
@@ -1,0 +1,18 @@
+'use strict';
+
+
+/**
+Check if parentheses should be added to a `node` when it's used as `argument` of `SpreadElement`.
+
+@param {Node} node - The AST node to check.
+@returns {boolean}
+*/
+function shouldAddParenthesesToConditionalExpressionChild(node) {
+	return node.type === 'AwaitExpression' ||
+		// Lower precedence, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table
+		node.type === 'AssignmentExpression' ||
+		node.type === 'YieldExpression' ||
+		node.type === 'SequenceExpression';
+}
+
+module.exports = shouldAddParenthesesToConditionalExpressionChild;

--- a/test/prefer-ternary.mjs
+++ b/test/prefer-ternary.mjs
@@ -1076,7 +1076,11 @@ test({
 					a = bar;
 				}
 			`,
-			output: 'a = (test) ? foo : bar;',
+			output: outdent`
+				a = (
+						test
+					) ? foo : bar;
+			`,
 			options: onlySingleLineOptions,
 			errors
 		},


### PR DESCRIPTION
Use common `getParenthesizedText` function to avoid confusing. Extract `shouldAddParenthesesToConditionalExpressionChild`.