### PR TITLE
Fix test for `recommended` rule doc notice

### DIFF
--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -1,7 +1,5 @@
 # Enforce correct `Error` subclassing
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 🔧 *This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).*
 
 Enforces the only valid way of `Error` subclassing. It works with any super class that ends in `Error`.

--- a/docs/rules/import-index.md
+++ b/docs/rules/import-index.md
@@ -1,7 +1,5 @@
 # Enforce importing index files with `.`
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 🔧 *This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).*
 
 Enforces importing index file with `.` instead of `./`, `./index` or `./index.js`.

--- a/docs/rules/no-keyword-prefix.md
+++ b/docs/rules/no-keyword-prefix.md
@@ -1,7 +1,5 @@
 # Disallow identifiers starting with `new` or `class`
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 `new Foo` and `newFoo` look very similar. Use alternatives that do not look like keyword usage.
 
 ## Fail

--- a/docs/rules/no-unsafe-regex.md
+++ b/docs/rules/no-unsafe-regex.md
@@ -1,7 +1,5 @@
 # Disallow unsafe regular expressions
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 Uses [safe-regex](https://github.com/substack/safe-regex) to disallow potentially [catastrophic](https://regular-expressions.mobi/catastrophic.html) [exponential-time](https://perlgeek.de/blog-en/perl-tips/in-search-of-an-exponetial-regexp.html) regular expressions.
 
 ## Fail

--- a/docs/rules/no-unused-properties.md
+++ b/docs/rules/no-unused-properties.md
@@ -1,7 +1,5 @@
 # Disallow unused object properties
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 Unused properties, much like unused variables, are often a result of incomplete refactoring and may confuse readers.
 
 This rule is primarily useful when you use objects to group constants or model enumerations. It is much harder to predict class properties usage, and practically impossible to predict reflective property access. This rule ignores cases like that.

--- a/docs/rules/prefer-at.md
+++ b/docs/rules/prefer-at.md
@@ -1,7 +1,5 @@
 # Prefer `.at()` method for index access and `String#charAt()`
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 🔧💡 *This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) and provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).*
 
 Prefer [`Array#at()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at), [`String#at()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/at), and `{TypedArray,NodeList,CSSRuleList,…}#at()` for index access and `String#charAt()`.

--- a/docs/rules/prefer-object-has-own.md
+++ b/docs/rules/prefer-object-has-own.md
@@ -1,7 +1,5 @@
 # Prefer `Object.hasOwn(…)` over `Object.prototype.hasOwnProperty.call(…)`
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 🔧 *This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).*
 
 [`Object.hasOwn(…)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) is more accessible than `Object.prototype.hasOwnProperty.call(…)`.

--- a/docs/rules/prefer-string-replace-all.md
+++ b/docs/rules/prefer-string-replace-all.md
@@ -1,7 +1,5 @@
 # Prefer `String#replaceAll()` over regex searches with the global flag
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 🔧 *This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).*
 
 The [`String#replaceAll()`](https://github.com/tc39/proposal-string-replaceall) method is both faster and safer as you don't have to escape the regex if the string is not a literal.

--- a/docs/rules/prefer-top-level-await.md
+++ b/docs/rules/prefer-top-level-await.md
@@ -1,7 +1,5 @@
 # Prefer top-level await over top-level promises and async function calls
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 💡 *This rule provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).*
 
 [Top-level await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top-level-await) is more readable and can prevent unhandled rejections.

--- a/docs/rules/require-post-message-target-origin.md
+++ b/docs/rules/require-post-message-target-origin.md
@@ -1,7 +1,5 @@
 # Enforce using the `targetOrigin` argument with `window.postMessage()`
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 💡 *This rule provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).*
 
 When calling [`window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) without the `targetOrigin` argument, the message cannot be received by any window.

--- a/docs/rules/string-content.md
+++ b/docs/rules/string-content.md
@@ -1,7 +1,5 @@
 # Enforce better string content
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 🔧💡 *This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) and provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).*
 
 Enforce certain things about the contents of strings. For example, you can enforce using `’` instead of `'` to avoid escaping. Or you could block some words. The possibilities are endless.

--- a/docs/rules/template-indent.md
+++ b/docs/rules/template-indent.md
@@ -1,7 +1,5 @@
 # Fix whitespace-insensitive template indentation
 
-✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
-
 🔧 *This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).*
 
 [Tagged templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) often look ugly/jarring because their indentation doesn't match the code they're found in. In many cases, whitespace is insignificant, or a library like [strip-indent](https://www.npmjs.com/package/strip-indent) is used to remove the margin. See [proposal-string-dedent](https://github.com/tc39/proposal-string-dedent) (stage 1 at the time of writing) for a proposal on fixing this in JavaScript.

--- a/docs/rules/template-indent.md
+++ b/docs/rules/template-indent.md
@@ -1,5 +1,7 @@
 # Fix whitespace-insensitive template indentation
 
+✅ *This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.*
+
 🔧 *This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).*
 
 [Tagged templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) often look ugly/jarring because their indentation doesn't match the code they're found in. In many cases, whitespace is insignificant, or a library like [strip-indent](https://www.npmjs.com/package/strip-indent) is used to remove the margin. See [proposal-string-dedent](https://github.com/tc39/proposal-string-dedent) (stage 1 at the time of writing) for a proposal on fixing this in JavaScript.

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -236,7 +236,7 @@ test('Every rule has a doc with the appropriate content', t => {
 		// Decide which notices should be shown at the top of the doc.
 		const expectedNotices = [];
 		const unexpectedNotices = [];
-		if (index.configs.recommended.rules[`unicorn/${ruleName}`] !== 'off') {
+		if (['error', 'warn'].includes(index.configs.recommended.rules[`unicorn/${ruleName}`])) {
 			expectedNotices.push('configRecommended');
 		} else {
 			unexpectedNotices.push('configRecommended');

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -236,7 +236,7 @@ test('Every rule has a doc with the appropriate content', t => {
 		// Decide which notices should be shown at the top of the doc.
 		const expectedNotices = [];
 		const unexpectedNotices = [];
-		if (index.configs.recommended.rules[`unicorn/${ruleName}`]) {
+		if (index.configs.recommended.rules[`unicorn/${ruleName}`] === 'error') {
 			expectedNotices.push('configRecommended');
 		} else {
 			unexpectedNotices.push('configRecommended');

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -236,7 +236,7 @@ test('Every rule has a doc with the appropriate content', t => {
 		// Decide which notices should be shown at the top of the doc.
 		const expectedNotices = [];
 		const unexpectedNotices = [];
-		if (index.configs.recommended.rules[`unicorn/${ruleName}`] === 'error') {
+		if (index.configs.recommended.rules[`unicorn/${ruleName}`] !== 'off') {
 			expectedNotices.push('configRecommended');
 		} else {
 			unexpectedNotices.push('configRecommended');


### PR DESCRIPTION
There was a bug in this test so we mistakenly added the `recommended` rule notice to some rule docs that are not in the `recommended` config.

The test will now correctly verify that the `recommended` rules include this notice and non-recommended rules don't.