### PR TITLE
Turn of `require-post-message-target-origin` rule in recommended configs by default

### DIFF
--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -96,18 +96,12 @@ module.exports = {
 		'unicorn/prevent-abbreviations': 'error',
 		'unicorn/require-array-join-separator': 'error',
 		'unicorn/require-number-to-fixed-digits-argument': 'error',
-		'unicorn/require-post-message-target-origin': 'error',
+		// Turned off because we can't distinguish `widow.postMessage` and `{Worker,MessagePort,Client,BroadcastChannel}#postMessage()`
+		// See #1396
+		'unicorn/require-post-message-target-origin': 'off',
 		'unicorn/string-content': 'off',
 		'unicorn/template-indent': 'warn',
 		'unicorn/throw-new-error': 'error',
 		...require('./conflicting-rules.js').rules,
 	},
-	overrides: [
-		{
-			files: ['*.ts', '*.tsx'],
-			rules: {
-				'unicorn/require-post-message-target-origin': 'off',
-			},
-		},
-	],
 };

--- a/docs/rules/require-post-message-target-origin.md
+++ b/docs/rules/require-post-message-target-origin.md
@@ -2,6 +2,8 @@
 
 When calling [`window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) without the `targetOrigin` argument, the message cannot be received by any window.
 
+This rule can't distinguish `window.postMessage()` and other calls like [`Worker#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage), [` MessagePort#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage), [`Client#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Client/postMessage), and [`BroadcastChannel#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/postMessage), use on your own risk.
+
 ## Fail
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -125,22 +125,11 @@ Configure it in `package.json`.
 			"unicorn/prevent-abbreviations": "error",
 			"unicorn/require-array-join-separator": "error",
 			"unicorn/require-number-to-fixed-digits-argument": "error",
-			"unicorn/require-post-message-target-origin": "error",
+			"unicorn/require-post-message-target-origin": "off",
 			"unicorn/string-content": "off",
 			"unicorn/template-indent": "warn",
 			"unicorn/throw-new-error": "error"
-		},
-		"overrides": [
-			{
-				"files": [
-					"*.ts",
-					"*.tsx"
-				],
-				"rules": {
-					"unicorn/require-post-message-target-origin": "off"
-				}
-			}
-		]
+		}
 	}
 }
 ```
@@ -248,7 +237,7 @@ Each rule has emojis denoting:
 | [prevent-abbreviations](docs/rules/prevent-abbreviations.md) | Prevent abbreviations. | ✅ | 🔧 |  |
 | [require-array-join-separator](docs/rules/require-array-join-separator.md) | Enforce using the separator argument with `Array#join()`. | ✅ | 🔧 |  |
 | [require-number-to-fixed-digits-argument](docs/rules/require-number-to-fixed-digits-argument.md) | Enforce using the digits argument with `Number#toFixed()`. | ✅ | 🔧 |  |
-| [require-post-message-target-origin](docs/rules/require-post-message-target-origin.md) | Enforce using the `targetOrigin` argument with `window.postMessage()`. | ✅ |  | 💡 |
+| [require-post-message-target-origin](docs/rules/require-post-message-target-origin.md) | Enforce using the `targetOrigin` argument with `window.postMessage()`. |  |  | 💡 |
 | [string-content](docs/rules/string-content.md) | Enforce better string content. |  | 🔧 | 💡 |
 | [template-indent](docs/rules/template-indent.md) | Fix whitespace-insensitive template indentation. |  | 🔧 |  |
 | [throw-new-error](docs/rules/throw-new-error.md) | Require `new` when throwing an error. | ✅ | 🔧 |  |


### PR DESCRIPTION
Fixes #1396
Fixes #1552