### PR TITLE
Update `eslint-remote-tester` to v2

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - run: |
           npm install
           npm link
           npm link eslint-plugin-unicorn
-      - uses: AriPerkkio/eslint-remote-tester-run-action@v1
+      - uses: AriPerkkio/eslint-remote-tester-run-action@v2
         with:
           issue-title: "Results of weekly scheduled smoke test"
           eslint-remote-tester-config: test/smoke/eslint-remote-tester.config.js

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"eslint": "^8.0.0",
 		"eslint-ava-rule-tester": "^4.0.0",
 		"eslint-plugin-eslint-plugin": "^4.0.1",
-		"eslint-remote-tester": "^1.3.0",
+		"eslint-remote-tester": "^2.0.1",
 		"eslint-remote-tester-repositories": "^0.0.3",
 		"execa": "^5.1.1",
 		"listr": "^0.14.3",


### PR DESCRIPTION
Fixes #1550.

- `AriPerkkio/eslint-remote-tester-run-action@v2` adds support for ESLint v8. https://github.com/AriPerkkio/eslint-remote-tester-run-action/releases/tag/v2
- `eslint-remote-tester@2` improves erroneous ruleId parsing when used with ESLint v8. https://github.com/AriPerkkio/eslint-remote-tester/blob/master/CHANGELOG.md

Test run: https://github.com/AriPerkkio/eslint-plugin-unicorn/runs/4061394157