### PR TITLE
Add jsdoc `type` annotation to rules

### DIFF
--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -111,6 +111,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -112,8 +112,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -14,6 +14,7 @@ const newRegExp = [
 	'[arguments.0.type="Literal"]',
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {sortCharacterClasses} = context.options[0] || {};
 

--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -112,9 +112,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -113,6 +113,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -32,6 +32,7 @@ const selector = matches([
 	].join(''),
 ]);
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = {
 		name: 'error',

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -114,9 +114,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -114,8 +114,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -149,6 +149,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -150,8 +150,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -150,9 +150,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -51,6 +51,7 @@ const isChildInParentScope = (child, parent) => {
 	return false;
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const source = context.getSourceCode();
 	const declarations = new Map();

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -207,8 +207,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -149,6 +149,7 @@ function checkNode(node, scopeManager) {
 	return checkReferences(scope, parentScope, scopeManager);
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {checkArrowFunctions} = {checkArrowFunctions: true, ...context.options[0]};
 	const sourceCode = context.getSourceCode();

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -207,9 +207,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -206,6 +206,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -188,6 +188,9 @@ const create = context => ({
 	'AssignmentExpression[left.type="MemberExpression"][left.object.type="Identifier"][left.object.name="exports"]': node => customErrorExport(context, node),
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -181,7 +181,7 @@ const customErrorExport = (context, node) => {
 		fix: fixer => fixer.replaceText(node.left.property, errorName),
 	};
 };
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	ClassDeclaration: node => customErrorDefinition(context, node),
 	'AssignmentExpression[right.type="ClassExpression"]': node => customErrorDefinition(context, node.right),

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -181,6 +181,7 @@ const customErrorExport = (context, node) => {
 		fix: fixer => fixer.replaceText(node.left.property, errorName),
 	};
 };
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	ClassDeclaration: node => customErrorDefinition(context, node),

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -189,8 +189,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -189,9 +189,7 @@ const create = context => ({
 	'AssignmentExpression[left.type="MemberExpression"][left.object.type="Identifier"][left.object.name="exports"]': node => customErrorExport(context, node),
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/empty-brace-spaces.js
+++ b/rules/empty-brace-spaces.js
@@ -45,8 +45,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/empty-brace-spaces.js
+++ b/rules/empty-brace-spaces.js
@@ -44,6 +44,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/empty-brace-spaces.js
+++ b/rules/empty-brace-spaces.js
@@ -44,9 +44,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -83,9 +83,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -24,6 +24,7 @@ const selector = callOrNewExpressionSelector([
 	'InternalError',
 	'AggregateError',
 ]);
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](expression) {

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -82,6 +82,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -24,7 +24,7 @@ const selector = callOrNewExpressionSelector([
 	'InternalError',
 	'AggregateError',
 ]);
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](expression) {
 		if (isShadowed(context.getScope(), expression.callee)) {

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -83,8 +83,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -48,9 +48,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -47,6 +47,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -48,8 +48,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -20,6 +20,7 @@ const getProblem = ({node, original, regex = escapeWithLowercase, fix}) => {
 	}
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	Literal(node) {
 		if (typeof node.value !== 'string') {

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -535,9 +535,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -535,8 +535,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -534,6 +534,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -242,6 +242,7 @@ function semverComparisonForOperator(operator) {
 	}[operator];
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = {
 		terms: ['todo', 'fixme', 'xxx'],

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -195,9 +195,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -196,8 +196,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -195,6 +195,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -254,8 +254,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -253,6 +253,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -142,6 +142,7 @@ function englishishJoinWords(words) {
 	return `${words.slice(0, -1).join(', ')}, or ${words[words.length - 1]}`;
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = context.options[0] || {};
 	const chosenCases = getChosenCases(options);

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -254,9 +254,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -47,6 +47,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -48,9 +48,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -48,8 +48,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/import-index.js
+++ b/rules/import-index.js
@@ -20,6 +20,7 @@ const importIndex = (context, node, argument) => {
 	}
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = context.options[0] || {};
 

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -150,6 +150,7 @@ const assignedRequireTemplate = templates.template`
 	${variableDeclarationVariable} ${assignmentTargetVariable} = require(${moduleNameVariable});
 `;
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	let [
 		{

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -364,6 +364,9 @@ const schema = {
 	},
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -365,8 +365,8 @@ const schema = {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -365,9 +365,7 @@ const schema = {
 	},
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -1,3 +1,4 @@
+
 'use strict';
 const builtins = require('./utils/builtins.js');
 const isShadowed = require('./utils/is-shadowed.js');
@@ -12,6 +13,7 @@ const messages = {
 	disallow: 'Use `{{name}}()` instead of `new {{name}}()`.',
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -67,9 +67,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -1,4 +1,3 @@
-
 'use strict';
 const builtins = require('./utils/builtins.js');
 const isShadowed = require('./utils/is-shadowed.js');

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -67,8 +67,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -66,6 +66,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -34,6 +34,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -35,9 +35,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -7,6 +7,7 @@ const messages = {
 
 const disableRegex = /^eslint-disable(?:-next-line|-line)?(?<ruleId>$|(?:\s+(?:@(?:[\w-]+\/){1,2})?[\w-]+)?)/;
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	* Program(node) {
 		for (const comment of node.comments) {

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -35,8 +35,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -187,6 +187,7 @@ const ignoredFirstArgumentSelector = [
 	'[arguments.0.type!="ArrowFunctionExpression"]',
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 	const rules = {};

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -221,8 +221,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -221,9 +221,7 @@ const create = context => {
 	return rules;
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -220,6 +220,9 @@ const create = context => {
 	return rules;
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -417,8 +417,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -417,9 +417,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -364,6 +364,7 @@ const ignoredObjects = [
 	'R',
 ];
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const functionStack = [];
 	const callExpressions = [];

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -416,6 +416,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-method-this-argument.js
+++ b/rules/no-array-method-this-argument.js
@@ -159,6 +159,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-method-this-argument.js
+++ b/rules/no-array-method-this-argument.js
@@ -159,9 +159,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-method-this-argument.js
+++ b/rules/no-array-method-this-argument.js
@@ -160,8 +160,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -120,6 +120,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -121,8 +121,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -120,9 +120,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -81,6 +81,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -48,6 +48,7 @@ const schema = [
 	},
 ];
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {allowSimpleOperations} = {allowSimpleOperations: true, ...context.options[0]};
 

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -82,9 +82,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -82,8 +82,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-await-expression-member.js
+++ b/rules/no-await-expression-member.js
@@ -70,9 +70,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-await-expression-member.js
+++ b/rules/no-await-expression-member.js
@@ -71,8 +71,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-await-expression-member.js
+++ b/rules/no-await-expression-member.js
@@ -70,6 +70,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-console-spaces.js
+++ b/rules/no-console-spaces.js
@@ -72,8 +72,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-console-spaces.js
+++ b/rules/no-console-spaces.js
@@ -72,9 +72,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-console-spaces.js
+++ b/rules/no-console-spaces.js
@@ -27,6 +27,7 @@ const hasLeadingSpace = value => value.length > 1 && value.charAt(0) === ' ' && 
 // Find exactly one trailing space, allow exactly one space
 const hasTrailingSpace = value => value.length > 1 && value.charAt(value.length - 1) === ' ' && value.charAt(value.length - 2) !== ' ';
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 	const getProblem = (node, method, position) => {

--- a/rules/no-console-spaces.js
+++ b/rules/no-console-spaces.js
@@ -71,6 +71,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-document-cookie.js
+++ b/rules/no-document-cookie.js
@@ -28,9 +28,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-document-cookie.js
+++ b/rules/no-document-cookie.js
@@ -29,8 +29,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-document-cookie.js
+++ b/rules/no-document-cookie.js
@@ -28,6 +28,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -13,6 +13,7 @@ const isEmpty = node =>
 	|| node.type === 'EmptyStatement'
 	|| (node.type === 'ExpressionStatement' && 'directive' in node);
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const filename = context.getPhysicalFilename().toLowerCase();
 

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -34,6 +34,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -35,9 +35,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -35,8 +35,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -412,9 +412,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -411,6 +411,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -1,3 +1,4 @@
+
 'use strict';
 const {isClosingParenToken, getStaticValue} = require('eslint-utils');
 const isLiteralValue = require('./utils/is-literal-value.js');
@@ -260,6 +261,7 @@ const someVariablesLeakOutOfTheLoop = (forStatement, variables, forScope) =>
 const getReferencesInChildScopes = (scope, name) =>
 	getReferences(scope).filter(reference => reference.identifier.name === name);
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 	const {scopeManager, text: sourceCodeText} = sourceCode;

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -1,4 +1,3 @@
-
 'use strict';
 const {isClosingParenToken, getStaticValue} = require('eslint-utils');
 const isLiteralValue = require('./utils/is-literal-value.js');

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -412,8 +412,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -20,7 +20,7 @@ function checkEscape(context, node, value) {
 		};
 	}
 }
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	Literal: node => {
 		if (node.regex || typeof node.value === 'string') {

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -31,8 +31,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -31,9 +31,7 @@ const create = context => ({
 	TemplateElement: node => checkEscape(context, node, node.value.raw),
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -20,6 +20,7 @@ function checkEscape(context, node, value) {
 		};
 	}
 }
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	Literal: node => {

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -30,6 +30,9 @@ const create = context => ({
 	TemplateElement: node => checkEscape(context, node, node.value.raw),
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-instanceof-array.js
+++ b/rules/no-instanceof-array.js
@@ -1,3 +1,5 @@
+
+
 'use strict';
 const {checkVueTemplate} = require('./utils/rule.js');
 const {getParenthesizedRange} = require('./utils/parentheses.js');
@@ -16,6 +18,7 @@ const selector = [
 	'[right.name="Array"]',
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/no-instanceof-array.js
+++ b/rules/no-instanceof-array.js
@@ -49,9 +49,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/no-instanceof-array.js
+++ b/rules/no-instanceof-array.js
@@ -1,5 +1,3 @@
-
-
 'use strict';
 const {checkVueTemplate} = require('./utils/rule.js');
 const {getParenthesizedRange} = require('./utils/parentheses.js');

--- a/rules/no-instanceof-array.js
+++ b/rules/no-instanceof-array.js
@@ -49,8 +49,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/no-instanceof-array.js
+++ b/rules/no-instanceof-array.js
@@ -48,6 +48,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/no-invalid-remove-event-listener.js
+++ b/rules/no-invalid-remove-event-listener.js
@@ -40,6 +40,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-invalid-remove-event-listener.js
+++ b/rules/no-invalid-remove-event-listener.js
@@ -41,8 +41,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-invalid-remove-event-listener.js
+++ b/rules/no-invalid-remove-event-listener.js
@@ -40,9 +40,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-keyword-prefix.js
+++ b/rules/no-keyword-prefix.js
@@ -189,6 +189,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-keyword-prefix.js
+++ b/rules/no-keyword-prefix.js
@@ -190,8 +190,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-keyword-prefix.js
+++ b/rules/no-keyword-prefix.js
@@ -189,9 +189,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-lonely-if.js
+++ b/rules/no-lonely-if.js
@@ -120,6 +120,7 @@ function fix(innerIfStatement, sourceCode) {
 	};
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/no-lonely-if.js
+++ b/rules/no-lonely-if.js
@@ -135,9 +135,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-lonely-if.js
+++ b/rules/no-lonely-if.js
@@ -135,8 +135,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-lonely-if.js
+++ b/rules/no-lonely-if.js
@@ -134,6 +134,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-nested-ternary.js
+++ b/rules/no-nested-ternary.js
@@ -10,6 +10,7 @@ const messages = {
 
 const nestTernarySelector = level => `:not(ConditionalExpression)${' > ConditionalExpression'.repeat(level)}`;
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/no-nested-ternary.js
+++ b/rules/no-nested-ternary.js
@@ -33,9 +33,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-nested-ternary.js
+++ b/rules/no-nested-ternary.js
@@ -33,8 +33,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-nested-ternary.js
+++ b/rules/no-nested-ternary.js
@@ -32,6 +32,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -82,8 +82,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -81,6 +81,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -74,7 +74,7 @@ function getProblem(context, node) {
 
 	return problem;
 }
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[newArraySelector](node) {
 		return getProblem(context, node);

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -82,9 +82,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -74,6 +74,7 @@ function getProblem(context, node) {
 
 	return problem;
 }
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[newArraySelector](node) {

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -77,6 +77,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -78,9 +78,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -49,6 +49,7 @@ function fix(node, sourceCode, method) {
 	};
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 	return {

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -78,8 +78,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -32,6 +32,7 @@ const selector = [
 const isLooseEqual = node => node.type === 'BinaryExpression' && ['==', '!='].includes(node.operator);
 const isStrictEqual = node => node.type === 'BinaryExpression' && ['===', '!=='].includes(node.operator);
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {checkStrictEquality} = {
 		checkStrictEquality: false,

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -103,6 +103,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -104,8 +104,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -104,9 +104,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-object-as-default-parameter.js
+++ b/rules/no-object-as-default-parameter.js
@@ -32,6 +32,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-object-as-default-parameter.js
+++ b/rules/no-object-as-default-parameter.js
@@ -33,8 +33,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-object-as-default-parameter.js
+++ b/rules/no-object-as-default-parameter.js
@@ -13,6 +13,7 @@ const objectParameterSelector = [
 	'[right.properties.length>0]',
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	[objectParameterSelector]: node => {
 		const {left, right} = node;

--- a/rules/no-object-as-default-parameter.js
+++ b/rules/no-object-as-default-parameter.js
@@ -33,9 +33,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -75,6 +75,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -76,8 +76,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -29,6 +29,7 @@ const processExitCallSelector = methodCallSelector({
 	method: 'exit',
 });
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const startsWithHashBang = context.getSourceCode().lines[0].indexOf('#!') === 0;
 

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -76,9 +76,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-static-only-class.js
+++ b/rules/no-static-only-class.js
@@ -215,6 +215,9 @@ function create(context) {
 	};
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-static-only-class.js
+++ b/rules/no-static-only-class.js
@@ -215,9 +215,7 @@ function create(context) {
 	};
 }
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-static-only-class.js
+++ b/rules/no-static-only-class.js
@@ -216,8 +216,8 @@ function create(context) {
 }
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-this-assignment.js
+++ b/rules/no-this-assignment.js
@@ -31,6 +31,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-this-assignment.js
+++ b/rules/no-this-assignment.js
@@ -32,9 +32,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-this-assignment.js
+++ b/rules/no-this-assignment.js
@@ -32,8 +32,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-this-assignment.js
+++ b/rules/no-this-assignment.js
@@ -20,6 +20,7 @@ const assignmentExpressionSelector = [
 
 const selector = matches([variableDeclaratorSelector, assignmentExpressionSelector]);
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	[selector](node) {
 		const variable = node.type === 'AssignmentExpression' ? node.left : node.id;

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -11,6 +11,7 @@ const messages = {
 const isCommaFollowedWithComma = (element, index, array) =>
 	element === null && array[index + 1] === null;
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -67,9 +67,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -67,8 +67,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -66,6 +66,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-unsafe-regex.js
+++ b/rules/no-unsafe-regex.js
@@ -56,6 +56,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-unsafe-regex.js
+++ b/rules/no-unsafe-regex.js
@@ -12,6 +12,7 @@ const newRegExpSelector = [
 	'[arguments.0.type="Literal"]',
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	'Literal[regex]': node => {
 		// Handle regex literal inside RegExp constructor in the other handler

--- a/rules/no-unsafe-regex.js
+++ b/rules/no-unsafe-regex.js
@@ -57,8 +57,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-unsafe-regex.js
+++ b/rules/no-unsafe-regex.js
@@ -57,9 +57,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -226,8 +226,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -226,9 +226,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -80,6 +80,7 @@ const isUnusedVariable = variable => {
 	return !hasReadReference;
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const getPropertyDisplayName = property => {
 		if (property.key.type === 'Identifier') {

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -225,6 +225,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-fallback-in-spread.js
+++ b/rules/no-useless-fallback-in-spread.js
@@ -58,6 +58,9 @@ const create = context => ({
 
 const schema = [];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-fallback-in-spread.js
+++ b/rules/no-useless-fallback-in-spread.js
@@ -58,9 +58,7 @@ const create = context => ({
 
 const schema = [];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-fallback-in-spread.js
+++ b/rules/no-useless-fallback-in-spread.js
@@ -59,8 +59,8 @@ const create = context => ({
 const schema = [];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-length-check.js
+++ b/rules/no-useless-length-check.js
@@ -135,6 +135,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-length-check.js
+++ b/rules/no-useless-length-check.js
@@ -135,9 +135,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-length-check.js
+++ b/rules/no-useless-length-check.js
@@ -136,8 +136,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-spread.js
+++ b/rules/no-useless-spread.js
@@ -208,8 +208,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-spread.js
+++ b/rules/no-useless-spread.js
@@ -207,9 +207,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-spread.js
+++ b/rules/no-useless-spread.js
@@ -207,6 +207,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -89,6 +89,7 @@ const getFunction = scope => {
 	}
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const listener = (fix, checkFunctionReturnType) => node => {
 		if (checkFunctionReturnType) {

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -200,8 +200,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -199,6 +199,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -200,9 +200,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -11,7 +11,7 @@ const messages = {
 	[MESSAGE_ZERO_FRACTION]: 'Don\'t use a zero fraction in the number.',
 	[MESSAGE_DANGLING_DOT]: 'Don\'t use a dangling dot in the number.',
 };
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	Literal: node => {
 		if (!isNumber(node)) {

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -63,6 +63,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -64,8 +64,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -11,6 +11,7 @@ const messages = {
 	[MESSAGE_ZERO_FRACTION]: 'Don\'t use a zero fraction in the number.',
 	[MESSAGE_DANGLING_DOT]: 'Don\'t use a dangling dot in the number.',
 };
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	Literal: node => {

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -64,9 +64,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -37,6 +37,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -38,9 +38,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -16,6 +16,7 @@ const fix = raw => {
 	return fixed;
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	Literal: node => {
 		const {raw} = node;

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -38,8 +38,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/numeric-separators-style.js
+++ b/rules/numeric-separators-style.js
@@ -165,9 +165,7 @@ const schema = [{
 	},
 }];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/numeric-separators-style.js
+++ b/rules/numeric-separators-style.js
@@ -165,6 +165,9 @@ const schema = [{
 	},
 }];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/numeric-separators-style.js
+++ b/rules/numeric-separators-style.js
@@ -166,8 +166,8 @@ const schema = [{
 }];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -171,8 +171,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -170,6 +170,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -58,6 +58,7 @@ const isClearing = node => {
 	return false;
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = context.options[0] || {};
 	const excludedPackages = new Set(options.excludedPackages || ['koa', 'sax']);

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -171,9 +171,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -322,8 +322,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -321,6 +321,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -322,9 +322,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -227,6 +227,7 @@ const isDestructuringFirstElement = node => {
 		&& left.elements[0].type !== 'RestElement';
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/prefer-array-flat-map.js
+++ b/rules/prefer-array-flat-map.js
@@ -18,7 +18,7 @@ const selector = [
 ].join('');
 
 const ignored = ['React.Children', 'Children'];
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](flatCallExpression) {
 		const mapCallExpression = flatCallExpression.callee.object;

--- a/rules/prefer-array-flat-map.js
+++ b/rules/prefer-array-flat-map.js
@@ -52,6 +52,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-flat-map.js
+++ b/rules/prefer-array-flat-map.js
@@ -18,6 +18,7 @@ const selector = [
 ].join('');
 
 const ignored = ['React.Children', 'Children'];
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](flatCallExpression) {

--- a/rules/prefer-array-flat-map.js
+++ b/rules/prefer-array-flat-map.js
@@ -53,8 +53,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-flat-map.js
+++ b/rules/prefer-array-flat-map.js
@@ -53,9 +53,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -244,9 +244,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -244,6 +244,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -245,8 +245,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-array-index-of.js
+++ b/rules/prefer-array-index-of.js
@@ -7,8 +7,8 @@ const {messages, createListeners} = simpleArraySearchRule({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create: context => createListeners(context),
 	meta: {

--- a/rules/prefer-array-index-of.js
+++ b/rules/prefer-array-index-of.js
@@ -6,6 +6,9 @@ const {messages, createListeners} = simpleArraySearchRule({
 	replacement: 'indexOf',
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create: context => createListeners(context),
 	meta: {

--- a/rules/prefer-array-index-of.js
+++ b/rules/prefer-array-index-of.js
@@ -6,9 +6,7 @@ const {messages, createListeners} = simpleArraySearchRule({
 	replacement: 'indexOf',
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create: context => createListeners(context),
 	meta: {

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -57,7 +57,7 @@ const arrayFilterCallSelector = [
 	' > ',
 	`${methodCallSelector('filter')}.object`,
 ].join('');
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[arrayFindCallSelector](findCall) {
 		const isCompare = isCheckingUndefined(findCall);

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -128,8 +128,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -127,6 +127,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -57,6 +57,7 @@ const arrayFilterCallSelector = [
 	' > ',
 	`${methodCallSelector('filter')}.object`,
 ].join('');
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[arrayFindCallSelector](findCall) {

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -128,9 +128,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -299,8 +299,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -298,6 +298,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -298,9 +298,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-code-point.js
+++ b/rules/prefer-code-point.js
@@ -42,8 +42,8 @@ const create = () => Object.fromEntries(
 );
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-code-point.js
+++ b/rules/prefer-code-point.js
@@ -42,9 +42,7 @@ const create = () => Object.fromEntries(
 	]),
 );
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-code-point.js
+++ b/rules/prefer-code-point.js
@@ -19,6 +19,7 @@ const cases = [
 	},
 ];
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => Object.fromEntries(
 	cases.map(({selector, replacement}) => [
 		selector,

--- a/rules/prefer-code-point.js
+++ b/rules/prefer-code-point.js
@@ -41,6 +41,9 @@ const create = () => Object.fromEntries(
 	]),
 );
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-date-now.js
+++ b/rules/prefer-date-now.js
@@ -101,8 +101,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-date-now.js
+++ b/rules/prefer-date-now.js
@@ -100,6 +100,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-date-now.js
+++ b/rules/prefer-date-now.js
@@ -65,6 +65,7 @@ const getProblem = (node, problem, sourceCode) => ({
 	},
 	...problem,
 });
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[methodsSelector](node) {

--- a/rules/prefer-date-now.js
+++ b/rules/prefer-date-now.js
@@ -65,7 +65,7 @@ const getProblem = (node, problem, sourceCode) => ({
 	},
 	...problem,
 });
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[methodsSelector](node) {
 		const method = node.callee.property;

--- a/rules/prefer-date-now.js
+++ b/rules/prefer-date-now.js
@@ -101,9 +101,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -209,9 +209,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -209,8 +209,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -125,6 +125,7 @@ const fixDefaultExpression = (fixer, sourceCode, node) => {
 	return fixer.remove(node);
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 	const functionStack = [];

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -208,6 +208,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-append.js
+++ b/rules/prefer-dom-node-append.js
@@ -29,6 +29,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-append.js
+++ b/rules/prefer-dom-node-append.js
@@ -15,6 +15,7 @@ const selector = [
 	notDomNodeSelector('arguments.0'),
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	[selector](node) {
 		const fix = isValueNotUsable(node)

--- a/rules/prefer-dom-node-append.js
+++ b/rules/prefer-dom-node-append.js
@@ -30,8 +30,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-append.js
+++ b/rules/prefer-dom-node-append.js
@@ -30,9 +30,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-dataset.js
+++ b/rules/prefer-dom-node-dataset.js
@@ -35,6 +35,7 @@ const fix = (context, node, fixer) => {
 
 	return fixer.replaceText(node, replacement);
 };
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {

--- a/rules/prefer-dom-node-dataset.js
+++ b/rules/prefer-dom-node-dataset.js
@@ -52,6 +52,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-dataset.js
+++ b/rules/prefer-dom-node-dataset.js
@@ -53,8 +53,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-dataset.js
+++ b/rules/prefer-dom-node-dataset.js
@@ -53,9 +53,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-dataset.js
+++ b/rules/prefer-dom-node-dataset.js
@@ -35,7 +35,7 @@ const fix = (context, node, fixer) => {
 
 	return fixer.replaceText(node, replacement);
 };
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
 		const name = node.arguments[0].value;

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -67,6 +67,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -22,6 +22,7 @@ const selector = [
 	notDomNodeSelector('arguments.0'),
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -68,8 +68,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -68,9 +68,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-text-content.js
+++ b/rules/prefer-dom-node-text-content.js
@@ -51,9 +51,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-text-content.js
+++ b/rules/prefer-dom-node-text-content.js
@@ -50,6 +50,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-dom-node-text-content.js
+++ b/rules/prefer-dom-node-text-content.js
@@ -20,6 +20,7 @@ const destructuringSelector = [
 	'[name="innerText"]',
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	[memberExpressionPropertySelector](node) {
 		return {

--- a/rules/prefer-dom-node-text-content.js
+++ b/rules/prefer-dom-node-text-content.js
@@ -51,8 +51,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-export-from.js
+++ b/rules/prefer-export-from.js
@@ -320,8 +320,8 @@ function create(context) {
 }
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-export-from.js
+++ b/rules/prefer-export-from.js
@@ -319,6 +319,9 @@ function create(context) {
 	};
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-export-from.js
+++ b/rules/prefer-export-from.js
@@ -319,9 +319,7 @@ function create(context) {
 	};
 }
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -41,6 +41,7 @@ const includesOverSomeRule = simpleArraySearchRule({
 	method: 'some',
 	replacement: 'includes',
 });
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	BinaryExpression: node => {

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -79,9 +79,7 @@ const create = context => ({
 	...includesOverSomeRule.createListeners(context),
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -78,6 +78,9 @@ const create = context => ({
 	...includesOverSomeRule.createListeners(context),
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -79,8 +79,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -41,7 +41,7 @@ const includesOverSomeRule = simpleArraySearchRule({
 	method: 'some',
 	replacement: 'includes',
 });
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	BinaryExpression: node => {
 		const {left, right, operator} = node;

--- a/rules/prefer-keyboard-event-key.js
+++ b/rules/prefer-keyboard-event-key.js
@@ -172,8 +172,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-keyboard-event-key.js
+++ b/rules/prefer-keyboard-event-key.js
@@ -172,9 +172,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-keyboard-event-key.js
+++ b/rules/prefer-keyboard-event-key.js
@@ -112,6 +112,7 @@ const getProblem = node => ({
 	node,
 	fix: fix(node),
 });
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	'Identifier:matches([name="keyCode"], [name="charCode"], [name="which"])'(node) {

--- a/rules/prefer-keyboard-event-key.js
+++ b/rules/prefer-keyboard-event-key.js
@@ -112,7 +112,7 @@ const getProblem = node => ({
 	node,
 	fix: fix(node),
 });
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	'Identifier:matches([name="keyCode"], [name="charCode"], [name="which"])'(node) {
 		// Normal case when usage is direct -> `event.keyCode`

--- a/rules/prefer-keyboard-event-key.js
+++ b/rules/prefer-keyboard-event-key.js
@@ -171,6 +171,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-math-trunc.js
+++ b/rules/prefer-math-trunc.js
@@ -100,6 +100,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-math-trunc.js
+++ b/rules/prefer-math-trunc.js
@@ -29,6 +29,7 @@ const bitwiseNotUnaryExpressionSelector = [
 	createBitwiseNotSelector(2, true),
 ].join('');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/prefer-math-trunc.js
+++ b/rules/prefer-math-trunc.js
@@ -101,9 +101,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-math-trunc.js
+++ b/rules/prefer-math-trunc.js
@@ -101,8 +101,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-modern-dom-apis.js
+++ b/rules/prefer-modern-dom-apis.js
@@ -121,8 +121,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-modern-dom-apis.js
+++ b/rules/prefer-modern-dom-apis.js
@@ -110,7 +110,7 @@ const checkForInsertAdjacentTextOrInsertAdjacentElement = (context, node) => {
 		fix,
 	};
 };
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[replaceChildOrInsertBeforeSelector](node) {
 		return checkForReplaceChildOrInsertBefore(context, node);

--- a/rules/prefer-modern-dom-apis.js
+++ b/rules/prefer-modern-dom-apis.js
@@ -120,6 +120,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-modern-dom-apis.js
+++ b/rules/prefer-modern-dom-apis.js
@@ -110,6 +110,7 @@ const checkForInsertAdjacentTextOrInsertAdjacentElement = (context, node) => {
 		fix,
 	};
 };
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[replaceChildOrInsertBeforeSelector](node) {

--- a/rules/prefer-modern-dom-apis.js
+++ b/rules/prefer-modern-dom-apis.js
@@ -121,9 +121,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-module.js
+++ b/rules/prefer-module.js
@@ -320,8 +320,8 @@ function create(context) {
 }
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-module.js
+++ b/rules/prefer-module.js
@@ -319,6 +319,9 @@ function create(context) {
 	};
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-module.js
+++ b/rules/prefer-module.js
@@ -319,9 +319,7 @@ function create(context) {
 	};
 }
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -167,6 +167,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -168,8 +168,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -168,9 +168,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -1,3 +1,4 @@
+
 'use strict';
 const isLiteralValue = require('./utils/is-literal-value.js');
 const {
@@ -129,7 +130,7 @@ function parse(node) {
 		};
 	}
 }
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	'CallExpression[callee.type="MemberExpression"]': node => {
 		const parsed = parse(node);

--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -1,4 +1,3 @@
-
 'use strict';
 const isLiteralValue = require('./utils/is-literal-value.js');
 const {

--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -130,6 +130,7 @@ function parse(node) {
 		};
 	}
 }
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	'CallExpression[callee.type="MemberExpression"]': node => {

--- a/rules/prefer-node-protocol.js
+++ b/rules/prefer-node-protocol.js
@@ -60,6 +60,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-node-protocol.js
+++ b/rules/prefer-node-protocol.js
@@ -61,8 +61,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-node-protocol.js
+++ b/rules/prefer-node-protocol.js
@@ -60,9 +60,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -138,9 +138,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -137,6 +137,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -38,6 +38,7 @@ const isNegative = node => {
 	return parent && parent.type === 'UnaryExpression' && parent.operator === '-' && parent.argument === node;
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 	const options = {

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -138,8 +138,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-object-from-entries.js
+++ b/rules/prefer-object-from-entries.js
@@ -257,6 +257,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-object-from-entries.js
+++ b/rules/prefer-object-from-entries.js
@@ -258,8 +258,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-object-from-entries.js
+++ b/rules/prefer-object-from-entries.js
@@ -257,9 +257,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-object-has-own.js
+++ b/rules/prefer-object-has-own.js
@@ -91,9 +91,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-object-has-own.js
+++ b/rules/prefer-object-has-own.js
@@ -91,6 +91,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-object-has-own.js
+++ b/rules/prefer-object-has-own.js
@@ -92,8 +92,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-optional-catch-binding.js
+++ b/rules/prefer-optional-catch-binding.js
@@ -62,9 +62,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-optional-catch-binding.js
+++ b/rules/prefer-optional-catch-binding.js
@@ -62,8 +62,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-optional-catch-binding.js
+++ b/rules/prefer-optional-catch-binding.js
@@ -14,6 +14,7 @@ const selector = [
 	' > ',
 	'.param',
 ].join('');
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector]: node => {

--- a/rules/prefer-optional-catch-binding.js
+++ b/rules/prefer-optional-catch-binding.js
@@ -14,7 +14,7 @@ const selector = [
 	' > ',
 	'.param',
 ].join('');
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector]: node => {
 		const variables = context.getDeclaredVariables(node.parent);

--- a/rules/prefer-optional-catch-binding.js
+++ b/rules/prefer-optional-catch-binding.js
@@ -61,6 +61,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-prototype-methods.js
+++ b/rules/prefer-prototype-methods.js
@@ -66,8 +66,8 @@ function create(context) {
 }
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-prototype-methods.js
+++ b/rules/prefer-prototype-methods.js
@@ -65,9 +65,7 @@ function create(context) {
 	};
 }
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-prototype-methods.js
+++ b/rules/prefer-prototype-methods.js
@@ -65,6 +65,9 @@ function create(context) {
 	};
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-query-selector.js
+++ b/rules/prefer-query-selector.js
@@ -122,8 +122,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-query-selector.js
+++ b/rules/prefer-query-selector.js
@@ -122,9 +122,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-query-selector.js
+++ b/rules/prefer-query-selector.js
@@ -121,6 +121,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-query-selector.js
+++ b/rules/prefer-query-selector.js
@@ -99,6 +99,7 @@ const fix = (node, identifierName, preferredSelector) => {
 	};
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	[selector](node) {
 		const method = node.callee.property.name;

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -63,6 +63,7 @@ const fixFunctionPrototypeCall = (node, sourceCode) => {
 		);
 	}
 };
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector]: node => {

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -79,8 +79,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -63,7 +63,7 @@ const fixFunctionPrototypeCall = (node, sourceCode) => {
 		);
 	}
 };
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector]: node => {
 		const sourceCode = context.getSourceCode();

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -78,6 +78,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -79,9 +79,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -123,8 +123,8 @@ const create = context => Object.fromEntries(
 );
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -122,6 +122,9 @@ const create = context => Object.fromEntries(
 	]),
 );
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -82,6 +82,7 @@ const isRegExpNode = node => {
 	return false;
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => Object.fromEntries(
 	cases.map(checkCase => [
 		checkCase.selector,

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -123,9 +123,7 @@ const create = context => Object.fromEntries(
 	]),
 );
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create: checkVueTemplate(create),
 	meta: {

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -187,9 +187,7 @@ const create = context => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -123,6 +123,7 @@ const isMultipleCall = (identifier, node) => {
 
 	return false;
 };
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector]: node => {

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -187,8 +187,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -186,6 +186,9 @@ const create = context => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -123,7 +123,7 @@ const isMultipleCall = (identifier, node) => {
 
 	return false;
 };
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector]: node => {
 		const variable = findVariable(context.getScope(), node);

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -476,9 +476,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -320,6 +320,7 @@ function isClassName(node) {
 	return /^[A-Z]./.test(name) && name.toUpperCase() !== name;
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -475,6 +475,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -476,8 +476,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-replace-all.js
+++ b/rules/prefer-string-replace-all.js
@@ -42,6 +42,7 @@ function removeEscapeCharacters(regexString) {
 	return fixedString;
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	[selector]: node => {
 		const {arguments: arguments_, callee} = node;

--- a/rules/prefer-string-replace-all.js
+++ b/rules/prefer-string-replace-all.js
@@ -63,8 +63,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-replace-all.js
+++ b/rules/prefer-string-replace-all.js
@@ -62,6 +62,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-replace-all.js
+++ b/rules/prefer-string-replace-all.js
@@ -63,9 +63,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -181,8 +181,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -180,6 +180,9 @@ const create = context => {
 	});
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -40,6 +40,7 @@ const isLengthProperty = node => (
 
 const isLikelyNumeric = node => isLiteralNumber(node) || isLengthProperty(node);
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -181,9 +181,7 @@ const create = context => {
 	});
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -172,9 +172,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -172,8 +172,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -171,6 +171,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -59,6 +59,7 @@ const checkRegex = ({pattern, flags}) => {
 	}
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const sourceCode = context.getSourceCode();
 

--- a/rules/prefer-string-trim-start-end.js
+++ b/rules/prefer-string-trim-start-end.js
@@ -29,6 +29,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-trim-start-end.js
+++ b/rules/prefer-string-trim-start-end.js
@@ -15,6 +15,7 @@ const selector = [
 	' > .property',
 ].join(' ');
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	[selector](node) {
 		const method = node.name;

--- a/rules/prefer-string-trim-start-end.js
+++ b/rules/prefer-string-trim-start-end.js
@@ -30,8 +30,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-string-trim-start-end.js
+++ b/rules/prefer-string-trim-start-end.js
@@ -30,9 +30,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-switch.js
+++ b/rules/prefer-switch.js
@@ -243,6 +243,7 @@ function fix({discriminant, ifStatements}, sourceCode, options) {
 	};
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = {
 		minimumCases: 3,

--- a/rules/prefer-switch.js
+++ b/rules/prefer-switch.js
@@ -322,9 +322,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-switch.js
+++ b/rules/prefer-switch.js
@@ -322,8 +322,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-switch.js
+++ b/rules/prefer-switch.js
@@ -321,6 +321,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -260,9 +260,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -260,8 +260,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -259,6 +259,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -43,6 +43,7 @@ function getNodeBody(node) {
 
 const isSingleLineNode = node => node.loc.start.line === node.loc.end.line;
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const onlySingleLine = context.options[0] === 'only-single-line';
 	const sourceCode = context.getSourceCode();

--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -88,6 +88,9 @@ function create(context) {
 	};
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -89,8 +89,8 @@ function create(context) {
 }
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -88,9 +88,7 @@ function create(context) {
 	};
 }
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -127,6 +127,9 @@ const create = () => ({
 	},
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -110,6 +110,7 @@ const isTypecheckingExpression = (node, callExpression) => {
 
 const isTypechecking = node => node.type === 'IfStatement' && isTypecheckingExpression(node.test);
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = () => ({
 	[selector]: node => {
 		if (

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -128,9 +128,7 @@ const create = () => ({
 	},
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -128,8 +128,8 @@ const create = () => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -609,6 +609,9 @@ const schema = {
 	},
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -320,6 +320,7 @@ const isInternalImport = node => {
 	);
 };
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = prepareOptions(context.options[0]);
 	const filenameWithExtension = context.getPhysicalFilename();

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -610,9 +610,7 @@ const schema = {
 	},
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -610,8 +610,8 @@ const schema = {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-array-join-separator.js
+++ b/rules/require-array-join-separator.js
@@ -42,8 +42,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-array-join-separator.js
+++ b/rules/require-array-join-separator.js
@@ -41,6 +41,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-array-join-separator.js
+++ b/rules/require-array-join-separator.js
@@ -41,9 +41,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-number-to-fixed-digits-argument.js
+++ b/rules/require-number-to-fixed-digits-argument.js
@@ -36,8 +36,8 @@ const create = context => {
 };
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-number-to-fixed-digits-argument.js
+++ b/rules/require-number-to-fixed-digits-argument.js
@@ -35,9 +35,7 @@ const create = context => {
 	};
 };
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-number-to-fixed-digits-argument.js
+++ b/rules/require-number-to-fixed-digits-argument.js
@@ -35,6 +35,9 @@ const create = context => {
 	};
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-post-message-target-origin.js
+++ b/rules/require-post-message-target-origin.js
@@ -56,9 +56,7 @@ function create(context) {
 	};
 }
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-post-message-target-origin.js
+++ b/rules/require-post-message-target-origin.js
@@ -57,8 +57,8 @@ function create(context) {
 }
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/require-post-message-target-origin.js
+++ b/rules/require-post-message-target-origin.js
@@ -56,6 +56,9 @@ function create(context) {
 	};
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -172,9 +172,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -172,8 +172,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -171,6 +171,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -61,6 +61,7 @@ function getReplacements(patterns) {
 		});
 }
 
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {patterns} = {
 		patterns: {},

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -150,6 +150,9 @@ const schema = [
 	},
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -150,9 +150,7 @@ const schema = [
 	},
 ];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -151,8 +151,8 @@ const schema = [
 ];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -37,6 +37,9 @@ const create = context => ({
 	}),
 });
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -28,7 +28,7 @@ const selector = [
 		].join(''),
 	]),
 ].join('');
-
+/** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector]: node => ({
 		node,

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -28,6 +28,7 @@ const selector = [
 		].join(''),
 	]),
 ].join('');
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector]: node => ({

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -38,8 +38,8 @@ const create = context => ({
 });
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -38,9 +38,7 @@ const create = context => ({
 	}),
 });
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/scripts/template/rule.js.jst
+++ b/scripts/template/rule.js.jst
@@ -29,8 +29,8 @@ const create = context => {
 const schema = [];
 
 /**
- * @type {import('eslint').Rule.RuleModule}
- */
+@type {import('eslint').Rule.RuleModule}
+*/
 module.exports = {
 	create,
 	meta: {

--- a/scripts/template/rule.js.jst
+++ b/scripts/template/rule.js.jst
@@ -28,9 +28,7 @@ const create = context => {
 
 const schema = [];
 
-/**
-@type {import('eslint').Rule.RuleModule}
-*/
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
 	meta: {

--- a/scripts/template/rule.js.jst
+++ b/scripts/template/rule.js.jst
@@ -28,6 +28,9 @@ const create = context => {
 
 const schema = [];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
 	create,
 	meta: {


### PR DESCRIPTION
Supported by VSCode/Webstorm/other code editors. Uses TypeScript declaration to give JavaScript hints so code editors can provide information/autocomplete about various rule fields.

https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#type

Idea from: https://github.com/eslint/generator-eslint/pull/113

<img width="391" alt="133895350-a19d0daf-593e-44b9-835f-bebf8b6a3d30" src="https://user-images.githubusercontent.com/698306/141347823-8d947657-812e-4f00-950e-a8a95b65bf71.png">
