### PR TITLE
Use `context.getFilename` in `prefer-module` rule

### DIFF
--- a/rules/prefer-module.js
+++ b/rules/prefer-module.js
@@ -212,7 +212,7 @@ function fixModuleExports(node, sourceCode) {
 }
 
 function create(context) {
-	const filename = context.getPhysicalFilename();
+	const filename = context.getFilename();
 
 	if (filename.toLowerCase().endsWith('.cjs')) {
 		return {};


### PR DESCRIPTION
related https://github.com/sindresorhus/eslint-plugin-unicorn/pull/1415#issuecomment-878985623

````md
```cjs
const fs = require('fs')
```
````