### PR TITLE
Use `meta.hasSuggestions` for suggestable rules to prepare for ESLint 8

### DIFF
--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -159,14 +159,14 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Use destructured variables over properties.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
 		messages: {
 			[MESSAGE_ID]: 'Use destructured variables over properties.',
 			[MESSAGE_ID_SUGGEST]: 'Replace `{{expression}}` with destructured property `{{property}}`.'
-		}
+		},
+		hasSuggestions: true
 	}
 };

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -203,11 +203,11 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Enforce explicitly comparing the `length` or `size` property of a value.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema,
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -173,10 +173,10 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Prevent passing a function reference directly to iterator methods.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -126,11 +126,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Enforce combining multiple `Array#push()` into one call.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema,
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -84,11 +84,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Disallow `new Array()`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -87,11 +87,11 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -132,11 +132,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Disallow the use of the `null` literal.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema,
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -319,11 +319,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `.find(…)` over the first element from `.filter(…)`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-array-index-of.js
+++ b/rules/prefer-array-index-of.js
@@ -15,11 +15,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `Array#indexOf()` over `Array#findIndex()` when looking for the index of an item.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -98,11 +98,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `.some(…)` over `.filter(…).length` check and `.find(…)`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -304,11 +304,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `.at()` method for index access and `String#charAt()`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema,
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -215,14 +215,14 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer default parameters over reassignment.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
 		messages: {
 			[MESSAGE_ID]: 'Prefer default parameters over reassignment.',
 			[MESSAGE_ID_SUGGEST]: 'Replace reassignment with default parameter.'
-		}
+		},
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -74,11 +74,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -85,14 +85,14 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `.includes()` over `.indexOf()` and `Array#some()` when checking for existence or non-existence.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
 		messages: {
 			...messages,
 			...includesOverSomeRule.messages
-		}
+		},
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-math-trunc.js
+++ b/rules/prefer-math-trunc.js
@@ -102,11 +102,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Enforce the use of `Math.trunc` instead of bitwise operators.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-module.js
+++ b/rules/prefer-module.js
@@ -310,11 +310,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer JavaScript modules (ESM) over CommonJS.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -140,11 +140,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `Number` static properties over global ones.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema,
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -195,11 +195,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `Set#has()` over `Array#includes()` when checking for existence or non-existence.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -423,11 +423,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer the spread operator over `Array.from(…)`, `Array#concat(…)` and `Array#slice()`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -178,11 +178,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer `String#startsWith()` & `String#endsWith()` over `RegExp#test()`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -95,10 +95,10 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Prefer top-level await over top-level promises and async function calls.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/require-post-message-target-origin.js
+++ b/rules/require-post-message-target-origin.js
@@ -63,10 +63,10 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Enforce using the `targetOrigin` argument with `window.postMessage()`.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		schema: [],
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -178,11 +178,11 @@ module.exports = {
 		type: 'suggestion',
 		docs: {
 			description: 'Enforce better string content.',
-			url: getDocumentationUrl(__filename),
-			suggestion: true
+			url: getDocumentationUrl(__filename)
 		},
 		fixable: 'code',
 		schema,
-		messages
+		messages,
+		hasSuggestions: true
 	}
 };

--- a/scripts/generate-rules-table.mjs
+++ b/scripts/generate-rules-table.mjs
@@ -25,8 +25,7 @@ const rulesTableContent = ruleNames
 	.map(ruleName => {
 		// Check which emojis to show for this rule.
 		const isRecommended = configs.recommended.rules[`unicorn/${ruleName}`] === 'error';
-		const isFixable = rules[ruleName].meta.fixable;
-		const hasSuggestions = rules[ruleName].meta.docs.suggestion; // Property likely to change in ESLint 8: https://github.com/eslint/eslint/issues/14312
+		const {fixable, hasSuggestions} = rules[ruleName].meta;
 
 		const url = `docs/rules/${ruleName}.md`;
 		const link = `[${ruleName}](${url})`;
@@ -37,7 +36,7 @@ const rulesTableContent = ruleNames
 			link,
 			description,
 			isRecommended ? EMOJI_RECOMMENDED : '',
-			isFixable ? EMOJI_FIXABLE : '',
+			fixable ? EMOJI_FIXABLE : '',
 			hasSuggestions ? EMOJI_HAS_SUGGESTIONS : ''
 		].join(' | ')} |`;
 	})

--- a/test/utils/snapshot-rule-tester.mjs
+++ b/test/utils/snapshot-rule-tester.mjs
@@ -148,9 +148,9 @@ class SnapshotRuleTester {
 						let messageForSnapshot = visualizeEslintMessage(code, message);
 
 						const {suggestions = []} = message;
-						if (suggestions.length > 0 && rule.meta.docs.suggestion !== true) {
+						if (suggestions.length > 0 && rule.meta.hasSuggestions !== true) {
 							// This check will no longer be necessary if this change lands in ESLint 8: https://github.com/eslint/eslint/issues/14312
-							throw new Error('Rule with suggestion is missing `meta.docs.suggestion`.');
+							throw new Error('Rule with suggestion is missing `meta.hasSuggestions`.');
 						}
 
 						for (const [index, suggestion] of suggestions.entries()) {

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -16,9 +16,9 @@ function normalizeInvalidTest(test, rule) {
 		throw new Error('Remove output if your test do not fix code.');
 	}
 
-	if (Array.isArray(errors) && errors.some(error => error.suggestions) && rule.meta.docs.suggestion !== true) {
+	if (Array.isArray(errors) && errors.some(error => error.suggestions) && rule.meta.hasSuggestions !== true) {
 		// This check will no longer be necessary if this change lands in ESLint 8: https://github.com/eslint/eslint/issues/14312
-		throw new Error('Rule with suggestion is missing `meta.docs.suggestion`.');
+		throw new Error('Rule with suggestion is missing `meta.hasSuggestions`.');
 	}
 
 	return {


### PR DESCRIPTION
The change to require suggestable rules to have `meta.hasSuggestions` has been accepted and mentioned in the blog post for the upcoming ESLint 8 breaking changes. So we should adopt this change now to ensure we are compatible with ESLint 8 as soon as possible. The old property `meta.docs.suggestion` was unused anyway.

https://eslint.org/blog/2021/06/whats-coming-in-eslint-8.0.0#rules-with-suggestions-now-require-the-metahassuggestions-property

Follow-up to #1306 / #1292.
