### PR TITLE
Update selectors with boolean attributes

### DIFF
--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -15,7 +15,7 @@ const declaratorSelector = [
 
 const memberSelector = [
 	'MemberExpression',
-	'[computed=false]',
+	'[computed!=true]',
 	not([
 		'AssignmentExpression > .left',
 		'CallExpression > .callee',

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -15,7 +15,7 @@ const getSelector = (parent, property) =>
 const returnSelector = getSelector('ReturnStatement', 'argument');
 
 // `yield undefined`
-const yieldSelector = getSelector('YieldExpression[delegate=false]', 'argument');
+const yieldSelector = getSelector('YieldExpression[delegate!=true]', 'argument');
 
 // `() => undefined`
 const arrowFunctionSelector = getSelector('ArrowFunctionExpression', 'body');

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -48,7 +48,7 @@ const filterVariableSelector = [
 
 const zeroIndexSelector = [
 	'MemberExpression',
-	'[computed=true]',
+	'[computed!=false]',
 	'[property.type="Literal"]',
 	'[property.raw="0"]',
 	methodCallSelector({

--- a/rules/prefer-array-flat-map.js
+++ b/rules/prefer-array-flat-map.js
@@ -24,7 +24,7 @@ const SELECTOR_SPREAD = [
 	// [].concat(...bar.map((i) => i))
 	//    ^^^^^^
 	'[callee.type="MemberExpression"]',
-	'[callee.computed=false]',
+	'[callee.computed!=true]',
 	'[callee.property.type="Identifier"]',
 	'[callee.property.name="concat"]',
 
@@ -39,7 +39,7 @@ const SELECTOR_SPREAD = [
 	// [].concat(...bar.map((i) => i))
 	//              ^^^^^^^
 	'[arguments.0.argument.callee.type="MemberExpression"]',
-	'[arguments.0.argument.callee.computed=false]',
+	'[arguments.0.argument.callee.computed!=true]',
 
 	// [].concat(...bar.map((i) => i))
 	//                  ^^^

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -69,8 +69,8 @@ const arrayReduce2 = {
 			length: 2
 		}),
 		'[arguments.0.type="ArrowFunctionExpression"]',
-		'[arguments.0.async=false]',
-		'[arguments.0.generator=false]',
+		'[arguments.0.async!=true]',
+		'[arguments.0.generator!=true]',
 		'[arguments.0.params.length=2]',
 		'[arguments.0.params.0.type="Identifier"]',
 		'[arguments.0.params.1.type="Identifier"]',
@@ -136,7 +136,7 @@ const lodashFlatten = {
 const anyCall = {
 	selector: [
 		'CallExpression',
-		'[optional=false]',
+		'[optional!=true]',
 		'[arguments.length=1]',
 		'[arguments.0.type!="SpreadElement"]'
 	].join(''),

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -22,8 +22,8 @@ const arrayFlatMap = {
 			length: 1
 		}),
 		'[arguments.0.type="ArrowFunctionExpression"]',
-		'[arguments.0.async=false]',
-		'[arguments.0.generator=false]',
+		'[arguments.0.async!=true]',
+		'[arguments.0.generator!=true]',
 		'[arguments.0.params.length=1]',
 		'[arguments.0.params.0.type="Identifier"]',
 		'[arguments.0.body.type="Identifier"]'
@@ -41,8 +41,8 @@ const arrayReduce = {
 			length: 2
 		}),
 		'[arguments.0.type="ArrowFunctionExpression"]',
-		'[arguments.0.async=false]',
-		'[arguments.0.generator=false]',
+		'[arguments.0.async!=true]',
+		'[arguments.0.generator!=true]',
 		'[arguments.0.params.length=2]',
 		'[arguments.0.params.0.type="Identifier"]',
 		'[arguments.0.params.1.type="Identifier"]',

--- a/rules/selectors/member-expression-selector.js
+++ b/rules/selectors/member-expression-selector.js
@@ -36,7 +36,7 @@ function memberExpressionSelector(options) {
 
 	const parts = [
 		`[${prefix}type="MemberExpression"]`,
-		`[${prefix}computed=false]`,
+		`[${prefix}computed!=true]`,
 		`[${prefix}property.type="Identifier"]`
 	];
 

--- a/rules/selectors/reference-identifier-selector.js
+++ b/rules/selectors/reference-identifier-selector.js
@@ -4,7 +4,7 @@ const matches = require('./matches-any');
 
 const nonReferenceSelectors = [
 	// `foo.Identifier`
-	'MemberExpression[computed=false] > .property',
+	'MemberExpression[computed!=true] > .property',
 	// `function Identifier() {}`
 	'FunctionDeclaration > .id',
 	// `const foo = function Identifier() {}`
@@ -14,18 +14,18 @@ const nonReferenceSelectors = [
 	// `const foo = class Identifier() {}`
 	'ClassExpression > .id',
 	// TODO: remove `ClassProperty` when `babel` and `typescript` support `PropertyDefinition`
-	'ClassProperty[computed=false] > .key',
+	'ClassProperty[computed!=true] > .key',
 	// `class Foo {Identifier = 1}`
-	'PropertyDefinition[computed=false] > .key',
+	'PropertyDefinition[computed!=true] > .key',
 	// `class Foo {Identifier() {}}`
-	'MethodDefinition[computed=false] > .key',
+	'MethodDefinition[computed!=true] > .key',
 	// `const Identifier = 1`
 	'VariableDeclarator > .id',
 	// `const foo = {Identifier: 1}`
-	'ObjectExpression > Property[shorthand=false][computed=false].properties > .key',
+	'ObjectExpression > Property[shorthand!=true][computed!=true].properties > .key',
 	// `const {Identifier} = {}`
 	// `const {Identifier: foo} = {}`
-	'ObjectPattern > Property[computed=false].properties > .key',
+	'ObjectPattern > Property[computed!=true].properties > .key',
 	// `const {Identifier} = {}`
 	// `const {foo: Identifier} = {}`
 	'ObjectPattern > Property.properties > .value',

--- a/rules/shared/simple-array-search-rule.js
+++ b/rules/shared/simple-array-search-rule.js
@@ -10,8 +10,8 @@ const getBinaryExpressionSelector = path => [
 	`:matches([${path}.left.type="Identifier"], [${path}.right.type="Identifier"])`
 ].join('');
 const getFunctionSelector = path => [
-	`[${path}.generator=false]`,
-	`[${path}.async=false]`,
+	`[${path}.generator!=true]`,
+	`[${path}.async!=true]`,
 	`[${path}.params.length=1]`,
 	`[${path}.params.0.type="Identifier"]`
 ].join('');

--- a/rules/shared/simple-array-search-rule.js
+++ b/rules/shared/simple-array-search-rule.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {hasSideEffect, isParenthesized, findVariable} = require('eslint-utils');
-const {methodCallSelector} = require('../selectors');
+const {matches, methodCallSelector} = require('../selectors');
 const isFunctionSelfUsedInside = require('../utils/is-function-self-used-inside');
 
 const getBinaryExpressionSelector = path => [
@@ -15,26 +15,24 @@ const getFunctionSelector = path => [
 	`[${path}.params.length=1]`,
 	`[${path}.params.0.type="Identifier"]`
 ].join('');
-const callbackFunctionSelector = path => `:matches(${
+const callbackFunctionSelector = path => matches([
+	// Matches `foo.findIndex(bar => bar === baz)`
 	[
-		// Matches `foo.findIndex(bar => bar === baz)`
-		[
-			`[${path}.type="ArrowFunctionExpression"]`,
-			getFunctionSelector(path),
-			getBinaryExpressionSelector(`${path}.body`)
-		].join(''),
-		// Matches `foo.findIndex(bar => {return bar === baz})`
-		// Matches `foo.findIndex(function (bar) {return bar === baz})`
-		[
-			`:matches([${path}.type="ArrowFunctionExpression"], [${path}.type="FunctionExpression"])`,
-			getFunctionSelector(path),
-			`[${path}.body.type="BlockStatement"]`,
-			`[${path}.body.body.length=1]`,
-			`[${path}.body.body.0.type="ReturnStatement"]`,
-			getBinaryExpressionSelector(`${path}.body.body.0.argument`)
-		].join('')
-	].join(', ')
-})`;
+		`[${path}.type="ArrowFunctionExpression"]`,
+		getFunctionSelector(path),
+		getBinaryExpressionSelector(`${path}.body`)
+	].join(''),
+	// Matches `foo.findIndex(bar => {return bar === baz})`
+	// Matches `foo.findIndex(function (bar) {return bar === baz})`
+	[
+		`:matches([${path}.type="ArrowFunctionExpression"], [${path}.type="FunctionExpression"])`,
+		getFunctionSelector(path),
+		`[${path}.body.type="BlockStatement"]`,
+		`[${path}.body.body.length=1]`,
+		`[${path}.body.body.0.type="ReturnStatement"]`,
+		getBinaryExpressionSelector(`${path}.body.body.0.argument`)
+	].join('')
+]);
 const isIdentifierNamed = ({type, name}, expectName) => type === 'Identifier' && name === expectName;
 
 function simpleArraySearchRule({method, replacement}) {


### PR DESCRIPTION
Use `!=` seems safer than `=`, prevent cases like #1302

When running with lower ecma version , some property didn't present, so it could be `undefined`.