### PR TITLE
`error-message`: Handle shadowed `Error` constructor

### DIFF
--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -1,5 +1,6 @@
 'use strict';
 const {getStaticValue} = require('eslint-utils');
+const isShadowed = require('./utils/is-shadowed.js');
 const {callOrNewExpressionSelector} = require('./selectors/index.js');
 
 const MESSAGE_ID_MISSING_MESSAGE = 'missing-message';
@@ -26,6 +27,10 @@ const selector = callOrNewExpressionSelector([
 
 const create = context => ({
 	[selector](expression) {
+		if (isShadowed(context.getScope(), expression.callee)) {
+			return;
+		}
+
 		const constructorName = expression.callee.name;
 		const messageArgumentIndex = constructorName === 'AggregateError' ? 1 : 0;
 		const callArguments = expression.arguments;

--- a/test/error-message.mjs
+++ b/test/error-message.mjs
@@ -28,6 +28,13 @@ test.snapshot({
 			const a = x;
 			throw x;
 		`,
+		// #1431 dont fail if Error is shadowed
+		outdent`
+			const Error = function () {};
+			const err = new Error({
+    			name: 'Unauthorized',
+			});
+		`,
 	],
 	invalid: [
 		'throw new Error()',

--- a/test/error-message.mjs
+++ b/test/error-message.mjs
@@ -28,11 +28,11 @@ test.snapshot({
 			const a = x;
 			throw x;
 		`,
-		// #1431 dont fail if Error is shadowed
+		// #1431: Do not fail if Error is shadowed
 		outdent`
 			const Error = function () {};
 			const err = new Error({
-    			name: 'Unauthorized',
+				name: 'Unauthorized',
 			});
 		`,
 	],


### PR DESCRIPTION
Fixes: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1431.

I just followed the instructions from https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1431#issuecomment-882150918.

Hopefully the first of many contributions! :tada: 