### PR TITLE
Add test for rule jsdoc type comment

### DIFF
--- a/rules/utils/rule.js
+++ b/rules/utils/rule.js
@@ -74,6 +74,7 @@ function checkVueTemplate(create, options) {
 	return wrapped;
 }
 
+/** @returns {import('eslint').Rule.RuleModule} */
 function loadRule(ruleId) {
 	const rule = require(`../${ruleId}`);
 

--- a/rules/utils/rule.js
+++ b/rules/utils/rule.js
@@ -74,7 +74,6 @@ function checkVueTemplate(create, options) {
 	return wrapped;
 }
 
-/** @returns {import('eslint').Rule.RuleModule} */
 function loadRule(ruleId) {
 	const rule = require(`../${ruleId}`);
 

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -187,6 +187,16 @@ test('Every deprecated rules listed in docs/deprecated-rules.md', async t => {
 	}
 });
 
+test('Every rule file has the appropriate contents', t => {
+	for (const ruleFile of ruleFiles) {
+		const ruleName = path.basename(ruleFile, '.js');
+		const rulePath = path.join('rules', `${ruleName}.js`);
+		const ruleContents = fs.readFileSync(rulePath, 'utf8');
+
+		t.true(ruleContents.includes('/** @type {import(\'eslint\').Rule.RuleModule} */'), `${ruleName} includes jsdoc comment for rule type`);
+	}
+});
+
 test('Every rule has a doc with the appropriate content', t => {
 	for (const ruleFile of ruleFiles) {
 		const ruleName = path.basename(ruleFile, '.js');


### PR DESCRIPTION
Follow-up to https://github.com/sindresorhus/eslint-plugin-unicorn/pull/1606

Ensures each rule has this jsdoc type comment. Otherwise, it would be easily forgotten in new rules.