### PR TITLE
Don't break CI with `expiring-todo-comments`

### DIFF
--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -10,7 +10,12 @@ module.exports = {
 		'unicorn/empty-brace-spaces': 'error',
 		'unicorn/error-message': 'error',
 		'unicorn/escape-case': 'error',
-		'unicorn/expiring-todo-comments': 'warn',
+		'unicorn/expiring-todo-comments': [
+			"error",
+			{
+				"ignoreDatesOnPullRequests": true
+			}
+		],
 		'unicorn/explicit-length-check': 'error',
 		'unicorn/filename-case': 'error',
 		'unicorn/import-index': 'off',

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -10,7 +10,7 @@ module.exports = {
 		'unicorn/empty-brace-spaces': 'error',
 		'unicorn/error-message': 'error',
 		'unicorn/escape-case': 'error',
-		'unicorn/expiring-todo-comments': 'error',
+		'unicorn/expiring-todo-comments': 'warn',
 		'unicorn/explicit-length-check': 'error',
 		'unicorn/filename-case': 'error',
 		'unicorn/import-index': 'off',


### PR DESCRIPTION
Is suddenly-breaking CI ideal? TODO comments that break the build immediately seem ok if condition is "engines", but not dates.

https://github.com/sindresorhus/refined-github/runs/3786952560

The current setting makes sense, but it probably means I can't use dates.