### PR TITLE
`prefer-spread`: Ignore `{arrayBuffer,blob,buffer,file,this}.slice()`

### DIFF
--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -16,6 +16,8 @@ Enforces the use of [the spread operator (`...`)](https://developer.mozilla.org/
 
 	Shallow copy an `Array`.
 
+	Variables named `arrayBuffer`, `blob`, `buffer`, `file` and `this` are ignored.
+
 This rule is partly fixable.
 
 ## Fail

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -78,7 +78,8 @@ const ignoredCallee = [
 	'underscore',
 	'_',
 	'Async',
-	'async'
+	'async',
+	'this'
 ];
 
 function check(context, node, method, options) {
@@ -155,10 +156,7 @@ const create = context => {
 		].join('');
 
 		rules[selector] = node => {
-			if (
-				isNodeMatches(node.callee.object, ignoredCallee) ||
-				node.callee.object.type === 'ThisExpression'
-			) {
+			if (isNodeMatches(node.callee.object, ignoredCallee)) {
 				return;
 			}
 

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -8,6 +8,7 @@ const shouldAddParenthesesToSpreadElementArgument = require('./utils/should-add-
 const replaceNodeOrTokenAndSpacesBefore = require('./utils/replace-node-or-token-and-spaces-before');
 const removeSpacesAfter = require('./utils/remove-spaces-after');
 const isLiteralValue = require('./utils/is-literal-value');
+const {isNodeMatches} = require('./utils/is-node-matches');
 
 const ERROR_ARRAY_FROM = 'array-from';
 const ERROR_ARRAY_CONCAT = 'array-concat';
@@ -61,6 +62,14 @@ const arraySliceCallSelector = [
 	}),
 	'[callee.object.type!="ArrayExpression"]'
 ].join('');
+
+const ignoredSliceCallee = [
+	'arrayBuffer',
+	'blob',
+	'buffer',
+	'file',
+	'this'
+];
 
 const isArrayLiteral = node => node.type === 'ArrayExpression';
 const isArrayLiteralHasTrailingComma = (node, sourceCode) => {
@@ -392,6 +401,10 @@ const create = context => {
 			context.report(problem);
 		},
 		[arraySliceCallSelector](node) {
+			if (isNodeMatches(node.callee, ignoredSliceCallee)) {
+				return;
+			}
+
 			const [firstArgument] = node.arguments;
 			if (firstArgument && !isLiteralValue(firstArgument, 0)) {
 				return;

--- a/test/prefer-spread.mjs
+++ b/test/prefer-spread.mjs
@@ -288,7 +288,13 @@ test.snapshot({
 		'array.notSlice()',
 		// Why would someone write these
 		'[...foo].slice()',
-		'[foo].slice()'
+		'[foo].slice()',
+		'arrayBuffer.slice()',
+		// Ignored
+		'blob.slice()',
+		'buffer.slice()',
+		'file.slice()',
+		'class A {foo() {this.slice()}}'
 	],
 	invalid: [
 		'array.slice()',


### PR DESCRIPTION
Fixes #1279