### PR TITLE
Update babel parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
 	},
 	"devDependencies": {
 		"@babel/code-frame": "7.14.5",
-		"@babel/core": "7.14.8",
-		"@babel/eslint-parser": "7.14.9",
+		"@babel/core": "7.15.0",
+		"@babel/eslint-parser": "7.15.0",
 		"@lubien/fixture-beta-package": "^1.0.0-beta.1",
 		"@typescript-eslint/parser": "^4.29.0",
 		"ava": "^3.15.0",

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -20,6 +20,7 @@ module.exports = {
 			babelrc: false,
 			configFile: false,
 			parserOpts: {
+				attachComment: false,
 				plugins: [
 					'jsx',
 					'doExpressions',

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -20,7 +20,6 @@ module.exports = {
 			babelrc: false,
 			configFile: false,
 			parserOpts: {
-				allowAwaitOutsideFunction: true,
 				plugins: [
 					'jsx',
 					'doExpressions',

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -20,7 +20,6 @@ module.exports = {
 			babelrc: false,
 			configFile: false,
 			parserOpts: {
-				attachComment: false,
 				plugins: [
 					'jsx',
 					'doExpressions',

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -116,7 +116,6 @@ class Tester {
 						configFile: false,
 						...testerOptions.parserOptions.babelOptions,
 						parserOpts: {
-							allowAwaitOutsideFunction: true,
 							...testerOptions.parserOptions.babelOptions.parserOpts,
 							plugins: babelPlugins,
 						},

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -116,6 +116,7 @@ class Tester {
 						configFile: false,
 						...testerOptions.parserOptions.babelOptions,
 						parserOpts: {
+							attachComment: false,
 							...testerOptions.parserOptions.babelOptions.parserOpts,
 							plugins: babelPlugins,
 						},

--- a/test/utils/test.mjs
+++ b/test/utils/test.mjs
@@ -116,7 +116,6 @@ class Tester {
 						configFile: false,
 						...testerOptions.parserOptions.babelOptions,
 						parserOpts: {
-							attachComment: false,
 							...testerOptions.parserOptions.babelOptions.parserOpts,
 							plugins: babelPlugins,
 						},


### PR DESCRIPTION
https://github.com/babel/babel/pull/13387 Enable top-level await parsing by default