### PR TITLE
feat(prevent-abbreviations): add `app` => `application`

### DIFF
--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -4,6 +4,9 @@ module.exports.defaultReplacements = {
 	acc: {
 		accumulator: true,
 	},
+	app: {
+		application: true,
+	},
 	arg: {
 		argument: true,
 	},

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1258,6 +1258,11 @@ const tests = {
 			options: noExtendDefaultAllowListOptions,
 			errors: createErrors(),
 		},
+		{
+			code: 'const app = {};',
+			output: 'const application = {};',
+			errors: createErrors('The variable `app` should be named `application`. A more descriptive name will do too.')
+		}
 	],
 };
 


### PR DESCRIPTION
Hey :wave:,

The word `app` is really famous in programming, but in fact, I'm surprised it is not yet included in the list of abbreviations of this `eslint` plugin.

I tried to see if there was issues or PRs talking about that, here is what I found:

> The second one is actually a valid word. I'd rather do application => app.

From @sindresorhus in https://github.com/sindresorhus/eslint-plugin-unicorn/issues/463#issuecomment-560086267

In fact, it is not a "valid" word, `app` is an abbreviation.

From https://searchmobilecomputing.techtarget.com/definition/app (and many others sources saying that `app` is an abbreviation).
> App is an abbreviated form of the word "application."  An application is a software program  that's designed to perform a specific function directly for the user or, in some cases, for another application program.