### PR TITLE
Add jsdoc type to externally-exported rules

### DIFF
--- a/rules/utils/create-deprecated-rules.js
+++ b/rules/utils/create-deprecated-rules.js
@@ -3,6 +3,7 @@ const packageJson = require('../../package.json');
 
 const repoUrl = 'https://github.com/sindresorhus/eslint-plugin-unicorn';
 
+/** @returns {{ [ruleName: string]: import('eslint').Rule.RuleModule }} */
 function createDeprecatedRules(data) {
 	return Object.fromEntries(
 		Object.entries(data).map(([ruleId, replacedBy = []]) => [

--- a/rules/utils/rule.js
+++ b/rules/utils/rule.js
@@ -74,6 +74,7 @@ function checkVueTemplate(create, options) {
 	return wrapped;
 }
 
+/** @returns {import('eslint').Rule.RuleModule} */
 function loadRule(ruleId) {
 	const rule = require(`../${ruleId}`);
 


### PR DESCRIPTION
Adds a much more useful and complete type to the rules exported by this package. This would benefit anyone manually importing the rules from this package (side note: I'm not really sure of use cases for someone to do that, but this can't hurt).

| Before | After | 
| --- | --- | 
| <img width="405" alt="Screen Shot 2021-11-16 at 7 34 24 PM" src="https://user-images.githubusercontent.com/698306/142088060-907cb937-9136-40c8-8fc9-4b6026d1a2a0.png"> | <img width="401" alt="Screen Shot 2021-11-16 at 7 33 40 PM" src="https://user-images.githubusercontent.com/698306/142088073-8f76282e-2413-4daf-94bc-31101f4c9aaa.png"> |

jsdoc types can provide autocomplete and even type-checking: https://medium.com/@trukrs/type-safe-javascript-with-jsdoc-7a2a63209b76