### PR TITLE
Add basic tests of rule docs

### DIFF
--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -1,4 +1,4 @@
-# Enforce correct Error subclassing
+# Enforce correct `Error` subclassing
 
 Enforces the only valid way of `Error` subclassing. It works with any super class that ends in `Error`.
 

--- a/docs/rules/new-for-builtins.md
+++ b/docs/rules/new-for-builtins.md
@@ -1,4 +1,4 @@
-# Enforce the use of `new` for all builtins, except `String`, `Number` and `Boolean`
+# Enforce the use of `new` for all builtins, except `String`, `Number`, `Boolean`, `Symbol` and `BigInt`
 
 They work the same, but `new` should be preferred for consistency with other constructors.
 

--- a/docs/rules/no-null.md
+++ b/docs/rules/no-null.md
@@ -1,4 +1,4 @@
-# Disallow the use of the `null` literal.
+# Disallow the use of the `null` literal
 
 Disallow the use of the `null` literal, to encourage using `undefined` instead.
 

--- a/docs/rules/no-useless-spread.md
+++ b/docs/rules/no-useless-spread.md
@@ -1,4 +1,4 @@
-# Disallow useless spread
+# Disallow unnecessary spread
 
 - Using spread syntax in the following cases is unnecessary:
 

--- a/docs/rules/prefer-dom-node-dataset.md
+++ b/docs/rules/prefer-dom-node-dataset.md
@@ -1,4 +1,6 @@
-# Prefer using [`.dataset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) on DOM elements over `.setAttribute(…)`
+# Prefer using `.dataset` on DOM elements over `.setAttribute(…)`
+
+Use [`.dataset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) on DOM elements over `.setAttribute(…)`.
 
 This rule is fixable.
 

--- a/docs/rules/prefer-modern-dom-apis.md
+++ b/docs/rules/prefer-modern-dom-apis.md
@@ -1,4 +1,4 @@
-# Prefer modern DOM APIs
+# Prefer `.before()` over `.insertBefore()`, `.replaceWith()` over `.replaceChild()`, prefer one of `.before()`, `.after()`, `.append()` or `.prepend()` over `insertAdjacentText()` and `insertAdjacentElement()`
 
 Enforces the use of:
 

--- a/docs/rules/prefer-number-properties.md
+++ b/docs/rules/prefer-number-properties.md
@@ -1,4 +1,4 @@
-# Prefer `Number` static properties over global ones.
+# Prefer `Number` static properties over global ones
 
 Enforces the use of:
 
@@ -77,7 +77,7 @@ const isPositiveZero = value => value === 0 && 1 / value === Number.POSITIVE_INF
 const isNegativeZero = value => value === 0 && 1 / value === Number.NEGATIVE_INFINITY;
 ```
 
-# Options
+## Options
 
 Type: `object`
 

--- a/docs/rules/prefer-prototype-methods.md
+++ b/docs/rules/prefer-prototype-methods.md
@@ -1,4 +1,4 @@
-# Prefer borrowing methods from the prototype instead of methods from an instance
+# Prefer borrowing methods from the prototype instead of the instance
 
 When “borrowing” a method from `Array` or `Object`, it‘s clearer to get it from the prototype than from an instance.
 

--- a/docs/rules/prefer-switch.md
+++ b/docs/rules/prefer-switch.md
@@ -48,7 +48,7 @@ switch (foo) {
 }
 ```
 
-### `options`
+## Options
 
 Type: `object`
 

--- a/scripts/create-rule.mjs
+++ b/scripts/create-rule.mjs
@@ -6,7 +6,7 @@ import {fileURLToPath} from 'node:url';
 import enquirer from 'enquirer';
 import {template} from 'lodash-es';
 import execa from 'execa';
-import ruleDescriptionToDocTitle from '../test/utils/rule-description-to-doc-title.mjs';
+import ruleDescriptionToDocumentTitle from '../test/utils/rule-description-to-document-title.mjs';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(dirname, '..');
@@ -139,7 +139,7 @@ function updateRecommended(id) {
 		data.fixableType = false;
 	}
 
-	data.docTitle = ruleDescriptionToDocTitle(data.description);
+	data.docTitle = ruleDescriptionToDocumentTitle(data.description);
 
 	const {id} = data;
 

--- a/scripts/create-rule.mjs
+++ b/scripts/create-rule.mjs
@@ -6,6 +6,7 @@ import {fileURLToPath} from 'node:url';
 import enquirer from 'enquirer';
 import {template} from 'lodash-es';
 import execa from 'execa';
+import ruleDescriptionToDocTitle from '../test/utils/rule-description-to-doc-title.mjs';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(dirname, '..');
@@ -137,6 +138,8 @@ function updateRecommended(id) {
 	if (data.fixableType === 'No') {
 		data.fixableType = false;
 	}
+
+	data.docTitle = ruleDescriptionToDocTitle(data.description);
 
 	const {id} = data;
 

--- a/scripts/template/documentation.md.jst
+++ b/scripts/template/documentation.md.jst
@@ -1,4 +1,4 @@
-# <%= description %>
+# <%= docTitle %>
 
 <!-- More detailed description. Remove this comment. -->
 <% if (fixableType) { %>

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -4,6 +4,7 @@ import {createRequire} from 'node:module';
 import test from 'ava';
 import {ESLint} from 'eslint';
 import index from '../index.js';
+import ruleDescriptionToDocTitle from './utils/rule-description-to-doc-title.mjs';
 
 const require = createRequire(import.meta.url);
 let ruleFiles;
@@ -31,15 +32,6 @@ const testSorted = (t, actualOrder, sourceName) => {
 		t.is(actualIndex, wantedIndex, `${sourceName} should be alphabetically sorted, '${name}' should be placed at index ${wantedIndex}${whereMessage}`);
 	}
 };
-
-function toSentenceCase(originalString) {
-	let newString = originalString.charAt(0).toUpperCase() + originalString.slice(1); // Capitalize first letter.
-	if (newString.endsWith('.')) {
-		newString = newString.slice(0, -1); // Remove any ending period.
-	}
-
-	return newString;
-}
 
 /**
 Get list of named options from a JSON schema (used for rule schemas).
@@ -193,7 +185,7 @@ test('Every rule has a doc with the appropriate content', t => {
 		const documentLines = documentContents.split('\n');
 
 		// Check title.
-		const expectedTitle = `# ${toSentenceCase(rule.meta.docs.description)}`;
+		const expectedTitle = `# ${ruleDescriptionToDocTitle(rule.meta.docs.description)}`;
 		t.is(documentLines[0], expectedTitle, `${ruleName} includes the rule description in title`);
 
 		// Check if the rule has configuration options.

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -4,7 +4,7 @@ import {createRequire} from 'node:module';
 import test from 'ava';
 import {ESLint} from 'eslint';
 import index from '../index.js';
-import ruleDescriptionToDocTitle from './utils/rule-description-to-doc-title.mjs';
+import ruleDescriptionToDocumentTitle from './utils/rule-description-to-document-title.mjs';
 
 const require = createRequire(import.meta.url);
 let ruleFiles;
@@ -185,7 +185,7 @@ test('Every rule has a doc with the appropriate content', t => {
 		const documentLines = documentContents.split('\n');
 
 		// Check title.
-		const expectedTitle = `# ${ruleDescriptionToDocTitle(rule.meta.docs.description)}`;
+		const expectedTitle = `# ${ruleDescriptionToDocumentTitle(rule.meta.docs.description)}`;
 		t.is(documentLines[0], expectedTitle, `${ruleName} includes the rule description in title`);
 
 		// Check if the rule has configuration options.

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -42,10 +42,11 @@ function toSentenceCase(originalString) {
 }
 
 /**
- * Get list of named options from a JSON schema (used for rule schemas).
- * @param {Object|Array} jsonSchema - the JSON schema to check
- * @returns {String[]} list of named options
- */
+Get list of named options from a JSON schema (used for rule schemas).
+
+@param {object | Array} jsonSchema - The JSON schema to check.
+@returns {string[]} A list of named options.
+*/
 function getNamedOptions(jsonSchema) {
 	if (!jsonSchema) {
 		return [];

--- a/test/utils/rule-description-to-doc-title.mjs
+++ b/test/utils/rule-description-to-doc-title.mjs
@@ -1,0 +1,14 @@
+/**
+From a rule's description, generate the intended title for its rule doc.
+
+@param {string} description - rule description
+@returns {string} title for rule doc
+*/
+export default function (description) {
+	let title = description.charAt(0).toUpperCase() + description.slice(1); // Capitalize first letter.
+	if (title.endsWith('.')) {
+		title = title.slice(0, -1); // Remove any ending period.
+	}
+
+	return title;
+}

--- a/test/utils/rule-description-to-doc-title.mjs
+++ b/test/utils/rule-description-to-doc-title.mjs
@@ -4,7 +4,7 @@ From a rule's description, generate the intended title for its rule doc.
 @param {string} description - rule description
 @returns {string} title for rule doc
 */
-export default function (description) {
+export default function ruleDescriptionToDocTitle(description) {
 	let title = description.charAt(0).toUpperCase() + description.slice(1); // Capitalize first letter.
 	if (title.endsWith('.')) {
 		title = title.slice(0, -1); // Remove any ending period.

--- a/test/utils/rule-description-to-document-title.mjs
+++ b/test/utils/rule-description-to-document-title.mjs
@@ -4,7 +4,7 @@ From a rule's description, generate the intended title for its rule doc.
 @param {string} description - rule description
 @returns {string} title for rule doc
 */
-export default function ruleDescriptionToDocTitle(description) {
+export default function ruleDescriptionToDocumentTitle(description) {
 	let title = description.charAt(0).toUpperCase() + description.slice(1); // Capitalize first letter.
 	if (title.endsWith('.')) {
 		title = title.slice(0, -1); // Remove any ending period.


### PR DESCRIPTION
1. Ensure rule doc title matches rule description (prevents these titles from becoming out-of-date).
2. Ensure rules with options have an `## Options` section and rules without options don't.
3. Ensure rules with options have their named options mentioned in their rule doc.

