### PR TITLE
`no-array-callback-reference`: Ignore mobx-state-tree usage

### DIFF
--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -29,7 +29,11 @@ const iteratorMethods = [
 			returnsUndefined: true,
 		},
 	],
-	['map'],
+	[
+		'map', {
+			extraSelector: '[callee.object.name!="types"]',
+		},
+	],
 	[
 		'reduce', {
 			parameters: [

--- a/test/no-array-callback-reference.mjs
+++ b/test/no-array-callback-reference.mjs
@@ -119,6 +119,7 @@ test({
 				.toArray()
 		`,
 
+		// #1455 - mobx-state-tree
 		outdent`
 			const EventsStore = types.model('EventsStore', {
 				events: types.optional(types.map(Event), {}),

--- a/test/no-array-callback-reference.mjs
+++ b/test/no-array-callback-reference.mjs
@@ -118,6 +118,12 @@ test({
 				.limit(params.limit + 1)
 				.toArray()
 		`,
+
+		outdent`
+			const EventsStore = types.model('EventsStore', {
+				events: types.optional(types.map(Event), {}),
+			})
+		`,
 	],
 	invalid: [
 		// Suggestions


### PR DESCRIPTION
Hey,

I want to enable this rule in the project which uses [MST](https://www.npmjs.com/package/mobx-state-tree)

but at the moment this rule shows errors on default usage of this lib: https://mobx-state-tree.js.org/API/#map

WDYT about these changes?