### PR TITLE
Simplify `prefer-array-flat`

### DIFF
--- a/docs/rules/prefer-array-flat.md
+++ b/docs/rules/prefer-array-flat.md
@@ -62,7 +62,7 @@ Type: `string[]`
 
 You can also check custom functions that flatten arrays.
 
-`_.flatten()`, `lodash.flatten()` and `underscore.flatten()` are checked by default.
+`_.flatten()`, `lodash.flatten()`, and `underscore.flatten()` are checked by default.
 
 Example:
 

--- a/docs/rules/prefer-array-flat.md
+++ b/docs/rules/prefer-array-flat.md
@@ -62,6 +62,8 @@ Type: `string[]`
 
 You can also check custom functions that flatten arrays.
 
+`_.flatten`, `lodash.flatten` and `underscore.flattern` are checked by default.
+
 Example:
 
 ```js

--- a/docs/rules/prefer-array-flat.md
+++ b/docs/rules/prefer-array-flat.md
@@ -62,7 +62,7 @@ Type: `string[]`
 
 You can also check custom functions that flatten arrays.
 
-`_.flatten`, `lodash.flatten` and `underscore.flattern` are checked by default.
+`_.flatten()`, `lodash.flatten()` and `underscore.flatten()` are checked by default.
 
 Example:
 


### PR DESCRIPTION
I don't know what I was thinking, the `lodash` flatten function can merge with functions in `options`.