### PR TITLE
`prevent-abbreviations`: Add `def`

### DIFF
--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -41,6 +41,9 @@ module.exports.defaultReplacements = {
 		database: true
 	},
 	def: {
+		defer: true,
+		deferred: true,
+		define: true,
 		definition: true
 	},
 	dest: {

--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -40,6 +40,9 @@ module.exports.defaultReplacements = {
 	db: {
 		database: true
 	},
+	def: {
+		definition: true
+	},
 	dest: {
 		destination: true
 	},


### PR DESCRIPTION
Just added eslint-plugin-unicorn to my project, and while straightening out my code, I noticed I used "def" as an abbreviation.  Not sure if it means "definition" to everyone else, but it does to me, : )
