### PR TITLE
Use `npm-run-all` to run `test` and `lint` scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm run test:js
+      - run: npx ava
   lint-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npx ava
+      - run: npm run test:js
   lint-test:
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: 16
       - run: npm install
-      - run: npx xo
+      - run: npm run lint
       # Force update snapshots, https://github.com/avajs/ava/discussions/2754
       - run: npx nyc ava --update-snapshots
         env:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"scripts": {
 		"lint": "run-p --continue-on-error \"lint:!(fix)\"",
-		"lint:fix": "run-p --continue-on-error \"lint:*:fix\"",
+		"lint:fix": "run-p --continue-on-error lint:*:fix",
 		"lint:js": "xo",
 		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:md": "markdownlint \"**/*.md\"",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"scripts": {
 		"lint": "run-p --continue-on-error \"lint:!(fix)\"",
-		"lint:fix": "run-p \"lint:*:fix\"",
+		"lint:fix": "run-p --continue-on-error \"lint:*:fix\"",
 		"lint:js": "xo",
 		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:md": "markdownlint \"**/*.md\"",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
 		"lint:js": "xo",
-		"lint:md": "markdownlint '**/*.md'",
+		"lint:md": "markdownlint \"**/*.md\"",
 		"test": "npm-run-all --continue-on-error lint test:*",
 		"test:js": "nyc ava",
 		"create-rule": "node ./scripts/create-rule.mjs && npm run generate-rules-table && npm run generate-usage-example",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
 		"node": ">=12"
 	},
 	"scripts": {
-		"lint": "run-p --continue-on-error \"lint:!(fix)\"",
-		"lint:fix": "run-p --continue-on-error lint:*:fix",
+		"fix": "run-p --continue-on-error fix:*",
+		"fix:js": "npm run lint:js -- --fix",
+		"fix:md": "npm run lint:md -- --fix",
+		"lint": "run-p --continue-on-error lint:*",
 		"lint:js": "xo",
-		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:md": "markdownlint \"**/*.md\"",
-		"lint:md:fix": "npm run lint:md -- --fix",
 		"test": "npm-run-all --continue-on-error lint test:*",
 		"test:js": "nyc ava",
 		"create-rule": "node ./scripts/create-rule.mjs && npm run generate-rules-table && npm run generate-usage-example",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
 		"node": ">=12"
 	},
 	"scripts": {
-		"lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
+		"lint": "run-p --continue-on-error \"lint:!(fix)\"",
+		"lint:fix": "run-p \"lint:*:fix\"",
 		"lint:js": "xo",
+		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:md": "markdownlint \"**/*.md\"",
+		"lint:md:fix": "npm run lint:md -- --fix",
 		"test": "npm-run-all --continue-on-error lint test:*",
 		"test:js": "nyc ava",
 		"create-rule": "node ./scripts/create-rule.mjs && npm run generate-rules-table && npm run generate-usage-example",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
 		"node": ">=12"
 	},
 	"scripts": {
-		"test": "xo && nyc ava && markdownlint '**/*.md'",
+		"lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
+		"lint:js": "xo",
+		"lint:md": "markdownlint '**/*.md'",
+		"test": "npm-run-all --continue-on-error lint test:*",
+		"test:js": "nyc ava",
 		"create-rule": "node ./scripts/create-rule.mjs && npm run generate-rules-table && npm run generate-usage-example",
 		"run-rules-on-codebase": "node ./test/run-rules-on-codebase/lint.mjs",
 		"integration": "node ./test/integration/test.mjs",
@@ -73,6 +77,7 @@
 		"lodash-es": "4.17.21",
 		"markdownlint-cli": "^0.29.0",
 		"mem": "^9.0.1",
+		"npm-run-all": "^4.1.5",
 		"nyc": "^15.1.0",
 		"outdent": "^0.8.0",
 		"typescript": "^4.4.2",


### PR DESCRIPTION
* Reorganizes `test` and `lint` NPM scripts with popular tool [npm-run-all](https://github.com/mysticatea/npm-run-all)
* Adds convenient scripts for running different types of linting or tests
* Runs linting in parallel but keeps output of linters separate
* Does not run linting and testing in parallel, since this would break the real-time/live output from ava
* Shows complete output from all types of linting and tests, even if one type fails (previously, the `test` script would exit early if one type failed, so you wouldn't be able to see all the failures)
* Avoids using `&&` which might not have as good of cross-platform support according to the [npm-run-all](https://github.com/mysticatea/npm-run-all) readme