### PR TITLE
`prefer-string-starts-ends-with-rule`: don't autofix known non-string values

### DIFF
--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -64,8 +64,6 @@ const create = context => {
 				return;
 			}
 
-
-
 			context.report({
 				node,
 				messageId: result.messageId,

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -1,5 +1,5 @@
 'use strict';
-const {isParenthesized} = require('eslint-utils');
+const {isParenthesized, getStaticValue} = require('eslint-utils');
 const getDocumentationUrl = require('./utils/get-documentation-url');
 const methodSelector = require('./utils/method-selector');
 const quoteString = require('./utils/quote-string');
@@ -64,12 +64,18 @@ const create = context => {
 				return;
 			}
 
+			const [target] = node.arguments;
+			const staticValue = getStaticValue(target, context.getScope());
+			if (staticValue && typeof staticValue.value !== 'string') {
+				// Ignore known, non-string value which won't have a startsWith/endsWith function.
+				return;
+			}
+
 			context.report({
 				node,
 				messageId: result.messageId,
 				fix: fixer => {
 					const method = result.messageId === MESSAGE_STARTS_WITH ? 'startsWith' : 'endsWith';
-					const [target] = node.arguments;
 					let targetString = sourceCode.getText(target);
 
 					if (

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -64,17 +64,19 @@ const create = context => {
 				return;
 			}
 
-			const [target] = node.arguments;
-			const staticValue = getStaticValue(target, context.getScope());
-			if (staticValue && typeof staticValue.value !== 'string') {
-				// Ignore known, non-string value which won't have a startsWith/endsWith function.
-				return;
-			}
+
 
 			context.report({
 				node,
 				messageId: result.messageId,
 				fix: fixer => {
+					const [target] = node.arguments;
+					const staticValue = getStaticValue(target, context.getScope());
+					if (staticValue && typeof staticValue.value !== 'string') {
+						// Ignore known, non-string value which won't have a startsWith/endsWith function.
+						return;
+					}
+
 					const method = result.messageId === MESSAGE_STARTS_WITH ? 'startsWith' : 'endsWith';
 					let targetString = sourceCode.getText(target);
 

--- a/test/prefer-string-starts-ends-with.mjs
+++ b/test/prefer-string-starts-ends-with.mjs
@@ -51,6 +51,10 @@ test({
 		'if (foo.match(/^foo/)) {}',
 		'if (/^foo/.exec(foo)) {}',
 
+		// Ignore known, non-strings which don't have a startsWith/endsWith function
+		'const foo = {}; /^abc/.test(foo)',
+		'const foo = 123; /^abc/.test(foo)',
+
 		...validRegex.map(re => `${re}.test(bar)`)
 	],
 	invalid: [
@@ -73,6 +77,12 @@ test({
 				errors: [{messageId}]
 			};
 		}),
+		// String in variable.
+		{
+			code: 'const foo = "hello"; /^abc/.test(foo);',
+			output: 'const foo = "hello"; foo.startsWith(\'abc\');',
+			errors: [{messageId: MESSAGE_STARTS_WITH}]
+		},
 		// Parenthesized
 		{
 			code: '/^b/.test(("a"))',

--- a/test/prefer-string-starts-ends-with.mjs
+++ b/test/prefer-string-starts-ends-with.mjs
@@ -76,12 +76,10 @@ test({
 		// String in variable. Don't autofix known, non-strings which don't have a startsWith/endsWith function.
 		{
 			code: 'const foo = {}; /^abc/.test(foo);',
-			output: null,
 			errors: [{messageId: MESSAGE_STARTS_WITH}]
 		},
 		{
 			code: 'const foo = 123; /^abc/.test(foo);',
-			output: null,
 			errors: [{messageId: MESSAGE_STARTS_WITH}]
 		},
 		{

--- a/test/prefer-string-starts-ends-with.mjs
+++ b/test/prefer-string-starts-ends-with.mjs
@@ -51,10 +51,6 @@ test({
 		'if (foo.match(/^foo/)) {}',
 		'if (/^foo/.exec(foo)) {}',
 
-		// Ignore known, non-strings which don't have a startsWith/endsWith function
-		'const foo = {}; /^abc/.test(foo)',
-		'const foo = 123; /^abc/.test(foo)',
-
 		...validRegex.map(re => `${re}.test(bar)`)
 	],
 	invalid: [
@@ -77,7 +73,17 @@ test({
 				errors: [{messageId}]
 			};
 		}),
-		// String in variable.
+		// String in variable. Don't autofix known, non-strings which don't have a startsWith/endsWith function.
+		{
+			code: 'const foo = {}; /^abc/.test(foo);',
+			output: null,
+			errors: [{messageId: MESSAGE_STARTS_WITH}]
+		},
+		{
+			code: 'const foo = 123; /^abc/.test(foo);',
+			output: null,
+			errors: [{messageId: MESSAGE_STARTS_WITH}]
+		},
 		{
 			code: 'const foo = "hello"; /^abc/.test(foo);',
 			output: 'const foo = "hello"; foo.startsWith(\'abc\');',


### PR DESCRIPTION
Known, non-string values don't have a startsWith/endsWith function.