### PR TITLE
Add `markdownlint`

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "line-length": false,
+  "no-duplicate-heading": false,
+  "no-hard-tabs": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,7 @@
 	"line-length": false,
 	"no-duplicate-heading": false,
 	"no-hard-tabs": false,
-	"ul-style": { "style": "dash" }
+	"ul-style": {
+		"style": "dash"
+	}
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
 	"line-length": false,
 	"no-duplicate-heading": false,
-	"no-hard-tabs": false
+	"no-hard-tabs": false,
+	"ul-style": { "style": "dash" }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,5 @@
 {
-  "line-length": false,
-  "no-duplicate-heading": false,
-  "no-hard-tabs": false
+	"line-length": false,
+	"no-duplicate-heading": false,
+	"no-hard-tabs": false
 }

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+node_modules
+test/snapshots

--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -4,7 +4,6 @@
 
 A function definition should be placed as close to the top-level scope as possible without breaking its captured values. This improves readability, [directly improves performance](https://stackoverflow.com/a/81329/207247) and allows JavaScript engines to [better optimize performance](https://ponyfoo.com/articles/javascript-performance-pitfalls-v8#optimization-limit).
 
-
 ## Fail
 
 ```js
@@ -23,7 +22,6 @@ function doFoo(foo) {
 	};
 }
 ```
-
 
 ## Pass
 

--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -6,7 +6,6 @@
 
 Enforces the only valid way of `Error` subclassing. It works with any super class that ends in `Error`.
 
-
 ## Fail
 
 ```js
@@ -21,7 +20,6 @@ class CustomError extends Error {
 
 The `this.message` assignment is useless as it's already set via the `super()` call.
 
-
 ```js
 class CustomError extends Error {
 	constructor(message) {
@@ -34,7 +32,6 @@ class CustomError extends Error {
 
 Pass the error message to `super()` instead of setting `this.message`.
 
-
 ```js
 class CustomError extends Error {
 	constructor(message) {
@@ -44,7 +41,6 @@ class CustomError extends Error {
 ```
 
 No `name` property set. The name property is needed so the error shows up as `[CustomError: foo]` and not `[Error: foo]`.
-
 
 ```js
 class CustomError extends Error {
@@ -57,7 +53,6 @@ class CustomError extends Error {
 
 Use a string literal to set the `name` property as it will not change after minifying.
 
-
 ```js
 class CustomError extends Error {
 	constructor(message) {
@@ -69,7 +64,6 @@ class CustomError extends Error {
 
 The `name` property should be set to the class name.
 
-
 ```js
 class foo extends Error {
 	constructor(message) {
@@ -80,7 +74,6 @@ class foo extends Error {
 ```
 
 The class name is invalid. It should be capitalized and end with `Error`. In this case it should be `FooError`.
-
 
 ## Pass
 

--- a/docs/rules/error-message.md
+++ b/docs/rules/error-message.md
@@ -4,7 +4,6 @@
 
 This rule enforces a `message` value to be passed in when creating an instance of a built-in [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) object, which leads to more readable and debuggable code.
 
-
 ## Fail
 
 ```js
@@ -22,7 +21,6 @@ throw new TypeError();
 ```js
 const error = new AggregateError(errors);
 ```
-
 
 ## Pass
 

--- a/docs/rules/escape-case.md
+++ b/docs/rules/escape-case.md
@@ -6,7 +6,6 @@
 
 Enforces defining escape sequence values with uppercase characters rather than lowercase ones. This promotes readability by making the escaped value more distinguishable from the identifier.
 
-
 ## Fail
 
 ```js
@@ -15,7 +14,6 @@ const foo = '\ud834';
 const foo = '\u{1d306}';
 const foo = '\ca';
 ```
-
 
 ## Pass
 

--- a/docs/rules/explicit-length-check.md
+++ b/docs/rules/explicit-length-check.md
@@ -156,9 +156,9 @@ You can define your preferred way of checking non-zero length by providing a `no
 The `non-zero` option can be configured with one of the following:
 
 - `greater-than` (default)
-	- Enforces non-zero to be checked with: `foo.length > 0`
+  - Enforces non-zero to be checked with: `foo.length > 0`
 - `not-equal`
-	- Enforces non-zero to be checked with: `foo.length !== 0`
+  - Enforces non-zero to be checked with: `foo.length !== 0`
 
 ## Unsafe to fix case
 

--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -8,6 +8,8 @@ Files named `index.js`, `index.mjs`, `index.cjs`, `index.ts`, `index.tsx`, `inde
 
 Characters in the filename except `a-z`, `A-Z`, `0-9`, `-`, `_` and `$` are ignored.
 
+## Cases
+
 ### `kebabCase`
 
 - `foo-bar.js`
@@ -31,7 +33,6 @@ Characters in the filename except `a-z`, `A-Z`, `0-9`, `-`, `_` and `$` are igno
 - `FooBar.js`
 - `FooBar.Test.js`
 - `FooBar.TestUtils.js`
-
 
 ## Options
 
@@ -80,6 +81,7 @@ When a string is given, it's interpreted as a regular expressions inside a strin
 Sometimes you may have non-standard filenames in a project. This option lets you ignore those files.
 
 For example:
+
 - Vendor packages that are not published and was copy-pasted.
 - Ignore some files when you use [eslint-plugin-markdown](https://github.com/eslint/eslint-plugin-markdown), for example `README.md`.
 - Some tools may require special names for some files.

--- a/docs/rules/import-index.md
+++ b/docs/rules/import-index.md
@@ -6,7 +6,6 @@
 
 Enforces importing index file with `.` instead of `./`, `./index` or `./index.js`.
 
-
 ## Fail
 
 ```js
@@ -41,7 +40,6 @@ import m from './';
 import m from './index';
 ```
 
-
 ## Pass
 
 ```js
@@ -63,7 +61,6 @@ const m = require('@foo/bar');
 ```js
 import m from '.';
 ```
-
 
 ## Options
 

--- a/docs/rules/import-style.md
+++ b/docs/rules/import-style.md
@@ -5,6 +5,7 @@
 Sometimes a module contains unrelated functions, like `util`, thus it is a good practice to enforce destructuring or named imports here. Other times, in modules like `path`, it is good to use default import as they have similar functions, all likely to be utilized.
 
 This rule defines 4 import styles:
+
 - `unassigned` - `import 'foo'` or `require('foo')`
 - `default` - `import path from 'path'` or `const path = require('path')`
 - `namespace` - `import * as path from 'path'` or `const path = require('path')`
@@ -37,11 +38,13 @@ Type: `object`
 You can extend default import styles per module by passing the `styles` option.
 
 Default options per module are:
+
 - `util` - `named` only
 - `path` - `default` only
 - `chalk` - `default` only
 
 The example below:
+
 - Disables any restrictions on the `util` module imports.
 - Allows `named` import (leaving `default` allowed too) from the `path` module (by default only `default` import of `path` is allowed).
 

--- a/docs/rules/no-abusive-eslint-disable.md
+++ b/docs/rules/no-abusive-eslint-disable.md
@@ -33,7 +33,6 @@ console.log(message); // `message` is not defined, but it won't be reported
 
 This rule enforces specifying the rules to disable. If you want to disable ESLint on a file altogether, you should ignore it through [`.eslintignore`](https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories) for ESLint or through the [`ignores` property](https://github.com/xojs/xo#ignores) in `package.json` for `XO`.
 
-
 ## Fail
 
 ```js
@@ -45,7 +44,6 @@ console.log(message); // eslint-disable-line
 // eslint-disable-next-line
 console.log(message);
 ```
-
 
 ## Pass
 

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -54,6 +54,7 @@ for (const element of array) {
 	result += element;
 }
 ```
+
 ## Options
 
 ### allowSimpleOperations

--- a/docs/rules/no-console-spaces.md
+++ b/docs/rules/no-console-spaces.md
@@ -6,7 +6,6 @@
 
 The [`console.log()` method](https://developer.mozilla.org/en-US/docs/Web/API/Console/log) and similar methods joins the parameters with a space, so adding a leading/trailing space to a parameter, results in two spaces being added.
 
-
 ## Fail
 
 ```js
@@ -21,7 +20,6 @@ console.info('abc ', 'def');
 console.warn('abc ', 'def');
 console.error('abc ', 'def');
 ```
-
 
 ## Pass
 

--- a/docs/rules/no-for-loop.md
+++ b/docs/rules/no-for-loop.md
@@ -10,7 +10,6 @@ Off-by-one errors are one of the most common bugs in software. [Swift actually r
 
 This rule is fixable unless index or element variables were used outside of the loop.
 
-
 ## Fail
 
 ```js
@@ -19,7 +18,6 @@ for (let index = 0; index < array.length; index++) {
 	console.log(index, element);
 }
 ```
-
 
 ## Pass
 

--- a/docs/rules/no-hex-escape.md
+++ b/docs/rules/no-hex-escape.md
@@ -6,14 +6,12 @@
 
 Enforces a convention of using [Unicode escapes](https://mathiasbynens.be/notes/javascript-escapes#unicode) instead of [hexadecimal escapes](https://mathiasbynens.be/notes/javascript-escapes#hexadecimal) for consistency and clarity.
 
-
 ## Fail
 
 ```js
 const foo = '\x1B';
 const foo = `\x1B${bar}`;
 ```
-
 
 ## Pass
 

--- a/docs/rules/no-instanceof-array.md
+++ b/docs/rules/no-instanceof-array.md
@@ -6,14 +6,12 @@
 
 The `instanceof Array` check doesn't work across realms/contexts, for example, frames/windows in browsers or the `vm` module in Node.js.
 
-
 ## Fail
 
 ```js
 array instanceof Array;
 [1,2,3] instanceof Array;
 ```
-
 
 ## Pass
 

--- a/docs/rules/no-keyword-prefix.md
+++ b/docs/rules/no-keyword-prefix.md
@@ -11,7 +11,6 @@ const newFoo = 'foo';
 const classFoo = 'foo';
 ```
 
-
 ## Pass
 
 ```js
@@ -20,7 +19,6 @@ const _newFoo = 'foo';
 const new_foo = 'foo';
 const fooNew = 'foo';
 ```
-
 
 ## Options
 

--- a/docs/rules/no-nested-ternary.md
+++ b/docs/rules/no-nested-ternary.md
@@ -6,7 +6,6 @@
 
 Improved version of the [`no-nested-ternary`](https://eslint.org/docs/rules/no-nested-ternary) ESLint rule, which allows cases where the nested ternary is only one level and wrapped in parens.
 
-
 ## Fail
 
 ```js
@@ -14,14 +13,12 @@ const foo = i > 5 ? i < 100 ? true : false : true;
 const foo = i > 5 ? true : (i < 100 ? true : (i < 1000 ? true : false));
 ```
 
-
 ## Pass
 
 ```js
 const foo = i > 5 ? (i < 100 ? true : false) : true;
 const foo = i > 5 ? (i < 100 ? true : false) : (i < 100 ? true : false);
 ```
-
 
 ## Partly fixable
 
@@ -36,7 +33,6 @@ will get fixed to
 ```js
 const foo = i > 5 ? (i < 100 ? true : false) : true
 ```
-
 
 ## Disabling ESLint `no-nested-ternary`
 

--- a/docs/rules/no-new-buffer.md
+++ b/docs/rules/no-new-buffer.md
@@ -12,7 +12,7 @@ Enforces the use of [Buffer.from](https://nodejs.org/api/buffer.html#buffer_clas
 const buffer = new Buffer('7468697320697320612074c3a97374', 'hex');
 ```
 
-```
+```js
 const buffer = new Buffer([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 ```
 

--- a/docs/rules/no-object-as-default-parameter.md
+++ b/docs/rules/no-object-as-default-parameter.md
@@ -18,7 +18,6 @@ function foo({a} = {a: false}) {}
 const abc = (foo = {a: false, b: 123}) => {};
 ```
 
-
 ## Pass
 
 ```js

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -4,13 +4,11 @@
 
 This rule is an extension to ESLint's [`no-process-exit` rule](https://eslint.org/docs/rules/no-process-exit), that allows `process.exit()` to be called in files that start with a [hashbang](https://en.wikipedia.org/wiki/Shebang_(Unix)) → `#!/usr/bin/env node`. It also allows `process.exit()` to be called in `process.on('<event>', func)` event handlers and in files that imports `worker_threads`.
 
-
 ## Fail
 
 ```js
 process.exit(0);
 ```
-
 
 ## Pass
 

--- a/docs/rules/no-unreadable-array-destructuring.md
+++ b/docs/rules/no-unreadable-array-destructuring.md
@@ -24,7 +24,6 @@ const [,,,, foo] = parts;
 const [,,...rest] = parts;
 ```
 
-
 ## Pass
 
 ```js

--- a/docs/rules/no-unsafe-regex.md
+++ b/docs/rules/no-unsafe-regex.md
@@ -4,7 +4,6 @@
 
 Uses [safe-regex](https://github.com/substack/safe-regex) to disallow potentially [catastrophic](https://regular-expressions.mobi/catastrophic.html) [exponential-time](https://perlgeek.de/blog-en/perl-tips/in-search-of-an-exponetial-regexp.html) regular expressions.
 
-
 ## Fail
 
 ```js
@@ -16,7 +15,6 @@ const regex = /(a+){10}y/;
 const regex = /(a+){2}y/;
 const regex = /(.*){1,32000}[bc]/;
 ```
-
 
 ## Pass
 

--- a/docs/rules/no-unused-properties.md
+++ b/docs/rules/no-unused-properties.md
@@ -6,7 +6,6 @@ Unused properties, much like unused variables, are often a result of incomplete 
 
 This rule is primarily useful when you use objects to group constants or model enumerations. It is much harder to predict class properties usage, and practically impossible to predict reflective property access. This rule ignores cases like that.
 
-
 ## Example use cases
 
 When using [React](https://reactjs.org)'s inline styles or one of [many CSS-in-JS](https://michelebertoli.github.io/css-in-js/) like [glamor](https://github.com/threepointone/glamor), one might find it helpful to group component styles into a constant object. Later you might remove one of the styles, but forget to remove its definition, especially if the component grew in complexity by that time. If these were defined as separate constants, ESLint's builtin `no-unused-vars` rule would have helped, but they are not. That's when the `no-unused-properties` rules becomes useful.
@@ -30,7 +29,6 @@ const ClassName = {
 };
 ```
 
-
 ## Fail
 
 ```js
@@ -43,7 +41,6 @@ console.log(enum.used);
 
 const {used} = enum;
 ```
-
 
 ## Pass
 
@@ -67,7 +64,6 @@ const foo = {
 	}
 };
 ```
-
 
 ## Scope and limitations
 

--- a/docs/rules/no-useless-spread.md
+++ b/docs/rules/no-useless-spread.md
@@ -6,21 +6,21 @@
 
 - Using spread syntax in the following cases is unnecessary:
 
-	- Spread an array literal as elements of an array literal
-	- Spread an array literal as arguments of a call or a `new` call
-	- Spread an object literal as properties of an object literal
+  - Spread an array literal as elements of an array literal
+  - Spread an array literal as arguments of a call or a `new` call
+  - Spread an object literal as properties of an object literal
 
 - The following builtins accept an iterable, so it's unnecessary to convert the iterable to an array:
 
-	- `Map` constructor
-	- `WeakMap` constructor
-	- `Set` constructor
-	- `WeakSet` constructor
-	- `TypedArray` constructor
-	- `Array.from(…)`
-	- `TypedArray.from(…)`
-	- `Promise.{all,allSettled,any,race}(…)`
-	- `Object.fromEntries(…)`
+  - `Map` constructor
+  - `WeakMap` constructor
+  - `Set` constructor
+  - `WeakSet` constructor
+  - `TypedArray` constructor
+  - `Array.from(…)`
+  - `TypedArray.from(…)`
+  - `Promise.{all,allSettled,any,race}(…)`
+  - `Object.fromEntries(…)`
 
 - `for…of` loop can iterate over any iterable object not just array, so it's unnecessary to convert the iterable to an array.
 

--- a/docs/rules/numeric-separators-style.md
+++ b/docs/rules/numeric-separators-style.md
@@ -71,6 +71,7 @@ The size of the first group can be of any length as long as it is equal to or le
 ### Details
 
 Numbers are split into 3 distinct parts:
+
 - The integer part (**123**.456). The remaining digits (that do not fit in a group) have to be placed at the beginning: `12_345`.
 - The fractional part (123.**456**). The remaining digits have to be placed at the end of the number: `1.234_56`.
 - The exponential part (123.456e**789**). It acts exactly as the integer part: groups have to be at the beginning.

--- a/docs/rules/prefer-add-event-listener.md
+++ b/docs/rules/prefer-add-event-listener.md
@@ -8,7 +8,6 @@ Enforces the use of `.addEventListener()` and `.removeEventListener()` over thei
 
 This rule is fixable (only for `.addEventListener()`).
 
-
 ## Fail
 
 ```js
@@ -44,7 +43,6 @@ foo.bar.addEventListener('click', onClick);
 ```js
 foo.removeEventListener('click', onClick);
 ```
-
 
 ## Options
 

--- a/docs/rules/prefer-array-flat-map.md
+++ b/docs/rules/prefer-array-flat-map.md
@@ -6,7 +6,6 @@
 
 [`Array#flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) performs [`Array#map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`Array#flat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) in one step.
 
-
 ## Fail
 
 ```js
@@ -16,7 +15,6 @@ const foo = bar.map(element => unicorn(element)).flat();
 ```js
 const foo = bar.map(element => unicorn(element)).flat(1);
 ```
-
 
 ## Pass
 

--- a/docs/rules/prefer-dom-node-append.md
+++ b/docs/rules/prefer-dom-node-append.md
@@ -6,13 +6,11 @@
 
 Enforces the use of, for example, `document.body.append(div);` over `document.body.appendChild(div);` for DOM nodes. There are [some advantages of using `Node#append()`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append), like the ability to append multiple nodes and to append both [`DOMString`](https://developer.mozilla.org/en-US/docs/Web/API/DOMString) and DOM node objects.
 
-
 ## Fail
 
 ```js
 foo.appendChild(bar);
 ```
-
 
 ## Pass
 

--- a/docs/rules/prefer-dom-node-dataset.md
+++ b/docs/rules/prefer-dom-node-dataset.md
@@ -6,13 +6,11 @@
 
 Use [`.dataset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) on DOM elements over `.setAttribute(…)`.
 
-
 ## Fail
 
 ```js
 element.setAttribute('data-unicorn', '🦄');
 ```
-
 
 ## Pass
 

--- a/docs/rules/prefer-dom-node-remove.md
+++ b/docs/rules/prefer-dom-node-remove.md
@@ -6,14 +6,12 @@
 
 Enforces the use of, for example, `child.remove();` over `child.parentNode.removeChild(child);`. The DOM function [`Node#remove()`](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove) is preferred over the indirect removal of an object with [`Node#removeChild()`](https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild).
 
-
 ## Fail
 
 ```js
 parentNode.removeChild(foo);
 parentNode.removeChild(this);
 ```
-
 
 ## Pass
 

--- a/docs/rules/prefer-keyboard-event-key.md
+++ b/docs/rules/prefer-keyboard-event-key.md
@@ -8,7 +8,6 @@ Enforces the use of [`KeyboardEvent#key`](https://developer.mozilla.org/en-US/do
 
 This rule is partly fixable. It can only fix direct property access.
 
-
 ## Fail
 
 ```js
@@ -24,7 +23,6 @@ window.addEventListener('keydown', event => {
 	}
 });
 ```
-
 
 ## Pass
 

--- a/docs/rules/prefer-object-from-entries.md
+++ b/docs/rules/prefer-object-from-entries.md
@@ -81,4 +81,3 @@ Example:
 // eslint unicorn/prefer-object-from-entries: ["error", {"functions": ["utils.fromPairs"]}]
 const object = utils.fromPairs(pairs); // Fails
 ```
-

--- a/docs/rules/prefer-query-selector.md
+++ b/docs/rules/prefer-query-selector.md
@@ -15,7 +15,6 @@ document.getElementsByTagName('main');
 document.getElementsByClassName(fn());
 ```
 
-
 ## Pass
 
 ```js

--- a/docs/rules/prefer-reflect-apply.md
+++ b/docs/rules/prefer-reflect-apply.md
@@ -6,7 +6,6 @@
 
 [`Reflect.apply()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply) is arguably less verbose and easier to understand. In addition, when you accept arbitrary methods, it's not safe to assume `.apply()` exists or is not overridden.
 
-
 ## Fail
 
 ```js
@@ -21,7 +20,6 @@ Function.prototype.apply.call(foo, null, arguments);
 foo.apply(this, arguments);
 Function.prototype.apply.call(foo, this, arguments);
 ```
-
 
 ## Pass
 

--- a/docs/rules/prefer-switch.md
+++ b/docs/rules/prefer-switch.md
@@ -54,7 +54,7 @@ switch (foo) {
 
 Type: `object`
 
-#### `minimumCases`
+### `minimumCases`
 
 Type: `integer`\
 Minimum: `2`\
@@ -102,7 +102,7 @@ else if (foo === 2) {}
 // Fails
 ```
 
-#### `emptyDefaultCase`
+### `emptyDefaultCase`
 
 Type: `string`\
 Default: `'no-default-comment'`

--- a/docs/rules/prefer-ternary.md
+++ b/docs/rules/prefer-ternary.md
@@ -129,9 +129,9 @@ Type: `string`\
 Default: `'always'`
 
 - `'always'` (default)
-	- Always report when using an `IfStatement` where a ternary expression can be used.
+  - Always report when using an `IfStatement` where a ternary expression can be used.
 - `'only-single-line'`
-	- Only check if the content of the `if` and/or `else` block is less than one line long.
+  - Only check if the content of the `if` and/or `else` block is less than one line long.
 
 The following case is considered valid:
 

--- a/docs/rules/prefer-type-error.md
+++ b/docs/rules/prefer-type-error.md
@@ -10,7 +10,6 @@ It's aware of the most commonly used type checking operators and identifiers lik
 
 The rule investigates every throw-statement which throws a generic `Error`. It will fail if the throw-statement is the only expression in the surrounding block and is preceeded by an if-statement whose condition consists of type-checks exclusively. You have to replace the `Error` with a `TypeError`.
 
-
 ## Fail
 
 ```js
@@ -38,7 +37,6 @@ if (typeof foo !== 'function' &&
 	throw new Error('Magic expected');
 }
 ```
-
 
 ## Pass
 

--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -79,6 +79,7 @@ Lowercase replacements will match both complete identifiers and separate words i
 Camelcase replacements will only match complete identifiers. For example `errCb` will only match `errCb` and `ErrCb`. It will not match `fooErrCb` or `errCbFoo`.
 
 The example below:
+
 - disables the default `e` → `event` replacement (leaving `e` → `error` enabled),
 - disables `res` replacement completely (both `res` → `response` and `res` → `result` from defaults are disabled),
 - adds a custom `cmd` → `command` replacement,

--- a/docs/rules/require-post-message-target-origin.md
+++ b/docs/rules/require-post-message-target-origin.md
@@ -6,7 +6,7 @@
 
 When calling [`window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) without the `targetOrigin` argument, the message cannot be received by any window.
 
-This rule cannot distinguish between `window.postMessage()` and other calls like [`Worker#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage), [` MessagePort#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage), [`Client#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Client/postMessage), and [`BroadcastChannel#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/postMessage). Use on your own risk.
+This rule cannot distinguish between `window.postMessage()` and other calls like [`Worker#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage), [`MessagePort#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage), [`Client#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Client/postMessage), and [`BroadcastChannel#postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/postMessage). Use on your own risk.
 
 ## Fail
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"node": ">=12"
 	},
 	"scripts": {
-		"test": "xo && nyc ava",
+		"test": "xo && nyc ava && markdownlint '**/*.md'",
 		"create-rule": "node ./scripts/create-rule.mjs && npm run generate-rules-table && npm run generate-usage-example",
 		"run-rules-on-codebase": "node ./test/run-rules-on-codebase/lint.mjs",
 		"integration": "node ./test/integration/test.mjs",
@@ -71,6 +71,7 @@
 		"execa": "^5.1.1",
 		"listr": "^0.14.3",
 		"lodash-es": "4.17.21",
+		"markdownlint-cli": "^0.29.0",
 		"mem": "^9.0.1",
 		"nyc": "^15.1.0",
 		"outdent": "^0.8.0",

--- a/readme.md
+++ b/readme.md
@@ -142,9 +142,9 @@ Configure it in `package.json`.
 
 Each rule has emojis denoting:
 
-* ✅ if it belongs to the `recommended` configuration
-* 🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
-* 💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
+- ✅ if it belongs to the `recommended` configuration
+- 🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
+- 💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
 
 <!-- Do not manually modify this table. Run: `npm run generate-rules-table` -->
 <!-- RULES_TABLE_START -->
@@ -291,12 +291,12 @@ See the [ESLint docs](https://eslint.org/docs/user-guide/configuring/configurati
 
 ## Maintainers
 
-* [Sindre Sorhus](https://github.com/sindresorhus)
-* [Adam Babcock](https://github.com/MrHen)
-* [futpib](https://github.com/futpib)
-* [Fisker Cheung](https://github.com/fisker)
+- [Sindre Sorhus](https://github.com/sindresorhus)
+- [Adam Babcock](https://github.com/MrHen)
+- [futpib](https://github.com/futpib)
+- [Fisker Cheung](https://github.com/fisker)
 
 ### Former
 
-* [Jeroen Engels](https://github.com/jfmengels)
-* [Sam Verschueren](https://github.com/SamVerschueren)
+- [Jeroen Engels](https://github.com/jfmengels)
+- [Sam Verschueren](https://github.com/SamVerschueren)

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
 # eslint-plugin-unicorn [![Coverage Status](https://codecov.io/gh/sindresorhus/eslint-plugin-unicorn/branch/main/graph/badge.svg)](https://codecov.io/gh/sindresorhus/eslint-plugin-unicorn/branch/main) [![npm version](https://img.shields.io/npm/v/eslint-plugin-unicorn.svg?style=flat)](https://npmjs.com/package/eslint-plugin-unicorn)
 
+<!-- markdownlint-disable-next-line no-inline-html -->
 <img src="https://cloud.githubusercontent.com/assets/170270/18659176/1cc373d0-7f33-11e6-890f-0ba35362ee7e.jpg" width="180" align="right">
 
 > Various awesome ESLint rules
@@ -11,7 +12,7 @@ You might want to check out [XO](https://github.com/xojs/xo), which includes thi
 ## Install
 
 ```console
-$ npm install --save-dev eslint eslint-plugin-unicorn
+npm install --save-dev eslint eslint-plugin-unicorn
 ```
 
 ## Usage
@@ -290,12 +291,12 @@ See the [ESLint docs](https://eslint.org/docs/user-guide/configuring/configurati
 
 ## Maintainers
 
-- [Sindre Sorhus](https://github.com/sindresorhus)
-- [Adam Babcock](https://github.com/MrHen)
-- [futpib](https://github.com/futpib)
-- [Fisker Cheung](https://github.com/fisker)
+* [Sindre Sorhus](https://github.com/sindresorhus)
+* [Adam Babcock](https://github.com/MrHen)
+* [futpib](https://github.com/futpib)
+* [Fisker Cheung](https://github.com/fisker)
 
-###### Former
+### Former
 
-- [Jeroen Engels](https://github.com/jfmengels)
-- [Sam Verschueren](https://github.com/SamVerschueren)
+* [Jeroen Engels](https://github.com/jfmengels)
+* [Sam Verschueren](https://github.com/SamVerschueren)

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ You might want to check out [XO](https://github.com/xojs/xo), which includes thi
 
 ## Install
 
-```console
+```sh
 npm install --save-dev eslint eslint-plugin-unicorn
 ```
 


### PR DESCRIPTION
A few examples of what was fixed (most autofixed):

* Wrong header sizes
* Codeblocks missing language
* Inconsistent spacing / list types

https://github.com/igorshubovych/markdownlint-cli 

There's a good markdownlint VSCode extension which highlights and autofixes these issues as well: https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint