### PR TITLE
`no-empty-file`: Fix false positive with triple-slash directives

### DIFF
--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -16,7 +16,7 @@ const isEmpty = node =>
 const create = context => {
 	const filename = context.getPhysicalFilename().toLowerCase();
 
-	if (!/\.(?:js|mjs|cjs|ts|mts|cts)$/.test(filename)) {
+	if (!/\.(?:js|mjs|cjs|ts|mts|cts)$/.test(filename) || filename.endsWith('.d.ts')) {
 		return {};
 	}
 

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -17,7 +17,7 @@ const isTripleSlashDirective = node =>
 	node.type === 'Line' && node.value.startsWith('/');
 
 const hasTripeSlashDirectives = comments =>
-	!comments.every(currentNode => !isTripleSlashDirective(currentNode));
+	comments.some(currentNode => isTripleSlashDirective(currentNode));
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -5,18 +5,29 @@ const messages = {
 	[MESSAGE_ID]: 'Empty files are not allowed.',
 };
 
+const isTripleSlashDirective = node =>
+	node.type === 'Line' && node.value.startsWith('/');
+
 const isEmpty = node =>
 	(
-		(node.type === 'Program' || node.type === 'BlockStatement')
+		node.type === 'Program'
+		&& node.body.every(currentNode => isEmpty(currentNode))
+		&& node.comments.every(currentNode => !isTripleSlashDirective(currentNode))
+	)
+	|| (
+		node.type === 'BlockStatement'
 		&& node.body.every(currentNode => isEmpty(currentNode))
 	)
-	|| node.type === 'EmptyStatement'
-	|| (node.type === 'ExpressionStatement' && 'directive' in node);
+	|| (
+		node.type === 'ExpressionStatement'
+		&& 'directive' in node
+	)
+	|| node.type === 'EmptyStatement';
 
 const create = context => {
 	const filename = context.getPhysicalFilename().toLowerCase();
 
-	if (!/\.(?:js|mjs|cjs|ts|mts|cts)$/.test(filename) || filename.endsWith('.d.ts')) {
+	if (!/\.(?:js|mjs|cjs|ts|mts|cts)$/.test(filename)) {
 		return {};
 	}
 

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -22,8 +22,6 @@ const hasTripeSlashDirectives = comments =>
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const filename = context.getPhysicalFilename().toLowerCase();
-	const sourceCode = context.getSourceCode();
-	const comments = sourceCode.getAllComments();
 
 	if (!/\.(?:js|mjs|cjs|ts|mts|cts)$/.test(filename)) {
 		return {};
@@ -31,7 +29,14 @@ const create = context => {
 
 	return {
 		Program(node) {
-			if (!isEmpty(node) || hasTripeSlashDirectives(comments)) {
+			if (!isEmpty(node)) {
+				return;
+			}
+
+			const sourceCode = context.getSourceCode();
+			const comments = sourceCode.getAllComments();
+
+			if (hasTripeSlashDirectives(comments)) {
 				return;
 			}
 

--- a/test/no-empty-file.mjs
+++ b/test/no-empty-file.mjs
@@ -37,6 +37,7 @@ test.snapshot({
 			'svelte',
 			'tsx',
 		].map(extension => ({code: '', filename: `example.${extension}`})),
+		{code: '/// <reference types="unicorn" />', filename: 'example.d.ts'},
 	],
 	invalid: [
 		...[

--- a/test/no-empty-file.mjs
+++ b/test/no-empty-file.mjs
@@ -37,7 +37,10 @@ test.snapshot({
 			'svelte',
 			'tsx',
 		].map(extension => ({code: '', filename: `example.${extension}`})),
-		{code: '/// <reference types="unicorn" />', filename: 'example.d.ts'},
+		...[
+			'd.ts',
+			'ts',
+		].map(extension => ({code: '/// <reference types="example" />', filename: `example.${extension}`})),
 	],
 	invalid: [
 		...[


### PR DESCRIPTION
The simplest fix seems to be to ignore `.d.ts` files as `@babel/eslint-parser` and `@typescript-eslint/parser` still view [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) as regular comments that produce an empty `body`.

Fixes #1598