### PR TITLE
`expiring-todo-comments`: More helpful error when no conditions

### DIFF
--- a/docs/rules/expiring-todo-comments.md
+++ b/docs/rules/expiring-todo-comments.md
@@ -141,7 +141,7 @@ You can also use block comments to specify TODOs with conditions. Each line can 
 
 This rule implements [`eslint/no-warning-comments`](https://eslint.org/docs/rules/no-warning-comments).
 
-The sole difference is that first we check for **valid conditions** to apply this rule. If no valid conditions are met, we fall back to `eslint/no-warning-comments` if [`allowWarningComments`](#allowWarningComments) is set to `false` (default `true`) and you'll see something like `Unexpected 'todo' comment.`
+The sole difference is that first we check for **valid conditions** to apply this rule. If no valid conditions are met, we fall back to `eslint/no-warning-comments` if [`allowWarningComments`](#allowWarningComments) is set to `false` (default `true`) and you'll see something like `Unexpected 'todo' comment without any conditions.`
 
 The reason behind this is that now that you have a powerful rule to make sure there are no stray TODOs on your code, you should strive for best pratices. Don't just add TODO comments and leave them forever. Define conditions to justify the presence of warning comments.
 

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -17,7 +17,7 @@ const MESSAGE_ID_ENGINE_MATCHES = 'unicorn/engineMatches';
 const MESSAGE_ID_REMOVE_WHITESPACE = 'unicorn/removeWhitespaces';
 const MESSAGE_ID_MISSING_AT_SYMBOL = 'unicorn/missingAtSymbol';
 
-// no prefix for message that overrides core rule message with a more specific one
+// No prefix for message that overrides core rule message with a more specific one
 const MESSSAGE_ID_CORE_RULE_UNEXPECTED_COMMENT = 'unexpectedComment';
 const messages = {
 	[MESSAGE_ID_AVOID_MULTIPLE_DATES]:

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -16,6 +16,9 @@ const MESSAGE_ID_VERSION_MATCHES = 'unicorn/versionMatches';
 const MESSAGE_ID_ENGINE_MATCHES = 'unicorn/engineMatches';
 const MESSAGE_ID_REMOVE_WHITESPACE = 'unicorn/removeWhitespaces';
 const MESSAGE_ID_MISSING_AT_SYMBOL = 'unicorn/missingAtSymbol';
+
+// no prefix for message that overrides core rule message with a more specific one
+const MESSSAGE_ID_CORE_RULE_UNEXPECTED_COMMENT = 'unexpectedComment';
 const messages = {
 	[MESSAGE_ID_AVOID_MULTIPLE_DATES]:
 		'Avoid using multiple expiration dates in TODO: {{expirationDates}}. {{message}}',
@@ -37,7 +40,9 @@ const messages = {
 		'Avoid using whitespace on TODO argument. On \'{{original}}\' use \'{{fix}}\'. {{message}}',
 	[MESSAGE_ID_MISSING_AT_SYMBOL]:
 		'Missing \'@\' on TODO argument. On \'{{original}}\' use \'{{fix}}\'. {{message}}',
-	...baseRule.meta.messages
+	...baseRule.meta.messages,
+	[MESSSAGE_ID_CORE_RULE_UNEXPECTED_COMMENT]:
+		'Unexpected \'{{matchedTerm}}\' comment without any conditions: \'{{comment}}\'.'
 };
 
 const packageResult = readPkgUp.sync();

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -17,7 +17,7 @@ const MESSAGE_ID_ENGINE_MATCHES = 'unicorn/engineMatches';
 const MESSAGE_ID_REMOVE_WHITESPACE = 'unicorn/removeWhitespaces';
 const MESSAGE_ID_MISSING_AT_SYMBOL = 'unicorn/missingAtSymbol';
 
-// No prefix for message that overrides core rule message with a more specific one
+// Override of core rule message with a more specific one - no prefix
 const MESSSAGE_ID_CORE_RULE_UNEXPECTED_COMMENT = 'unexpectedComment';
 const messages = {
 	[MESSAGE_ID_AVOID_MULTIPLE_DATES]:

--- a/test/expiring-todo-comments.mjs
+++ b/test/expiring-todo-comments.mjs
@@ -43,7 +43,7 @@ const missingAtSymbolError = (bad, good, message) => ({
 });
 
 const noWarningCommentError = comment => ({
-	message: `Unexpected 'todo' comment: '${comment}'.`
+	message: `Unexpected 'todo' comment without any conditions: '${comment}'.`
 });
 
 test({


### PR DESCRIPTION
Fixes #744

This overrides the `no-warning-comments` default message for `TODO`s without any conditions, when `allowWarningComments` is set to false, to give a hint that the `TODO` would be allowed if it had a condition.

When I first saw `Unexpected "todo" comment` I thought "oh, this is a rule which aggressively says 'todos are bad'", and I turned it off. (Later, I spent a bunch of time implementing a worse version of `expiring-todo-comments`, which parsed ISO dates. Eventually I stumbled across the docs and realised how useful this rule really is.)

This change reduces the risk of the above scenario.