### PR TITLE
`no-null`: Allow `Object.create(null, …)`

### DIFF
--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -1,7 +1,6 @@
 'use strict';
 const {
 	not,
-	matches,
 	methodCallSelector,
 	callExpressionSelector,
 } = require('./selectors/index.js');
@@ -22,10 +21,8 @@ const selector = [
 		// `Object.create(null)`, `Object.create(null, foo)`
 		`${methodCallSelector({object: 'Object', method: 'create'})} > .arguments:first-child`,
 		// `useRef(null)`
-		// eslint-disable-next-line unicorn/prevent-abbreviations
 		`${callExpressionSelector({name: 'useRef', argumentsLength: 1})} > .arguments:first-child`,
 		// `React.useRef(null)`
-		// eslint-disable-next-line unicorn/prevent-abbreviations
 		`${methodCallSelector({object: 'React', method: 'useRef', argumentsLength: 1})} > .arguments:first-child`,
 		// `foo.insertBefore(bar, null)`
 		`${methodCallSelector({method: 'insertBefore', argumentsLength: 2})}[arguments.0.type!="SpreadElement"] > .arguments:nth-child(2)`,

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -15,43 +15,25 @@ const messages = {
 	[SUGGESTION_REMOVE_MESSAGE_ID]: 'Remove `null`.',
 };
 
-const objectCreateSelector = methodCallSelector({
-	object: 'Object',
-	method: 'create',
-	argumentsLength: 1,
-});
-
-// `useRef(null)`
-// eslint-disable-next-line unicorn/prevent-abbreviations
-const useRefSelector = callExpressionSelector({name: 'useRef', argumentsLength: 1});
-
-// `React.useRef(null)`
-// eslint-disable-next-line unicorn/prevent-abbreviations
-const reactUseRefSelector = methodCallSelector({
-	object: 'React',
-	method: 'useRef',
-	argumentsLength: 1,
-});
-
 const selector = [
 	'Literal',
 	'[raw="null"]',
-	not(`${matches([objectCreateSelector, useRefSelector, reactUseRefSelector])} > .arguments`),
+	not([
+		// `Object.create(null)`, `Object.create(null, foo)`
+		`${methodCallSelector({object: 'Object', method: 'create'})} > .arguments:first-child`,
+		// `useRef(null)`
+		// eslint-disable-next-line unicorn/prevent-abbreviations
+		`${callExpressionSelector({name: 'useRef', argumentsLength: 1})} > .arguments:first-child`,
+		// `React.useRef(null)`
+		// eslint-disable-next-line unicorn/prevent-abbreviations
+		`${methodCallSelector({object: 'React', method: 'useRef', argumentsLength: 1})} > .arguments:first-child`,
+		// `foo.insertBefore(bar, null)`
+		`${methodCallSelector({method: 'insertBefore', argumentsLength: 2})}[arguments.0.type!="SpreadElement"] > .arguments:nth-child(2)`,
+	]),
 ].join('');
 
 const isLooseEqual = node => node.type === 'BinaryExpression' && ['==', '!='].includes(node.operator);
 const isStrictEqual = node => node.type === 'BinaryExpression' && ['===', '!=='].includes(node.operator);
-const isSecondArgumentOfInsertBefore = node =>
-	node.parent.type === 'CallExpression' &&
-	!node.parent.optional &&
-	node.parent.arguments.length === 2 &&
-	node.parent.arguments[0].type !== 'SpreadElement' &&
-	node.parent.arguments[1] === node &&
-	node.parent.callee.type === 'MemberExpression' &&
-	!node.parent.callee.computed &&
-	!node.parent.callee.optional &&
-	node.parent.callee.property.type === 'Identifier' &&
-	node.parent.callee.property.name === 'insertBefore';
 
 const create = context => {
 	const {checkStrictEquality} = {
@@ -63,10 +45,6 @@ const create = context => {
 		[selector]: node => {
 			const {parent} = node;
 			if (!checkStrictEquality && isStrictEqual(parent)) {
-				return;
-			}
-
-			if (isSecondArgumentOfInsertBefore(node)) {
 				return;
 			}
 

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -19,7 +19,7 @@ const selector = [
 	'[raw="null"]',
 	not([
 		// `Object.create(null)`, `Object.create(null, foo)`
-		`${methodCallSelector({object: 'Object', method: 'create'})} > .arguments:first-child`,
+		`${methodCallSelector({object: 'Object', method: 'create', minimumArguments: 1, maximumArguments: 2})} > .arguments:first-child`,
 		// `useRef(null)`
 		`${callExpressionSelector({name: 'useRef', argumentsLength: 1})} > .arguments:first-child`,
 		// `React.useRef(null)`

--- a/test/no-null.mjs
+++ b/test/no-null.mjs
@@ -224,11 +224,13 @@ test({
 		invalidTestCase('lib.Object.create(null)'),
 		// More/Less arguments
 		invalidTestCase('Object.create(...[null])'),
+		invalidTestCase('Object.create(null, bar, extraArgument)'),
 		invalidTestCase('foo.insertBefore(null)'),
 		invalidTestCase('foo.insertBefore(foo, null, bar)'),
 		invalidTestCase('foo.insertBefore(...[foo], null)'),
 		// Not in right position
 		invalidTestCase('foo.insertBefore(null, bar)'),
+		invalidTestCase('Object.create(bar, null)'),
 	],
 });
 

--- a/test/no-null.mjs
+++ b/test/no-null.mjs
@@ -59,6 +59,7 @@ test({
 	valid: [
 		'let foo',
 		'Object.create(null)',
+		'Object.create(null, {foo: {value:1}})',
 		'let insertedNode = parentNode.insertBefore(newNode, null)',
 		// Not `null`
 		'const foo = "null";',
@@ -222,7 +223,6 @@ test({
 		// `callee.object.type` is not a `Identifier`
 		invalidTestCase('lib.Object.create(null)'),
 		// More/Less arguments
-		invalidTestCase('Object.create(null, "")'),
 		invalidTestCase('Object.create(...[null])'),
 		invalidTestCase('foo.insertBefore(null)'),
 		invalidTestCase('foo.insertBefore(foo, null, bar)'),


### PR DESCRIPTION
Allow 1~2 arguments on `Object.create`, allow `Object.create(null, foo)`
Simplify a little bit