### PR TITLE
`prefer-export-from`: Fix crash in typescript files

### DIFF
--- a/rules/prefer-export-from.js
+++ b/rules/prefer-export-from.js
@@ -207,7 +207,7 @@ function isVariableUnused(node, context) {
 }
 
 function getImported(variable, sourceCode) {
-	const specifier = variable.identifiers[0].parent;
+	const specifier = variable.defs[0].node;
 	const result = {
 		node: specifier,
 		declaration: specifier.parent,

--- a/rules/prefer-export-from.js
+++ b/rules/prefer-export-from.js
@@ -297,17 +297,22 @@ function create(context) {
 		},
 		* 'Program:exit'(program) {
 			for (const importDeclaration of importDeclarations) {
-				const variables = context.getDeclaredVariables(importDeclaration)
-					.map(variable => {
-						const imported = getImported(variable, sourceCode);
-						const exports = getExports(imported, context, sourceCode);
+				let variables = context.getDeclaredVariables(importDeclaration);
 
-						return {
-							variable,
-							imported,
-							exports,
-						};
-					});
+				if (variables.some(variable => variable.defs.length !== 1 || variable.defs[0].parent !== importDeclaration)) {
+					continue;
+				}
+
+				variables = variables.map(variable => {
+					const imported = getImported(variable, sourceCode);
+					const exports = getExports(imported, context, sourceCode);
+
+					return {
+						variable,
+						imported,
+						exports,
+					};
+				});
 
 				if (
 					ignoreUsedVariables

--- a/test/prefer-export-from.mjs
+++ b/test/prefer-export-from.mjs
@@ -330,6 +330,10 @@ test.typescript({
 
 			export const useDispatch: () => DispatchAllActions = reduxUseDispatch
 		`,
+		outdent`
+			type AceEditor = import("ace-builds").Ace.Editor;
+			import AceEditor from "./advanced-editor";
+		`,
 	],
 	invalid: [],
 });

--- a/test/prefer-export-from.mjs
+++ b/test/prefer-export-from.mjs
@@ -332,6 +332,11 @@ test.typescript({
 		`,
 		// #1645
 		outdent`
+			import React from "react";
+			import React from "react";
+			export {React}
+		`,
+		outdent`
 			type AceEditor = import("ace-builds").Ace.Editor;
 			import AceEditor from "./advanced-editor";
 		`,

--- a/test/prefer-export-from.mjs
+++ b/test/prefer-export-from.mjs
@@ -330,9 +330,20 @@ test.typescript({
 
 			export const useDispatch: () => DispatchAllActions = reduxUseDispatch
 		`,
+		// #1645
 		outdent`
 			type AceEditor = import("ace-builds").Ace.Editor;
 			import AceEditor from "./advanced-editor";
+		`,
+		outdent`
+			type AceEditor = import("ace-builds").Ace.Editor;
+			import AceEditor from "./advanced-editor";
+			export {AceEditor};
+		`,
+		outdent`
+			import AceEditor from "./advanced-editor";
+			type AceEditor = import("ace-builds").Ace.Editor;
+			export {AceEditor};
 		`,
 	],
 	invalid: [],


### PR DESCRIPTION
Fixes #1645

I'm not sure how should they work, just ignored unexpected cases.
This is also old behavior before #1590, I removed a check I thought useless in that PR https://github.com/sindresorhus/eslint-plugin-unicorn/pull/1590/files#diff-4975d506e62d0af676ec4744ee8a4fc23d954f8013ab2067f2db5bd94f1cf42dL204