### PR TITLE
`throw-new-error`: Fix an edge case

### DIFF
--- a/rules/utils/should-add-parentheses-to-new-expression-callee.js
+++ b/rules/utils/should-add-parentheses-to-new-expression-callee.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// Copied from https://github.com/eslint/eslint/blob/aa87329d919f569404ca573b439934552006572f/lib/rules/no-extra-parens.js#L448
+/**
+Check if a member expression contains a call expression
+
+@param {ASTNode} node MemberExpression node to evaluate
+@returns {boolean} true if found, false if not
+*/
+function doesMemberExpressionContainCallExpression(node) {
+	let currentNode = node.object;
+	let currentNodeType = node.object.type;
+
+	while (currentNodeType === 'MemberExpression') {
+		currentNode = currentNode.object;
+		currentNodeType = currentNode.type;
+	}
+
+	return currentNodeType === 'CallExpression';
+}
+
+/**
+Check if parentheses should be added to a `node` when it's used as `callee` of `NewExpression`.
+
+@param {Node} node - The AST node to check.
+@returns {boolean}
+*/
+function shouldAddParenthesesToNewExpressionCallee(node) {
+	return node.type === 'MemberExpression' && doesMemberExpressionContainCallExpression(node);
+}
+
+module.exports = shouldAddParenthesesToNewExpressionCallee;

--- a/rules/utils/should-add-parentheses-to-new-expression-callee.js
+++ b/rules/utils/should-add-parentheses-to-new-expression-callee.js
@@ -2,10 +2,10 @@
 
 // Copied from https://github.com/eslint/eslint/blob/aa87329d919f569404ca573b439934552006572f/lib/rules/no-extra-parens.js#L448
 /**
-Check if a member expression contains a call expression
+Check if a member expression contains a call expression.
 
-@param {ASTNode} node MemberExpression node to evaluate
-@returns {boolean} true if found, false if not
+@param {ASTNode} node - The `MemberExpression` node to evaluate.
+@returns {boolean} true if found, false if not.
 */
 function doesMemberExpressionContainCallExpression(node) {
 	let currentNode = node.object;

--- a/test/throw-new-error.mjs
+++ b/test/throw-new-error.mjs
@@ -119,6 +119,11 @@ test({
 			errors
 		},
 		{
+			code: 'throw (( URIError() ))',
+			output: 'throw (( new URIError() ))',
+			errors
+		},
+		{
 			code: 'throw (( URIError ))()',
 			output: 'throw new (( URIError ))()',
 			errors

--- a/test/throw-new-error.mjs
+++ b/test/throw-new-error.mjs
@@ -117,6 +117,26 @@ test({
 			code: 'throw URIError()',
 			output: 'throw new URIError()',
 			errors
+		},
+		{
+			code: 'throw (( URIError ))()',
+			output: 'throw new (( URIError ))()',
+			errors
+		},
+		{
+			code: 'throw getGlobalThis().Error()',
+			output: 'throw new (getGlobalThis().Error)()',
+			errors
+		},
+		{
+			code: 'throw utils.getGlobalThis().Error()',
+			output: 'throw new (utils.getGlobalThis().Error)()',
+			errors
+		},
+		{
+			code: 'throw (( getGlobalThis().Error ))()',
+			output: 'throw new (( getGlobalThis().Error ))()',
+			errors
 		}
 	]
 });


### PR DESCRIPTION
When the Error constructor is a `MemberExpression` contains `CallExpression`, it should be parenthesized.