### PR TITLE
`no-new-array`: Improve docs

### DIFF
--- a/docs/rules/no-new-array.md
+++ b/docs/rules/no-new-array.md
@@ -9,7 +9,7 @@ This rule is fixable if the value type of the argument is known.
 ## Fail
 
 ```js
-const array = new Array(length);
+const array = new Array(len);
 ```
 
 ```js
@@ -23,7 +23,7 @@ const array = new Array(...unknownArgumentsList);
 ## Pass
 
 ```js
-const array = Array.from({length});
+const array = Array.from({length: len});
 ```
 
 ```js

--- a/docs/rules/no-new-array.md
+++ b/docs/rules/no-new-array.md
@@ -9,7 +9,8 @@ This rule is fixable if the value type of the argument is known.
 ## Fail
 
 ```js
-const array = new Array(len);
+const length = 10;
+const array = new Array(length);
 ```
 
 ```js
@@ -23,7 +24,8 @@ const array = new Array(...unknownArgumentsList);
 ## Pass
 
 ```js
-const array = Array.from({length: len});
+const length = 10;
+const array = Array.from({length});
 ```
 
 ```js


### PR DESCRIPTION
This makes the documentation around `Array.from(...)` substantially clearer; it's unnecessarily 'clever' and confusing-to-newcomers as it's currently written — at least IMO!