### PR TITLE
Ensure no unexpected properties present in snapshot tests

### DIFF
--- a/test/prefer-module.mjs
+++ b/test/prefer-module.mjs
@@ -61,12 +61,6 @@ test({
 
 // `__dirname` and `__filename`
 test.snapshot({
-	testerOptions: {
-		globals: {
-			__dirname: true,
-			__filename: true
-		}
-	},
 	valid: [
 		outdent`
 			const __filename = 1;

--- a/test/utils/snapshot-rule-tester.mjs
+++ b/test/utils/snapshot-rule-tester.mjs
@@ -54,10 +54,19 @@ class SnapshotRuleTester {
 		const {test, config} = this;
 		const fixable = rule.meta && rule.meta.fixable;
 		const linter = new Linter();
+		const {valid, invalid, ...additionalProperties} = tests;
+		if (Object.keys(additionalProperties).length > 0) {
+			throw new Error('Unexpected snapshot test properties: ' + Object.keys(additionalProperties));
+		}
+
 		linter.defineRule(ruleId, rule);
 
-		for (const [index, testCase] of tests.valid.entries()) {
-			const {code, options, filename} = typeof testCase === 'string' ? {code: testCase} : testCase;
+		for (const [index, testCase] of valid.entries()) {
+			const {code, options, filename, ...additionalProperties} = typeof testCase === 'string' ? {code: testCase} : testCase;
+			if (Object.keys(additionalProperties).length > 0) {
+				throw new Error('Unexpected valid snapshot test case properties: ' + Object.keys(additionalProperties));
+			}
+
 			const verifyConfig = getVerifyConfig(ruleId, config, options);
 
 			test(
@@ -72,9 +81,14 @@ class SnapshotRuleTester {
 			);
 		}
 
-		for (const [index, testCase] of tests.invalid.entries()) {
-			const {code, options, filename} = typeof testCase === 'string' ? {code: testCase} : testCase;
+		for (const [index, testCase] of invalid.entries()) {
+			const {code, options, filename, ...additionalProperties} = typeof testCase === 'string' ? {code: testCase} : testCase;
+			if (Object.keys(additionalProperties).length > 0) {
+				throw new Error('Unexpected invalid snapshot test case properties: ' + Object.keys(additionalProperties));
+			}
+
 			const verifyConfig = getVerifyConfig(ruleId, config, options);
+
 			test(
 				outdent`
 					Invalid #${index + 1}


### PR DESCRIPTION
The snapshot tests in this plugin have a custom implementation and don't benefit from all the verification checks that ESLint performs on standard ESLint tests to ensure they are properly formed ([example from ESLint 7](https://eslint.org/docs/user-guide/migrating-to-7.0.0#rule-tester-strict)).

We can help ensure developers working in this plugin do not make mistakes while writing snapshot tests by throwing an exception when unexpected properties (like `errors`) are included in the snapshot test cases.

Example test cases with unexpected properties:

```js
import {getTester} from './utils/test.mjs';

const {test} = getTester(import.meta);

test.snapshot({
	foo: 123,
	bar: 456,
	valid: [
        {code: 'abc', foo: 123}
    ],
	invalid: [
		{code: 'abc', foo: 123},
    ]
});
```

Example exception output:

```js
Uncaught exception in test/prefer-string-starts-ends-with.mjs

Error: Unexpected snapshot test properties: foo,bar
```