### PR TITLE
Refactor `avoidCapture` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"xo"
 	],
 	"dependencies": {
+		"@babel/types": "^7.14.5",
 		"ci-info": "^3.2.0",
 		"clean-regexp": "^1.0.0",
 		"eslint-template-visitor": "^2.3.2",
@@ -46,7 +47,6 @@
 		"pluralize": "^8.0.0",
 		"read-pkg-up": "^7.0.1",
 		"regexp-tree": "^0.1.23",
-		"reserved-words": "^0.1.2",
 		"safe-regex": "^2.1.1",
 		"semver": "^7.3.5"
 	},

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"xo"
 	],
 	"dependencies": {
-		"@babel/types": "^7.14.5",
+		"@babel/helper-validator-identifier": "^7.14.5",
 		"ci-info": "^3.2.0",
 		"clean-regexp": "^1.0.0",
 		"eslint-template-visitor": "^2.3.2",

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -33,8 +33,6 @@ const selector = matches([
 ]);
 
 const create = context => {
-	const {ecmaVersion} = context.parserOptions;
-
 	const options = {
 		name: 'error',
 		ignore: [],
@@ -79,7 +77,7 @@ const create = context => {
 				variable.scope,
 				...variable.references.map(({from}) => from)
 			];
-			const fixedName = avoidCapture(expectedName, scopes, ecmaVersion);
+			const fixedName = avoidCapture(expectedName, scopes);
 
 			return {
 				node,

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -85,11 +85,11 @@ const create = context => {
 				data: {
 					originalName,
 					fixedName: fixedName || expectedName
-				},
+				}
 			};
 
 			if (fixedName) {
-				problem.fix = fixer => renameVariable(variable, fixedName, fixer)
+				problem.fix = fixer => renameVariable(variable, fixedName, fixer);
 			}
 
 			return problem;

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -79,15 +79,20 @@ const create = context => {
 			];
 			const fixedName = avoidCapture(expectedName, scopes);
 
-			return {
+			const problem = {
 				node,
 				messageId: MESSAGE_ID,
 				data: {
 					originalName,
-					fixedName
+					fixedName: fixedName || expectedName
 				},
-				fix: fixer => renameVariable(variable, fixedName, fixer)
 			};
+
+			if (fixedName) {
+				problem.fix = fixer => renameVariable(variable, fixedName, fixer)
+			}
+
+			return problem;
 		}
 	};
 };

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -52,7 +52,6 @@ const isChildInParentScope = (child, parent) => {
 };
 
 const create = context => {
-	const {ecmaVersion} = context.parserOptions;
 	const source = context.getSourceCode();
 	const declarations = new Map();
 
@@ -108,7 +107,7 @@ const create = context => {
 				}
 
 				// Destructured member collides with an existing identifier
-				if (avoidCapture(member, [memberScope], ecmaVersion) !== member) {
+				if (avoidCapture(member, [memberScope]) !== member) {
 					return;
 				}
 			}

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -355,7 +355,7 @@ const create = context => {
 
 					const index = indexIdentifierName;
 					const element = elementIdentifierName ||
-						avoidCapture(singular(arrayIdentifierName) || defaultElementName, getChildScopesRecursive(bodyScope), context.parserOptions.ecmaVersion);
+						avoidCapture(singular(arrayIdentifierName) || defaultElementName, getChildScopesRecursive(bodyScope));
 					const array = arrayIdentifierName;
 
 					let declarationElement = element;

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -299,7 +299,7 @@ const create = context => {
 					const singularName = singular(node.id.name);
 					if (singularName) {
 						// Rename variable to be singularized now that it refers to a single item in the array instead of the entire array.
-						const singularizedName = avoidCapture(singularName, getChildScopesRecursive(scope), context.parserOptions.ecmaVersion);
+						const singularizedName = avoidCapture(singularName, getChildScopesRecursive(scope));
 						yield * renameVariable(variable, singularizedName, fixer);
 
 						// Prevent possible variable conflicts

--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -216,7 +216,7 @@ const create = context => {
 					let generateNewVariables = false;
 					if (type === 'ThrowStatement') {
 						const scopes = getScopes(scope);
-						const errorName = avoidCapture('error', scopes, context.parserOptions.ecmaVersion, isSafeName);
+						const errorName = avoidCapture('error', scopes, isSafeName);
 
 						for (const scope of scopes) {
 							if (!scopeToNamesGeneratedByFixer.has(scope)) {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -423,7 +423,7 @@ const create = context => {
 			message: formatMessage(definition.name.name, variableReplacements, 'variable')
 		};
 
-		if (variableReplacements.total === 1 && shouldFix(variable)) {
+		if (variableReplacements.total === 1 && shouldFix(variable) && variableReplacements.samples[0]) {
 			const [replacement] = variableReplacements.samples;
 
 			for (const scope of scopes) {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -313,7 +313,6 @@ const isInternalImport = node => {
 };
 
 const create = context => {
-	const {ecmaVersion} = context.parserOptions;
 	const options = prepareOptions(context.options[0]);
 	const filenameWithExtension = context.getPhysicalFilename();
 
@@ -416,7 +415,7 @@ const create = context => {
 			variable.scope
 		];
 		variableReplacements.samples = variableReplacements.samples.map(
-			name => avoidCapture(name, scopes, ecmaVersion, isSafeName)
+			name => avoidCapture(name, scopes, isSafeName)
 		);
 
 		const problem = {

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -6,13 +6,78 @@ const {
 }= require("@babel/helper-validator-identifier");
 const resolveVariableName = require('./resolve-variable-name.js');
 
+// https://github.com/microsoft/TypeScript/issues/2536#issuecomment-87194347
+const typescriptReservedWords = new Set([
+	'break',
+	'case',
+	'catch',
+	'class',
+	'const',
+	'continue',
+	'debugger',
+	'default',
+	'delete',
+	'do',
+	'else',
+	'enum',
+	'export',
+	'extends',
+	'false',
+	'finally',
+	'for',
+	'function',
+	'if',
+	'import',
+	'in',
+	'instanceof',
+	'new',
+	'null',
+	'return',
+	'super',
+	'switch',
+	'this',
+	'throw',
+	'true',
+	'try',
+	'typeof',
+	'var',
+	'void',
+	'while',
+	'with',
+	'as',
+	'implements',
+	'interface',
+	'let',
+	'package',
+	'private',
+	'protected',
+	'public',
+	'static',
+	'yield',
+	'any',
+	'boolean',
+	'constructor',
+	'declare',
+	'get',
+	'module',
+	'require',
+	'number',
+	'set',
+	'string',
+	'symbol',
+	'type',
+	'from',
+	'of'
+]);
+
 // Copied from https://github.com/babel/babel/blob/fce35af69101c6b316557e28abf60bdbf77d6a36/packages/babel-types/src/validators/isValidIdentifier.ts#L7
 // Use this function instead of `require('@babel/types').isIdentifier`, since `@babel/helper-validator-identifier` package is much smaller
 const isValidIdentifier = name =>
 	typeof name === 'string' &&
 	!isKeyword(name) &&
 	!isStrictReservedWord(name, true) &&
-	isIdentifierName(name);
+	isIdentifierName(name) &&
+	!typescriptReservedWords.has(name);
 
 /*
 Unresolved reference is probably from the global scope. We should avoid using that name.

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -1,6 +1,18 @@
 'use strict';
-const {isValidES3Identifier} = require('@babel/types');
+const {
+  isIdentifierName,
+  isStrictReservedWord,
+  isKeyword,
+}= require("@babel/helper-validator-identifier");
 const resolveVariableName = require('./resolve-variable-name.js');
+
+// Copied from https://github.com/babel/babel/blob/fce35af69101c6b316557e28abf60bdbf77d6a36/packages/babel-types/src/validators/isValidIdentifier.ts#L7
+// Use this function instead of `require('@babel/types').isIdentifier`, since `@babel/helper-validator-identifier` is much smaller
+const isValidIdentifier = name =>
+	typeof name === 'string' &&
+	!isKeyword(name) &&
+	!isStrictReservedWord(name, true) &&
+	isIdentifierName(name);
 
 /*
 Unresolved reference is probably from the global scope. We should avoid using that name.
@@ -24,7 +36,7 @@ const isUnresolvedName = (name, scope) =>
 	scope.childScopes.some(scope => isUnresolvedName(name, scope));
 
 const isSafeName = (name, scopes) =>
-	isValidES3Identifier(name) &&
+	isValidIdentifier(name) &&
 	name !== 'arguments' &&
 	!scopes.some(scope => resolveVariableName(name, scope) || isUnresolvedName(name, scope));
 

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -29,7 +29,7 @@ const isUnresolvedName = (name, scopes) => scopes.some(scope =>
 
 const isSafeName = (name, scopes) =>
 	!someScopeHasVariableName(name, scopes) &&
-	!isValidES3Identifier(name) &&
+	isValidES3Identifier(name) &&
 	!isUnresolvedName(name, scopes);
 
 const alwaysTrue = () => true;
@@ -59,10 +59,11 @@ Useful when you want to rename a variable (or create a new variable) while being
 */
 module.exports = (name, scopes, isSafe = alwaysTrue) => {
 	let index = 0;
-	let indexifiedName = name;
+let indexifiedName = indexifyName(name, index);
 	while (!isSafeName(indexifiedName, scopes) || !isSafe(indexifiedName, scopes)) {
 		index++;
 		indexifiedName = indexifyName(name, index);
+
 	}
 
 	return indexifiedName;

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -30,6 +30,7 @@ const isUnresolvedName = (name, scopes) => scopes.some(scope =>
 const isSafeName = (name, scopes) =>
 	!someScopeHasVariableName(name, scopes) &&
 	isValidES3Identifier(name) &&
+	name !== 'arguments' &&
 	!isUnresolvedName(name, scopes);
 
 const alwaysTrue = () => true;

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -7,7 +7,7 @@ const {
 const resolveVariableName = require('./resolve-variable-name.js');
 
 // Copied from https://github.com/babel/babel/blob/fce35af69101c6b316557e28abf60bdbf77d6a36/packages/babel-types/src/validators/isValidIdentifier.ts#L7
-// Use this function instead of `require('@babel/types').isIdentifier`, since `@babel/helper-validator-identifier` is much smaller
+// Use this function instead of `require('@babel/types').isIdentifier`, since `@babel/helper-validator-identifier` package is much smaller
 const isValidIdentifier = name =>
 	typeof name === 'string' &&
 	!isKeyword(name) &&

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -1,33 +1,9 @@
 'use strict';
-const reservedWords = require('reserved-words');
+const {isValidES3Identifier} = require('@babel/types');
 const resolveVariableName = require('./resolve-variable-name.js');
 
 const indexifyName = (name, index) => name + '_'.repeat(index);
-
-const scopeHasArgumentsSpecial = scope => {
-	while (scope) {
-		/* istanbul ignore next: `someScopeHasVariableName` seems already handle this */
-		if (scope.taints.get('arguments')) {
-			return true;
-		}
-
-		scope = scope.upper;
-	}
-
-	return false;
-};
-
 const someScopeHasVariableName = (name, scopes) => scopes.some(scope => resolveVariableName(name, scope));
-
-const someScopeIsStrict = scopes => scopes.some(scope => scope.isStrict);
-
-const nameCollidesWithArgumentsSpecial = (name, scopes, isStrict) => {
-	if (name !== 'arguments') {
-		return false;
-	}
-
-	return isStrict || scopes.some(scope => scopeHasArgumentsSpecial(scope));
-};
 
 /*
 Unresolved reference is probably from the global scope. We should avoid using that name.
@@ -51,16 +27,10 @@ const isUnresolvedName = (name, scopes) => scopes.some(scope =>
 	isUnresolvedName(name, scope.childScopes)
 );
 
-const isSafeName = (name, scopes, ecmaVersion, isStrict) => {
-	ecmaVersion = Math.min(6, ecmaVersion); // 6 is the latest version understood by `reservedWords`
-
-	return (
-		!someScopeHasVariableName(name, scopes) &&
-		!reservedWords.check(name, ecmaVersion, isStrict) &&
-		!nameCollidesWithArgumentsSpecial(name, scopes, isStrict) &&
-		!isUnresolvedName(name, scopes)
-	);
-};
+const isSafeName = (name, scopes) =>
+	!someScopeHasVariableName(name, scopes) &&
+	!isValidES3Identifier(name) &&
+	!isUnresolvedName(name, scopes);
 
 const alwaysTrue = () => true;
 
@@ -84,19 +54,13 @@ Useful when you want to rename a variable (or create a new variable) while being
 
 @param {string} name - The desired name for a new variable.
 @param {Scope[]} scopes - The list of scopes the new variable will be referenced in.
-@param {number} ecmaVersion - The language version, get it from `context.parserOptions.ecmaVersion`.
 @param {isSafe} [isSafe] - Rule-specific name check function.
 @returns {string} - Either `name` as is, or a string like `${name}_` suffixed with underscores to make the name unique.
 */
-module.exports = (name, scopes, ecmaVersion, isSafe = alwaysTrue) => {
-	const isStrict = someScopeIsStrict(scopes);
-
+module.exports = (name, scopes, isSafe = alwaysTrue) => {
 	let index = 0;
-	let indexifiedName = indexifyName(name, index);
-	while (
-		!isSafeName(indexifiedName, scopes, ecmaVersion, isStrict) ||
-		!isSafe(indexifiedName, scopes)
-	) {
+	let indexifiedName = name;
+	while (!isSafeName(indexifiedName, scopes) || !isSafe(indexifiedName, scopes)) {
 		index++;
 		indexifiedName = indexifyName(name, index);
 	}

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -36,7 +36,6 @@ const isUnresolvedName = (name, scope) =>
 	scope.childScopes.some(scope => isUnresolvedName(name, scope));
 
 const isSafeName = (name, scopes) =>
-	isValidIdentifier(name) &&
 	name !== 'arguments' &&
 	!scopes.some(scope => resolveVariableName(name, scope) || isUnresolvedName(name, scope));
 
@@ -66,6 +65,15 @@ Useful when you want to rename a variable (or create a new variable) while being
 @returns {string} - Either `name` as is, or a string like `${name}_` suffixed with underscores to make the name unique.
 */
 module.exports = (name, scopes, isSafe = alwaysTrue) => {
+	if (!isValidIdentifier(name)) {
+		name += '_';
+
+		if (!isValidIdentifier(name)) {
+			return;
+		}
+	}
+
+
 	while (!isSafeName(name, scopes) || !isSafe(name, scopes)) {
 		name += '_';
 	}

--- a/rules/utils/avoid-capture.js
+++ b/rules/utils/avoid-capture.js
@@ -1,9 +1,9 @@
 'use strict';
 const {
-  isIdentifierName,
-  isStrictReservedWord,
-  isKeyword,
-}= require("@babel/helper-validator-identifier");
+	isIdentifierName,
+	isStrictReservedWord,
+	isKeyword
+} = require('@babel/helper-validator-identifier');
 const resolveVariableName = require('./resolve-variable-name.js');
 
 // https://github.com/microsoft/TypeScript/issues/2536#issuecomment-87194347
@@ -77,6 +77,7 @@ const isValidIdentifier = name =>
 	!isKeyword(name) &&
 	!isStrictReservedWord(name, true) &&
 	isIdentifierName(name) &&
+	name !== 'arguments' &&
 	!typescriptReservedWords.has(name);
 
 /*
@@ -101,7 +102,6 @@ const isUnresolvedName = (name, scope) =>
 	scope.childScopes.some(scope => isUnresolvedName(name, scope));
 
 const isSafeName = (name, scopes) =>
-	name !== 'arguments' &&
 	!scopes.some(scope => resolveVariableName(name, scope) || isUnresolvedName(name, scope));
 
 const alwaysTrue = () => true;
@@ -137,7 +137,6 @@ module.exports = (name, scopes, isSafe = alwaysTrue) => {
 			return;
 		}
 	}
-
 
 	while (!isSafeName(name, scopes) || !isSafe(name, scopes)) {
 		name += '_';

--- a/test/catch-error-name.mjs
+++ b/test/catch-error-name.mjs
@@ -508,6 +508,23 @@ test({
 			options: [{name: 'exception'}]
 		},
 
+		// Should not run into an infinity loop
+		{
+			code: 'try {} catch (e) {}',
+			errors: [generateError('e', 'has_space_after ')],
+			options: [{name: 'has_space_after '}]
+		},
+		{
+			code: 'try {} catch (e) {}',
+			errors: [generateError('e', '1_start_with_a_number')],
+			options: [{name: '1_start_with_a_number'}]
+		},
+		{
+			code: 'try {} catch (e) {}',
+			errors: [generateError('e', '_){} evilCode; if(false')],
+			options: [{name: '_){} evilCode; if(false'}]
+		},
+
 		// `ignore`
 		{
 			code: 'try {} catch (notMatching) {}',

--- a/test/prefer-array-find.mjs
+++ b/test/prefer-array-find.mjs
@@ -784,6 +784,17 @@ test({
 			`,
 			errors: [{messageId: ERROR_DECLARATION}]
 		},
+		{
+			code: outdent`
+				const packages = array.filter(bar);
+				console.log(packages[0]);
+			`,
+			output: outdent`
+				const package_ = array.find(bar);
+				console.log(package_);
+			`,
+			errors: [{messageId: ERROR_DECLARATION}]
+		},
 
 		// Not fixable
 		{

--- a/test/prefer-array-find.mjs
+++ b/test/prefer-array-find.mjs
@@ -795,6 +795,17 @@ test({
 			`,
 			errors: [{messageId: ERROR_DECLARATION}]
 		},
+		{
+			code: outdent`
+				const symbols = array.filter(bar);
+				console.log(symbols[0]);
+			`,
+			output: outdent`
+				const symbol_ = array.find(bar);
+				console.log(symbol_);
+			`,
+			errors: [{messageId: ERROR_DECLARATION}]
+		},
 
 		// Not fixable
 		{

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1316,6 +1316,16 @@ test({
 			output: 'function a() {try {} catch(arguments_) {}}',
 			options: customOptions,
 			errors: createErrors()
+		},
+		{
+			code: 'var one',
+			options: [{replacements: {one: {'1': true}}}],
+			errors: createErrors()
+		},
+		{
+			code: 'var one_two',
+			options: [{replacements: {one: {'first': true, '1': true}}}],
+			errors: createErrors()
 		}
 	]
 });

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1319,12 +1319,12 @@ test({
 		},
 		{
 			code: 'var one',
-			options: [{replacements: {one: {'1': true}}}],
+			options: [{replacements: {one: {1: true}}}],
 			errors: createErrors()
 		},
 		{
 			code: 'var one_two',
-			options: [{replacements: {one: {'first': true, '1': true}}}],
+			options: [{replacements: {one: {first: true, 1: true}}}],
 			errors: createErrors()
 		}
 	]

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1295,7 +1295,7 @@ test({
 
 		{
 			code: 'var y',
-			output: 'var yield',
+			output: 'var yield_',
 			options: customOptions,
 			errors: createErrors()
 		},


### PR DESCRIPTION
Reason behind this change, the new version of ESLint allows [`ecmaVersion: "latest"`](https://github.com/eslint/eslint/pull/14720), and this part don't understand it.

Let's not care about `ecmaVersion` and strict mode, just use the safest strategy.

WDYT? @futpib