### PR TITLE
`no-array-callback-reference`: Ignore primitive wrappers in `Array#map()`

### DIFF
--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -49,14 +49,10 @@ const iteratorMethods = [
 	],
 	[
 		'flatMap',
-		{
-			ignore: [
-				'Boolean',
-			],
-		},
 	],
 	[
-		'forEach', {
+		'forEach',
+		{
 			returnsUndefined: true,
 		},
 	],
@@ -65,7 +61,11 @@ const iteratorMethods = [
 		{
 			extraSelector: '[callee.object.name!="types"]',
 			ignore: [
+				'String',
+				'Number',
+				'BigInt',
 				'Boolean',
+				'Symbol',
 			],
 		},
 	],

--- a/test/no-array-callback-reference.mjs
+++ b/test/no-array-callback-reference.mjs
@@ -57,7 +57,14 @@ test({
 		...reduceLikeMethods.map(method => `this.${method}(fn)`),
 
 		// `Boolean`
+		'foo.find(Boolean)',
+
+		// Primitive wrappers are ignored
+		'foo.map(String)',
+		'foo.map(Number)',
+		'foo.map(BigInt)',
 		'foo.map(Boolean)',
+		'foo.map(Symbol)',
 
 		// Not `CallExpression`
 		'new foo.map(fn);',


### PR DESCRIPTION
All these primitive wrappers only accept one argument, they will never change, it's safe to use in `Array#map()`