### PR TITLE
Add missing `additionalProperties` to schema

### DIFF
--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -101,6 +101,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			sortCharacterClasses: {
 				type: 'boolean',

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -100,6 +100,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			name: {
 				type: 'string',

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -196,6 +196,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			checkArrowFunctions: {
 				type: 'boolean',

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -510,6 +510,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			terms: {
 				type: 'array',
@@ -530,7 +531,6 @@ const schema = [
 				default: false,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -185,6 +185,7 @@ function create(context) {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			'non-zero': {
 				enum: [...nonZeroStyles.keys()],

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -37,13 +37,13 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			ignoreImports: {
 				type: 'boolean',
 				default: false,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -313,6 +313,7 @@ const schema = {
 	items: [
 		{
 			type: 'object',
+			additionalProperties: false,
 			properties: {
 				checkImport: {
 					type: 'boolean',
@@ -333,7 +334,6 @@ const schema = {
 					$ref: '#/definitions/moduleStyles',
 				},
 			},
-			additionalProperties: false,
 		},
 	],
 	definitions: {

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -110,13 +110,13 @@ function create(context) {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			ignore: {
 				type: 'array',
 				uniqueItems: true,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -38,6 +38,7 @@ const selector = matches([
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			allowSimpleOperations: {
 				type: 'boolean',

--- a/rules/no-keyword-prefix.js
+++ b/rules/no-keyword-prefix.js
@@ -167,6 +167,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			disallowedPrefixes: {
 				type: 'array',
@@ -185,7 +186,6 @@ const schema = [
 				type: 'boolean',
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -93,13 +93,13 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			checkStrictEquality: {
 				type: 'boolean',
 				default: false,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -190,12 +190,12 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			checkArguments: {
 				type: 'boolean',
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/numeric-separators-style.js
+++ b/rules/numeric-separators-style.js
@@ -133,6 +133,7 @@ const create = context => {
 
 const formatOptionsSchema = ({minimumDigits, groupLength}) => ({
 	type: 'object',
+	additionalProperties: false,
 	properties: {
 		onlyIfContainsSeparator: {
 			type: 'boolean',
@@ -148,11 +149,11 @@ const formatOptionsSchema = ({minimumDigits, groupLength}) => ({
 			default: groupLength,
 		},
 	},
-	additionalProperties: false,
 });
 
 const schema = [{
 	type: 'object',
+	additionalProperties: false,
 	properties: {
 		...Object.fromEntries(
 			Object.entries(defaultOptions).map(([type, options]) => [type, formatOptionsSchema(options)]),
@@ -162,7 +163,6 @@ const schema = [{
 			default: false,
 		},
 	},
-	additionalProperties: false,
 }];
 
 module.exports = {

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -157,6 +157,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			excludedPackages: {
 				type: 'array',
@@ -166,7 +167,6 @@ const schema = [
 				uniqueItems: true,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -234,13 +234,13 @@ function create(context) {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			functions: {
 				type: 'array',
 				uniqueItems: true,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -284,6 +284,7 @@ function create(context) {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			getLastElementFunctions: {
 				type: 'array',
@@ -294,7 +295,6 @@ const schema = [
 				default: false,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/prefer-node-protocol.js
+++ b/rules/prefer-node-protocol.js
@@ -50,13 +50,13 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			checkRequire: {
 				type: 'boolean',
 				default: false,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -127,13 +127,13 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			checkInfinity: {
 				type: 'boolean',
 				default: true,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/prefer-object-from-entries.js
+++ b/rules/prefer-object-from-entries.js
@@ -249,13 +249,13 @@ function create(context) {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			functions: {
 				type: 'array',
 				uniqueItems: true,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/prefer-object-has-own.js
+++ b/rules/prefer-object-has-own.js
@@ -81,13 +81,13 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			functions: {
 				type: 'array',
 				uniqueItems: true,
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/prefer-switch.js
+++ b/rules/prefer-switch.js
@@ -302,6 +302,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			minimumCases: {
 				type: 'integer',
@@ -317,7 +318,6 @@ const schema = [
 				default: 'no-default-comment',
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -534,6 +534,7 @@ const schema = {
 	items: [
 		{
 			type: 'object',
+			additionalProperties: false,
 			properties: {
 				checkProperties: {
 					type: 'boolean',
@@ -578,7 +579,6 @@ const schema = {
 					uniqueItems: true,
 				},
 			},
-			additionalProperties: false,
 		},
 	],
 	definitions: {

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -136,6 +136,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			patterns: {
 				type: 'object',
@@ -167,7 +168,6 @@ const schema = [
 					],
 				}},
 		},
-		additionalProperties: false,
 	},
 ];
 

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -104,6 +104,7 @@ const create = context => {
 const schema = [
 	{
 		type: 'object',
+		additionalProperties: false,
 		properties: {
 			indent: {
 				oneOf: [
@@ -146,7 +147,6 @@ const schema = [
 				},
 			},
 		},
-		additionalProperties: false,
 	},
 ];
 


### PR DESCRIPTION
Add missing `additionalProperties` in schema, and move them under `type` field.