### PR TITLE
`prevent-abbreviations`: Show file basename instead of full path

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -502,9 +502,9 @@ const create = context => {
 				return;
 			}
 
-			const extension = path.extname(filenameWithExtension);
-			const filename = path.basename(filenameWithExtension, extension);
-			const filenameReplacements = getNameReplacements(filename, options);
+			const filename = path.basename(filenameWithExtension);
+			const extension = path.extname(filename);
+			const filenameReplacements = getNameReplacements(path.basename(filename, extension), options);
 
 			if (filenameReplacements.total === 0) {
 				return;
@@ -513,7 +513,7 @@ const create = context => {
 			filenameReplacements.samples = filenameReplacements.samples.map(replacement => `${replacement}${extension}`);
 
 			context.report({
-				...getMessage(filenameWithExtension, filenameReplacements, 'filename'),
+				...getMessage(filename, filenameReplacements, 'filename'),
 				node,
 			});
 		},

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1907,7 +1907,7 @@ test({
 		{
 			code: 'foo();',
 			filename: '/path/to/doc/__prev-Attr$1Err__.conf.js',
-			errors: createErrors('The filename `/path/to/doc/__prev-Attr$1Err__.conf.js` should be named `__previous-Attribute$1Error__.config.js`. A more descriptive name will do too.'),
+			errors: createErrors('The filename `__prev-Attr$1Err__.conf.js` should be named `__previous-Attribute$1Error__.config.js`. A more descriptive name will do too.'),
 		},
 		{
 			code: 'foo();',


### PR DESCRIPTION
Report formatter normally include a full path to the file, it's not necessary to show full path.
And it's hard to snapshot messages for shareable configs test.