### PR TITLE
Update eslint-plugin-eslint-plugin to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"enquirer": "2.3.6",
 		"eslint": "^8.0.0",
 		"eslint-ava-rule-tester": "^4.0.0",
-		"eslint-plugin-eslint-plugin": "^3.5.3",
+		"eslint-plugin-eslint-plugin": "^4.0.1",
 		"eslint-remote-tester": "^1.3.0",
 		"eslint-remote-tester-repositories": "^0.0.3",
 		"execa": "^5.1.1",

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -157,10 +157,10 @@ module.exports = {
 			description: 'Use destructured variables over properties.',
 		},
 		fixable: 'code',
+		hasSuggestions: true,
 		messages: {
 			[MESSAGE_ID]: 'Use destructured variables over properties.',
 			[MESSAGE_ID_SUGGEST]: 'Replace `{{expression}}` with destructured property `{{property}}`.',
 		},
-		hasSuggestions: true,
 	},
 };

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -185,7 +185,7 @@ module.exports = {
 		docs: {
 			description: 'Prevent passing a function reference directly to iterator methods.',
 		},
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/no-array-method-this-argument.js
+++ b/rules/no-array-method-this-argument.js
@@ -162,7 +162,7 @@ module.exports = {
 			description: 'Disallow using the `this` argument in array methods.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -128,8 +128,8 @@ module.exports = {
 			description: 'Enforce combining multiple `Array#push()` into one call.',
 		},
 		fixable: 'code',
+		hasSuggestions: true,
 		schema,
 		messages,
-		hasSuggestions: true,
 	},
 };

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -89,7 +89,7 @@ module.exports = {
 			description: 'Disallow `new Array()`.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -85,7 +85,7 @@ module.exports = {
 			description: 'Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -111,8 +111,8 @@ module.exports = {
 			description: 'Disallow the use of the `null` literal.',
 		},
 		fixable: 'code',
+		hasSuggestions: true,
 		schema,
 		messages,
-		hasSuggestions: true,
 	},
 };

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -329,7 +329,7 @@ module.exports = {
 			description: 'Prefer `.find(…)` over the first element from `.filter(…)`.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-array-index-of.js
+++ b/rules/prefer-array-index-of.js
@@ -14,7 +14,7 @@ module.exports = {
 			description: 'Prefer `Array#indexOf()` over `Array#findIndex()` when looking for the index of an item.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -306,8 +306,8 @@ module.exports = {
 			description: 'Prefer `.at()` method for index access and `String#charAt()`.',
 		},
 		fixable: 'code',
+		hasSuggestions: true,
 		schema,
 		messages,
-		hasSuggestions: true,
 	},
 };

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -216,10 +216,10 @@ module.exports = {
 			description: 'Prefer default parameters over reassignment.',
 		},
 		fixable: 'code',
+		hasSuggestions: true,
 		messages: {
 			[MESSAGE_ID]: 'Prefer default parameters over reassignment.',
 			[MESSAGE_ID_SUGGEST]: 'Replace reassignment with default parameter.',
 		},
-		hasSuggestions: true,
 	},
 };

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -75,7 +75,7 @@ module.exports = {
 			description: 'Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-dom-node-text-content.js
+++ b/rules/prefer-dom-node-text-content.js
@@ -57,7 +57,7 @@ module.exports = {
 		docs: {
 			description: 'Prefer `.textContent` over `.innerText`.',
 		},
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -86,10 +86,10 @@ module.exports = {
 			description: 'Prefer `.includes()` over `.indexOf()` and `Array#some()` when checking for existence or non-existence.',
 		},
 		fixable: 'code',
+		hasSuggestions: true,
 		messages: {
 			...messages,
 			...includesOverSomeRule.messages,
 		},
-		hasSuggestions: true,
 	},
 };

--- a/rules/prefer-math-trunc.js
+++ b/rules/prefer-math-trunc.js
@@ -108,7 +108,7 @@ module.exports = {
 			description: 'Enforce the use of `Math.trunc` instead of bitwise operators.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-module.js
+++ b/rules/prefer-module.js
@@ -326,7 +326,7 @@ module.exports = {
 			description: 'Prefer JavaScript modules (ESM) over CommonJS.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -145,8 +145,8 @@ module.exports = {
 			description: 'Prefer `Number` static properties over global ones.',
 		},
 		fixable: 'code',
+		hasSuggestions: true,
 		schema,
 		messages,
-		hasSuggestions: true,
 	},
 };

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -194,7 +194,7 @@ module.exports = {
 			description: 'Prefer `Set#has()` over `Array#includes()` when checking for existence or non-existence.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -482,7 +482,7 @@ module.exports = {
 			description: 'Prefer the spread operator over `Array.from(…)`, `Array#concat(…)`, `Array#slice()` and `String#split(\'\')`.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -179,7 +179,7 @@ module.exports = {
 			description: 'Prefer `String#startsWith()` & `String#endsWith()` over `RegExp#test()`.',
 		},
 		fixable: 'code',
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -95,7 +95,7 @@ module.exports = {
 		docs: {
 			description: 'Prefer top-level await over top-level promises and async function calls.',
 		},
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/require-post-message-target-origin.js
+++ b/rules/require-post-message-target-origin.js
@@ -63,7 +63,7 @@ module.exports = {
 		docs: {
 			description: 'Enforce using the `targetOrigin` argument with `window.postMessage()`.',
 		},
-		messages,
 		hasSuggestions: true,
+		messages,
 	},
 };

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -179,8 +179,8 @@ module.exports = {
 			description: 'Enforce better string content.',
 		},
 		fixable: 'code',
+		hasSuggestions: true,
 		schema,
 		messages,
-		hasSuggestions: true,
 	},
 };


### PR DESCRIPTION
https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/releases/tag/v4.0.0

The `meta.fixable` and `meta.hasSuggestions` properties are now grouped together by the [eslint-plugin/meta-property-ordering](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/meta-property-ordering.md) rule.