### PR TITLE
Add `allowSimpleOperations` option to `no-array-reduce` rule

### DIFF
--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -65,7 +65,7 @@ Set it to `false` to disable reduce completely.
 
 ```js
 // eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": true}]
-arr.reduce((total, item) => total + item) // Passes
+array.reduce((total, item) => total + item) // Passes
 ```
 
 ```js

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -1,6 +1,8 @@
 # Disallow `Array#reduce()` and `Array#reduceRight()`
 
-`Array#reduce()` and `Array#reduceRight()` usually result in [hard-to-read](https://twitter.com/jaffathecake/status/1213077702300852224) and [less performant](https://www.richsnapp.com/article/2019/06-09-reduce-spread-anti-pattern) code. In almost every case, it can be replaced by `.map`, `.filter`, or a `for-of` loop. It's only somewhat useful in the rare case of summing up numbers.
+`Array#reduce()` and `Array#reduceRight()` usually result in [hard-to-read](https://twitter.com/jaffathecake/status/1213077702300852224) and [less performant](https://www.richsnapp.com/article/2019/06-09-reduce-spread-anti-pattern) code. In almost every case, it can be replaced by `.map`, `.filter`, or a `for-of` loop.
+
+It's only somewhat useful in the rare case of summing up numbers, which is allowed by default.
 
 Use `eslint-disable` comment if you really need to use it.
 
@@ -40,6 +42,10 @@ array.reduce(reducer, initialValue);
 ```
 
 ```js
+array.reduce((total, value) => total + value, 0);
+```
+
+```js
 let result = initialValue;
 
 for (const element of array) {
@@ -51,9 +57,11 @@ for (const element of array) {
 ### allowNumericInitialValue
 
 Type: `boolean`\
-Default: `false`
+Default: `true`
 
-Can be enabled to allow `reduce` to be used to sum numbers.
+Allow a numeric `initialValue` in a `reduce` call.
+
+Pass `"allowNumericInitialValue": false` to disable reduce completely.
 
 ```js
 // eslint unicorn/no-array-reduce: ["error", {"allowNumericInitialValue": true}]

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -61,7 +61,7 @@ Default: `true`
 
 Allow simple operations (like addition, subtraction, etc.) in a `reduce` call.
 
-Pass `"allowSimpleOperations": false` to disable reduce completely.
+Set it to `false` to disable reduce completely.
 
 ```js
 // eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": true}]

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -46,3 +46,21 @@ for (const element of array) {
 	result += element;
 }
 ```
+## Options
+
+### allowNumericInitialValue
+
+Type: `boolean`\
+Default: `false`
+
+Can be enabled to allow `reduce` to be used to sum numbers.
+
+```js
+// eslint unicorn/no-array-reduce: ["error", {"allowNumericInitialValue": true}]
+arr.reduce((total, item) => total + item, 0) // Passes
+```
+
+```js
+// eslint unicorn/no-array-reduce: ["error", {"allowNumericInitialValue": false}]
+arr.reduce((total, item) => total + item, 0) // Fails
+```

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -54,21 +54,21 @@ for (const element of array) {
 ```
 ## Options
 
-### allowNumericInitialValue
+### allowSimpleOperations
 
 Type: `boolean`\
 Default: `true`
 
-Allow a numeric `initialValue` in a `reduce` call.
+Allow simple operations (like addition, subtraction, etc.) in a `reduce` call.
 
-Pass `"allowNumericInitialValue": false` to disable reduce completely.
+Pass `"allowSimpleOperations": false` to disable reduce completely.
 
 ```js
-// eslint unicorn/no-array-reduce: ["error", {"allowNumericInitialValue": true}]
-arr.reduce((total, item) => total + item, 0) // Passes
+// eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": true}]
+arr.reduce((total, item) => total + item) // Passes
 ```
 
 ```js
-// eslint unicorn/no-array-reduce: ["error", {"allowNumericInitialValue": false}]
-arr.reduce((total, item) => total + item, 0) // Fails
+// eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": false}]
+arr.reduce((total, item) => total + item) // Fails
 ```

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -70,5 +70,5 @@ array.reduce((total, item) => total + item) // Passes
 
 ```js
 // eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": false}]
-arr.reduce((total, item) => total + item) // Fails
+array.reduce((total, item) => total + item) // Fails
 ```

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -42,7 +42,7 @@ array.reduce(reducer, initialValue);
 ```
 
 ```js
-array.reduce((total, value) => total + value, 0);
+array.reduce((total, value) => total + value;
 ```
 
 ```js

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -42,7 +42,7 @@ array.reduce(reducer, initialValue);
 ```
 
 ```js
-array.reduce((total, value) => total + value;
+array.reduce((total, value) => total + value);
 ```
 
 ```js

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -1,4 +1,5 @@
 'use strict';
+const {get} = require('lodash');
 const {methodCallSelector} = require('./selectors/index.js');
 const {arrayPrototypeMethodSelector, notFunctionSelector, matches} = require('./selectors/index.js');
 const {isNumeric} = require('./utils/numeric.js');
@@ -41,18 +42,20 @@ const schema = [
 		properties: {
 			allowNumericInitialValue: {
 				type: 'boolean',
-				default: false,
+				default: true,
 			},
 		},
 	},
 ];
 
 const create = context => {
-	const {allowNumericInitialValue} = context.options[0] || {};
+	const {allowNumericInitialValue} = {allowNumericInitialValue: true, ...context.options[0]};
 
 	return {
 		[selector](node) {
-			if (!(allowNumericInitialValue && isNumeric(node.parent.parent.arguments[1]))) {
+			const initialValue = get(node, 'parent.parent.arguments[1]');
+
+			if (!(allowNumericInitialValue && isNumeric(initialValue))) {
 				return {
 					node,
 					messageId: MESSAGE_ID,

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -1,6 +1,7 @@
 'use strict';
 const {methodCallSelector} = require('./selectors/index.js');
 const {arrayPrototypeMethodSelector, notFunctionSelector, matches} = require('./selectors/index.js');
+const {isNumeric} = require('./utils/numeric.js');
 
 const MESSAGE_ID = 'no-reduce';
 const messages = {
@@ -34,9 +35,27 @@ const selector = matches([
 	].join(''),
 ]);
 
-const create = () => {
+const schema = [
+	{
+		type: 'object',
+		properties: {
+			allowNumericInitialValue: {
+				type: 'boolean',
+				default: false,
+			},
+		},
+	},
+];
+
+const create = context => {
+	const {allowNumericInitialValue} = context.options[0] || {};
+
 	return {
 		[selector](node) {
+			if (allowNumericInitialValue && isNumeric(node.parent.parent.arguments[1])) {
+				return;
+			}
+
 			return {
 				node,
 				messageId: MESSAGE_ID,
@@ -53,6 +72,7 @@ module.exports = {
 		docs: {
 			description: 'Disallow `Array#reduce()` and `Array#reduceRight()`.',
 		},
+		schema,
 		messages,
 	},
 };

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -2,7 +2,6 @@
 const {get} = require('lodash');
 const {methodCallSelector} = require('./selectors/index.js');
 const {arrayPrototypeMethodSelector, notFunctionSelector, matches} = require('./selectors/index.js');
-const {isNumeric} = require('./utils/numeric.js');
 
 const MESSAGE_ID = 'no-reduce';
 const messages = {
@@ -70,12 +69,9 @@ const create = context => {
 
 			if ((callback.type === 'ArrowFunctionExpression' || callback.type === 'FunctionExpression') &&
 				callback.body.type === 'BlockStatement' &&
+				callback.body.body.length === 1 &&
 				callback.body.body[0].type === 'ReturnStatement' &&
 				callback.body.body[0].argument.type === 'BinaryExpression') {
-				return;
-			}
-
-			if (isNumeric(get(node, 'parent.parent.arguments[1]'))) {
 				return;
 			}
 

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -52,15 +52,13 @@ const create = context => {
 
 	return {
 		[selector](node) {
-			if (allowNumericInitialValue && isNumeric(node.parent.parent.arguments[1])) {
-				return;
+			if (!(allowNumericInitialValue && isNumeric(node.parent.parent.arguments[1]))) {
+				return {
+					node,
+					messageId: MESSAGE_ID,
+					data: {method: node.name},
+				};
 			}
-
-			return {
-				node,
-				messageId: MESSAGE_ID,
-				data: {method: node.name},
-			};
 		},
 	};
 };

--- a/rules/utils/numeric.js
+++ b/rules/utils/numeric.js
@@ -8,7 +8,7 @@ const isDecimalIntegerNode = node => isNumber(node) && isDecimalInteger(node.raw
 
 const isNumber = node => typeof node.value === 'number';
 const isBigInt = node => Boolean(node.bigint);
-const isNumeric = node => node ? (isNumber(node) || isBigInt(node)) : false;
+const isNumeric = node => isNumber(node) || isBigInt(node);
 const isLegacyOctal = node => isNumber(node) && /^0\d+$/.test(node.raw);
 
 function getPrefix(text) {

--- a/rules/utils/numeric.js
+++ b/rules/utils/numeric.js
@@ -8,7 +8,7 @@ const isDecimalIntegerNode = node => isNumber(node) && isDecimalInteger(node.raw
 
 const isNumber = node => typeof node.value === 'number';
 const isBigInt = node => Boolean(node.bigint);
-const isNumeric = node => node ? isNumber(node) || isBigInt(node) : false;
+const isNumeric = node => node ? (isNumber(node) || isBigInt(node)) : false;
 const isLegacyOctal = node => isNumber(node) && /^0\d+$/.test(node.raw);
 
 function getPrefix(text) {

--- a/rules/utils/numeric.js
+++ b/rules/utils/numeric.js
@@ -8,7 +8,7 @@ const isDecimalIntegerNode = node => isNumber(node) && isDecimalInteger(node.raw
 
 const isNumber = node => typeof node.value === 'number';
 const isBigInt = node => Boolean(node.bigint);
-const isNumeric = node => isNumber(node) || isBigInt(node);
+const isNumeric = node => node ? isNumber(node) || isBigInt(node) : false;
 const isLegacyOctal = node => isNumber(node) && /^0\d+$/.test(node.raw);
 
 function getPrefix(text) {

--- a/test/no-array-reduce.mjs
+++ b/test/no-array-reduce.mjs
@@ -93,13 +93,15 @@ test({
 		// Second argument is not a function
 		...notFunctionTypes.map(data => `Array.prototype.reduce.call(foo, ${data})`),
 
-		// Option: allowNumericInitialValue
+		// Option: allowSimpleOperations
+		'arr.reduce((total, item) => total + item)',
+		'arr.reduce((total, item) => { return total + item })',
+		'arr.reduce(function (total, item) { return total + item })',
 		'arr.reduce((total, item) => total + item, 0)',
+		'arr.reduce((total, item) => { return total + item }, 0 )',
 		'arr.reduce(function (total, item) { return total + item }, 0)',
 	].flatMap(testCase => [testCase, testCase.replace('reduce', 'reduceRight')]),
 	invalid: [
-		'arr.reduce((total, item) => total + item)',
-		'arr.reduce(function (total, item) { return total + item })',
 		'arr.reduce((str, item) => str += item, "")',
 		outdent`
 			arr.reduce((obj, item) => {
@@ -122,14 +124,30 @@ test({
 		'Array.prototype.reduce.apply(arr, [(s, i) => s + i])',
 		'Array.prototype.reduce.apply(arr, [sum]);',
 
-		// Option: allowNumericInitialValue
+		// Option: allowSimpleOperations
+		{
+			code: 'arr.reduce((total, item) => total + item)',
+			options: [{allowSimpleOperations: false}],
+		},
+		{
+			code: 'arr.reduce((total, item) => { return total + item })',
+			options: [{allowSimpleOperations: false}],
+		},
+		{
+			code: 'arr.reduce(function (total, item) { return total + item })',
+			options: [{allowSimpleOperations: false}],
+		},
 		{
 			code: 'arr.reduce((total, item) => total + item, 0)',
-			options: [{allowNumericInitialValue: false}],
+			options: [{allowSimpleOperations: false}],
+		},
+		{
+			code: 'arr.reduce((total, item) => { return total + item }, 0 )',
+			options: [{allowSimpleOperations: false}],
 		},
 		{
 			code: 'arr.reduce(function (total, item) { return total + item }, 0)',
-			options: [{allowNumericInitialValue: false}],
+			options: [{allowSimpleOperations: false}],
 		},
 	].flatMap(testCase => {
 		const {code, options} = testCase;

--- a/test/no-array-reduce.mjs
+++ b/test/no-array-reduce.mjs
@@ -102,9 +102,8 @@ test({
 		'arr.reduce(function (total, item) { return total * item }, 0)',
 		outdent`
 			arr.reduce((total, item) => {
-				const multiplier = 100;
-				return (total / item) * multiplier;
-			}, 0)
+				return (total / item) * 100;
+			}, 0);
 		`,
 		'arr.reduce((total, item) => { return total + item }, 0)',
 	].flatMap(testCase => [testCase, testCase.replace('reduce', 'reduceRight')]),
@@ -130,6 +129,15 @@ test({
 		'[].reduce.apply(arr, [sum]);',
 		'Array.prototype.reduce.apply(arr, [(s, i) => s + i])',
 		'Array.prototype.reduce.apply(arr, [sum]);',
+		outdent`
+			array.reduce((total, item) => {
+				const doComplicatedThings = (item) => {
+					return item + 1;
+				}
+
+				return total + doComplicatedThings(item);
+			}, 0);
+		`,
 
 		// Option: allowSimpleOperations
 		{
@@ -159,9 +167,8 @@ test({
 		{
 			code: outdent`
 				arr.reduce((total, item) => {
-					const multiplier = 100;
-					return (total / item) * multiplier;
-				}, 0)
+					return (total / item) * 100;
+				}, 0);
 			`,
 			options: [{allowSimpleOperations: false}],
 		},

--- a/test/no-array-reduce.mjs
+++ b/test/no-array-reduce.mjs
@@ -94,27 +94,11 @@ test({
 		...notFunctionTypes.map(data => `Array.prototype.reduce.call(foo, ${data})`),
 
 		// Option: allowNumericInitialValue
-		{
-			code: 'arr.reduce((total, item) => total + item, 0)',
-			options: [{allowNumericInitialValue: true}],
-		},
-		{
-			code: 'arr.reduce(function (total, item) { return total + item }, 0)',
-			options: [{allowNumericInitialValue: true}],
-		},
-	].flatMap(testCase => {
-		const {code, options} = testCase;
-
-		if (options) {
-			return [testCase, {...testCase, code: code.replace('reduce', 'reduceRight')}];
-		}
-
-		return [testCase, testCase.replace('reduce', 'reduceRight')];
-	}),
-	invalid: [
-		'arr.reduce((total, item) => total + item)',
 		'arr.reduce((total, item) => total + item, 0)',
 		'arr.reduce(function (total, item) { return total + item }, 0)',
+	].flatMap(testCase => [testCase, testCase.replace('reduce', 'reduceRight')]),
+	invalid: [
+		'arr.reduce((total, item) => total + item)',
 		'arr.reduce(function (total, item) { return total + item })',
 		'arr.reduce((str, item) => str += item, "")',
 		outdent`

--- a/test/no-array-reduce.mjs
+++ b/test/no-array-reduce.mjs
@@ -83,52 +83,52 @@ test({
 		// We are not checking arguments length
 
 		// `reduce-like`
-		'arr.reducex(foo)',
-		'arr.xreduce(foo)',
-		'[].reducex.call(arr, foo)',
-		'[].xreduce.call(arr, foo)',
-		'Array.prototype.reducex.call(arr, foo)',
-		'Array.prototype.xreduce.call(arr, foo)',
+		'array.reducex(foo)',
+		'array.xreduce(foo)',
+		'[].reducex.call(array, foo)',
+		'[].xreduce.call(array, foo)',
+		'Array.prototype.reducex.call(array, foo)',
+		'Array.prototype.xreduce.call(array, foo)',
 
 		// Second argument is not a function
 		...notFunctionTypes.map(data => `Array.prototype.reduce.call(foo, ${data})`),
 
 		// Option: allowSimpleOperations
 		'array.reduce((total, item) => total + item)',
-		'arr.reduce((total, item) => { return total - item })',
-		'arr.reduce(function (total, item) { return total * item })',
-		'arr.reduce((total, item) => total + item, 0)',
-		'arr.reduce((total, item) => { return total - item }, 0 )',
-		'arr.reduce(function (total, item) { return total * item }, 0)',
+		'array.reduce((total, item) => { return total - item })',
+		'array.reduce(function (total, item) { return total * item })',
+		'array.reduce((total, item) => total + item, 0)',
+		'array.reduce((total, item) => { return total - item }, 0 )',
+		'array.reduce(function (total, item) { return total * item }, 0)',
 		outdent`
-			arr.reduce((total, item) => {
+			array.reduce((total, item) => {
 				return (total / item) * 100;
 			}, 0);
 		`,
-		'arr.reduce((total, item) => { return total + item }, 0)',
+		'array.reduce((total, item) => { return total + item }, 0)',
 	].flatMap(testCase => [testCase, testCase.replace('reduce', 'reduceRight')]),
 	invalid: [
-		'arr.reduce((str, item) => str += item, "")',
+		'array.reduce((str, item) => str += item, "")',
 		outdent`
-			arr.reduce((obj, item) => {
+			array.reduce((obj, item) => {
 				obj[item] = null;
 				return obj;
 			}, {})
 		`,
-		'arr.reduce((obj, item) => ({ [item]: null }), {})',
+		'array.reduce((obj, item) => ({ [item]: null }), {})',
 		outdent`
 			const hyphenate = (str, char) => \`\${str}-\${char}\`;
 			["a", "b", "c"].reduce(hyphenate);
 		`,
-		'[].reduce.call(arr, (s, i) => s + i)',
-		'[].reduce.call(arr, sum);',
+		'[].reduce.call(array, (s, i) => s + i)',
+		'[].reduce.call(array, sum);',
 		'[].reduce.call(sum);',
-		'Array.prototype.reduce.call(arr, (s, i) => s + i)',
-		'Array.prototype.reduce.call(arr, sum);',
-		'[].reduce.apply(arr, [(s, i) => s + i])',
-		'[].reduce.apply(arr, [sum]);',
-		'Array.prototype.reduce.apply(arr, [(s, i) => s + i])',
-		'Array.prototype.reduce.apply(arr, [sum]);',
+		'Array.prototype.reduce.call(array, (s, i) => s + i)',
+		'Array.prototype.reduce.call(array, sum);',
+		'[].reduce.apply(array, [(s, i) => s + i])',
+		'[].reduce.apply(array, [sum]);',
+		'Array.prototype.reduce.apply(array, [(s, i) => s + i])',
+		'Array.prototype.reduce.apply(array, [sum]);',
 		outdent`
 			array.reduce((total, item) => {
 				const doComplicatedThings = (item) => {
@@ -141,32 +141,32 @@ test({
 
 		// Option: allowSimpleOperations
 		{
-			code: 'arr.reduce((total, item) => total + item)',
+			code: 'array.reduce((total, item) => total + item)',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce((total, item) => { return total - item })',
+			code: 'array.reduce((total, item) => { return total - item })',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce(function (total, item) { return total * item })',
+			code: 'array.reduce(function (total, item) { return total * item })',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce((total, item) => total + item, 0)',
+			code: 'array.reduce((total, item) => total + item, 0)',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce((total, item) => { return total - item }, 0 )',
+			code: 'array.reduce((total, item) => { return total - item }, 0 )',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce(function (total, item) { return total * item }, 0)',
+			code: 'array.reduce(function (total, item) { return total * item }, 0)',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
 			code: outdent`
-				arr.reduce((total, item) => {
+				array.reduce((total, item) => {
 					return (total / item) * 100;
 				}, 0);
 			`,

--- a/test/no-array-reduce.mjs
+++ b/test/no-array-reduce.mjs
@@ -94,7 +94,7 @@ test({
 		...notFunctionTypes.map(data => `Array.prototype.reduce.call(foo, ${data})`),
 
 		// Option: allowSimpleOperations
-		'arr.reduce((total, item) => total + item)',
+		'array.reduce((total, item) => total + item)',
 		'arr.reduce((total, item) => { return total - item })',
 		'arr.reduce(function (total, item) { return total * item })',
 		'arr.reduce((total, item) => total + item, 0)',

--- a/test/no-array-reduce.mjs
+++ b/test/no-array-reduce.mjs
@@ -95,11 +95,18 @@ test({
 
 		// Option: allowSimpleOperations
 		'arr.reduce((total, item) => total + item)',
-		'arr.reduce((total, item) => { return total + item })',
-		'arr.reduce(function (total, item) { return total + item })',
+		'arr.reduce((total, item) => { return total - item })',
+		'arr.reduce(function (total, item) { return total * item })',
 		'arr.reduce((total, item) => total + item, 0)',
-		'arr.reduce((total, item) => { return total + item }, 0 )',
-		'arr.reduce(function (total, item) { return total + item }, 0)',
+		'arr.reduce((total, item) => { return total - item }, 0 )',
+		'arr.reduce(function (total, item) { return total * item }, 0)',
+		outdent`
+			arr.reduce((total, item) => {
+				const multiplier = 100;
+				return (total / item) * multiplier;
+			}, 0)
+		`,
+		'arr.reduce((total, item) => { return total + item }, 0)',
 	].flatMap(testCase => [testCase, testCase.replace('reduce', 'reduceRight')]),
 	invalid: [
 		'arr.reduce((str, item) => str += item, "")',
@@ -130,11 +137,11 @@ test({
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce((total, item) => { return total + item })',
+			code: 'arr.reduce((total, item) => { return total - item })',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce(function (total, item) { return total + item })',
+			code: 'arr.reduce(function (total, item) { return total * item })',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
@@ -142,11 +149,20 @@ test({
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce((total, item) => { return total + item }, 0 )',
+			code: 'arr.reduce((total, item) => { return total - item }, 0 )',
 			options: [{allowSimpleOperations: false}],
 		},
 		{
-			code: 'arr.reduce(function (total, item) { return total + item }, 0)',
+			code: 'arr.reduce(function (total, item) { return total * item }, 0)',
+			options: [{allowSimpleOperations: false}],
+		},
+		{
+			code: outdent`
+				arr.reduce((total, item) => {
+					const multiplier = 100;
+					return (total / item) * multiplier;
+				}, 0)
+			`,
 			options: [{allowSimpleOperations: false}],
 		},
 	].flatMap(testCase => {

--- a/test/no-array-reduce.mjs
+++ b/test/no-array-reduce.mjs
@@ -131,11 +131,10 @@ test({
 		'Array.prototype.reduce.apply(array, [sum]);',
 		outdent`
 			array.reduce((total, item) => {
-				const doComplicatedThings = (item) => {
+				return total + doComplicatedThings(item);
+				function doComplicatedThings(item) {
 					return item + 1;
 				}
-
-				return total + doComplicatedThings(item);
 			}, 0);
 		`,
 

--- a/test/no-array-reduce.mjs
+++ b/test/no-array-reduce.mjs
@@ -93,7 +93,24 @@ test({
 		// Second argument is not a function
 		...notFunctionTypes.map(data => `Array.prototype.reduce.call(foo, ${data})`),
 
-	].flatMap(code => [code, code.replace('reduce', 'reduceRight')]),
+		// Option: allowNumericInitialValue
+		{
+			code: 'arr.reduce((total, item) => total + item, 0)',
+			options: [{allowNumericInitialValue: true}],
+		},
+		{
+			code: 'arr.reduce(function (total, item) { return total + item }, 0)',
+			options: [{allowNumericInitialValue: true}],
+		},
+	].flatMap(testCase => {
+		const {code, options} = testCase;
+
+		if (options) {
+			return [testCase, {...testCase, code: code.replace('reduce', 'reduceRight')}];
+		}
+
+		return [testCase, testCase.replace('reduce', 'reduceRight')];
+	}),
 	invalid: [
 		'arr.reduce((total, item) => total + item)',
 		'arr.reduce((total, item) => total + item, 0)',
@@ -120,5 +137,29 @@ test({
 		'[].reduce.apply(arr, [sum]);',
 		'Array.prototype.reduce.apply(arr, [(s, i) => s + i])',
 		'Array.prototype.reduce.apply(arr, [sum]);',
-	].flatMap(code => [{code, errors: errorsReduce}, {code: code.replace('reduce', 'reduceRight'), errors: errorsReduceRight}]),
+
+		// Option: allowNumericInitialValue
+		{
+			code: 'arr.reduce((total, item) => total + item, 0)',
+			options: [{allowNumericInitialValue: false}],
+		},
+		{
+			code: 'arr.reduce(function (total, item) { return total + item }, 0)',
+			options: [{allowNumericInitialValue: false}],
+		},
+	].flatMap(testCase => {
+		const {code, options} = testCase;
+
+		if (options) {
+			return [
+				{code, errors: errorsReduce, options},
+				{code: code.replace('reduce', 'reduceRight'), errors: errorsReduceRight, options},
+			];
+		}
+
+		return [
+			{code: testCase, errors: errorsReduce},
+			{code: testCase.replace('reduce', 'reduceRight'), errors: errorsReduceRight},
+		];
+	}),
 });


### PR DESCRIPTION
This is my first time contributing something to this project besides from minor documentation tweaks, so don't feel bad telling me I did something incorrectly. 

I took a stab at the open issue to allow simple sums when using `reduce`. I am not married to the option name, so please offer better suggestions if you have them. 

Fixes #1348