### PR TITLE
`prevent-abbreviations`: Ignore `i18n` and `l10n`

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -8,7 +8,7 @@ const isShorthandPropertyValue = require('./utils/is-shorthand-property-value.js
 const isShorthandImportLocal = require('./utils/is-shorthand-import-local.js');
 const getVariableIdentifiers = require('./utils/get-variable-identifiers.js');
 const isStaticRequire = require('./utils/is-static-require.js');
-const {defaultReplacements, defaultAllowList} = require('./shared/abbreviations.js');
+const {defaultReplacements, defaultAllowList, defaultIgnore} = require('./shared/abbreviations.js');
 const {renameVariable} = require('./fix/index.js');
 const getScopes = require('./utils/get-scopes.js');
 
@@ -40,6 +40,8 @@ const prepareOptions = ({
 	const mergedAllowList = extendDefaultAllowList ?
 		defaultsDeep({}, allowList, defaultAllowList) :
 		allowList;
+
+	ignore = [...defaultIgnore, ...ignore];
 
 	ignore = ignore.map(
 		pattern => pattern instanceof RegExp ? pattern : new RegExp(pattern, 'u'),

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -96,10 +96,6 @@ const getNameReplacements = (name, options, limit = 3) => {
 		return {total: 0};
 	}
 
-	if (name.includes('i18n')) {
-		return {total: 0};
-	}
-
 	// Find exact replacements
 	const exactReplacements = getWordReplacements(name, options);
 

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -96,6 +96,10 @@ const getNameReplacements = (name, options, limit = 3) => {
 		return {total: 0};
 	}
 
+	if (name.includes('i18n')) {
+		return {total: 0};
+	}
+
 	// Find exact replacements
 	const exactReplacements = getWordReplacements(name, options);
 

--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -232,6 +232,10 @@ module.exports.defaultAllowList = {
 	// Next.js function
 	// https://nextjs.org/learn/basics/fetching-data-for-pages
 	getInitialProps: true,
+	// Internationalization and localization
+	// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1188
+	i18n: true,
+	l10n: true,
 	// React PropTypes
 	// https://reactjs.org/docs/typechecking-with-proptypes.html
 	propTypes: true,

--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -232,10 +232,6 @@ module.exports.defaultAllowList = {
 	// Next.js function
 	// https://nextjs.org/learn/basics/fetching-data-for-pages
 	getInitialProps: true,
-	// Internationalization and localization
-	// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1188
-	i18n: true,
-	l10n: true,
 	// React PropTypes
 	// https://reactjs.org/docs/typechecking-with-proptypes.html
 	propTypes: true,
@@ -243,3 +239,10 @@ module.exports.defaultAllowList = {
 	// https://jestjs.io/docs/en/configuration#setupfilesafterenv-array
 	setupFilesAfterEnv: true,
 };
+
+module.exports.defaultIgnore = [
+	// Internationalization and localization
+	// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1188
+	'i18n',
+	'l10n'
+];

--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -244,5 +244,5 @@ module.exports.defaultIgnore = [
 	// Internationalization and localization
 	// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1188
 	'i18n',
-	'l10n'
+	'l10n',
 ];

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -126,6 +126,7 @@ const tests = {
 		'(class C {})',
 		'class C {}',
 		'const i18n = new I18n({ locales: ["en", "fr"] })',
+		'const i18nData = {}',
 		'const l10n = new L10n()',
 		outdent`
 			(class {

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -125,6 +125,8 @@ const tests = {
 		'(class {})',
 		'(class C {})',
 		'class C {}',
+		'const i18n = new I18n({ locales: ["en", "fr"] })',
+		'application.use(i18n.init)',
 		outdent`
 			(class {
 				error() {}

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -126,7 +126,7 @@ const tests = {
 		'(class C {})',
 		'class C {}',
 		'const i18n = new I18n({ locales: ["en", "fr"] })',
-		'application.use(i18n.init)',
+		'const l10n = new L10n()',
 		outdent`
 			(class {
 				error() {}


### PR DESCRIPTION
Hey :wave:,

This PR fixes #1188
It ignores the `i18n` keyword for the `prevent-abbreviations` rule, as it is well-known and popular enough.

I also like the idea of, explicit > implicit, but sometimes, things are done like that, so we can relax a bit the rule.
