### PR TITLE
`require-array-join-separator`: Mention what the default `join` behavior is

### DIFF
--- a/docs/rules/require-array-join-separator.md
+++ b/docs/rules/require-array-join-separator.md
@@ -1,6 +1,6 @@
 # Enforce using the separator argument with `Array#join()`
 
-It's better to make it clear what the separator is when calling [Array#join()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join).
+It's better to make it clear what the separator is when calling [Array#join()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join), instead of relying on the default comma (`,`) separator. 
 
 This rule is fixable.
 


### PR DESCRIPTION
Naturally, I think readers will be curious what the default separator behavior of `join` is when this rule is not followed.

Alternatively, we could just mention it on the example:

```
const string = array.join(); // Defaults to comma (`,`)
```