### PR TITLE
`filename-case`: Ignore `$` in filenames

### DIFF
--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -6,7 +6,7 @@ Enforces all linted files to have their names in a certain case style and lowerc
 
 Files named `index.js`, `index.mjs`, `index.cjs`, `index.ts`, `index.tsx`, `index.vue` are ignored as they can't change case (Only a problem with `pascalCase`).
 
-Characters in the filename except `a-z`, `A-Z`, `0-9`, `-`, `_` and `$` are ignored.
+Characters in the filename except `a-z`, `A-Z`, `0-9`, `-`, and `_` are ignored.
 
 ## Cases
 

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -14,7 +14,7 @@ const pascalCase = string => upperFirst(camelCase(string));
 const numberRegex = /\d+/;
 const PLACEHOLDER = '\uFFFF\uFFFF\uFFFF';
 const PLACEHOLDER_REGEX = new RegExp(PLACEHOLDER, 'i');
-const isIgnoredChar = char => !/^[a-z\d-_$]$/i.test(char);
+const isIgnoredChar = char => !/^[a-z\d-_]$/i.test(char);
 const ignoredByDefault = new Set(['index.js', 'index.mjs', 'index.cjs', 'index.ts', 'index.tsx', 'index.vue']);
 const isLowerCase = string => string === string.toLowerCase();
 

--- a/test/filename-case.mjs
+++ b/test/filename-case.mjs
@@ -379,6 +379,16 @@ test({
 			undefined,
 			'Filename is not in kebab case. Rename it to `[foo-bar].js`.',
 		),
+		testCase(
+			'src/foo/$foo_bar.js',
+			undefined,
+			'Filename is not in kebab case. Rename it to `$foo-bar.js`.',
+		),
+		testCase(
+			'src/foo/$fooBar.js',
+			undefined,
+			'Filename is not in kebab case. Rename it to `$foo-bar.js`.',
+		),
 		testManyCases(
 			'src/foo/{foo_bar}.js',
 			{

--- a/test/filename-case.mjs
+++ b/test/filename-case.mjs
@@ -79,6 +79,7 @@ test({
 		testCase('src/foo/___foo-bar.js', 'kebabCase'),
 		testCase('src/foo/_FooBar.js', 'pascalCase'),
 		testCase('src/foo/___FooBar.js', 'pascalCase'),
+		testCase("src/foo/$foo.js"),
 		testManyCases('src/foo/foo-bar.js'),
 		testManyCases('src/foo/foo-bar.js', {}),
 		testManyCases('src/foo/fooBar.js', {camelCase: true}),

--- a/test/filename-case.mjs
+++ b/test/filename-case.mjs
@@ -79,7 +79,7 @@ test({
 		testCase('src/foo/___foo-bar.js', 'kebabCase'),
 		testCase('src/foo/_FooBar.js', 'pascalCase'),
 		testCase('src/foo/___FooBar.js', 'pascalCase'),
-		testCase("src/foo/$foo.js"),
+		testCase('src/foo/$foo.js'),
 		testManyCases('src/foo/foo-bar.js'),
 		testManyCases('src/foo/foo-bar.js', {}),
 		testManyCases('src/foo/fooBar.js', {camelCase: true}),


### PR DESCRIPTION
Fixes #1627 

There is no test case that demonstrates why `$` should not be ignored.