### PR TITLE
[docs] Add call stack size benefit to `no-array-for-each`

### DIFF
--- a/docs/rules/no-array-for-each.md
+++ b/docs/rules/no-array-for-each.md
@@ -5,6 +5,7 @@ Benefits of [`for…of` statement](https://developer.mozilla.org/en-US/docs/Web/
 - Faster
 - Better readability
 - Ability to exit early with `break` or `return`
+- Less likely to run into `Maximum call stack size exceeded` errors
 
 This rule is partly fixable.
 


### PR DESCRIPTION
Large arrays will eventually run into `Maximum call stack size exceeded` errors, whereas a `for .. of` will not, since it doesn't add a function call to the stack for every iteration.
