### PR TITLE
Docs: Use `string.repeat()` instead of `Array().join()`

### DIFF
--- a/docs/rules/no-unsafe-regex.md
+++ b/docs/rules/no-unsafe-regex.md
@@ -6,7 +6,7 @@ Uses [safe-regex](https://github.com/substack/safe-regex) to disallow potentiall
 
 ```js
 const regex = /^(a?){25}(a){25}$/;
-const regex = RegExp(Array(27).join('a?') + Array(27).join('a'));
+const regex = RegExp('a?'.repeat(27) + 'a'.repeat(27));
 const regex = /(x+x+)+y/;
 const regex = /foo|(x+x+)+y/;
 const regex = /(a+){10}y/;
@@ -22,5 +22,5 @@ const regex = /\b(Oakland|San Francisco)\b/i;
 const regex = /^\d+1337\d+$/i;
 const regex = /^\d+(1337|404)\d+$/i;
 const regex = /^\d+(1337|404)*\d+$/i;
-const regex = RegExp(Array(26).join('a?') + Array(26).join('a'));
+const regex = RegExp('a?'.repeat(26) + 'a'.repeat(26));
 ```

--- a/docs/rules/no-unsafe-regex.md
+++ b/docs/rules/no-unsafe-regex.md
@@ -6,7 +6,7 @@ Uses [safe-regex](https://github.com/substack/safe-regex) to disallow potentiall
 
 ```js
 const regex = /^(a?){25}(a){25}$/;
-const regex = RegExp('a?'.repeat(27) + 'a'.repeat(27));
+const regex = RegExp('a?'.repeat(26) + 'a'.repeat(26));
 const regex = /(x+x+)+y/;
 const regex = /foo|(x+x+)+y/;
 const regex = /(a+){10}y/;
@@ -22,5 +22,5 @@ const regex = /\b(Oakland|San Francisco)\b/i;
 const regex = /^\d+1337\d+$/i;
 const regex = /^\d+(1337|404)\d+$/i;
 const regex = /^\d+(1337|404)*\d+$/i;
-const regex = RegExp('a?'.repeat(26) + 'a'.repeat(26));
+const regex = RegExp('a?'.repeat(25) + 'a'.repeat(25));
 ```


### PR DESCRIPTION
This is a documentation only change to prefer `x.repeat(y)` over `Array(y).join(x)`