### PR TITLE
`no-array-push-push`: Ignore `process.{stdin,stdout,stderr}`

### DIFF
--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -49,7 +49,7 @@ function create(context) {
 		'this.stream',
 		'process.stdin',
 		'process.stdout',
-		'process.stdin',
+		'process.stderr',
 		...ignore,
 	];
 	const sourceCode = context.getSourceCode();

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -43,7 +43,15 @@ function create(context) {
 		ignore: [],
 		...context.options[0],
 	};
-	const ignoredObjects = ['stream', 'this', 'this.stream', ...ignore];
+	const ignoredObjects = [
+		'stream',
+		'this',
+		'this.stream',
+		'process.stdin',
+		'process.stdout',
+		'process.stdin',
+		...ignore,
+	];
 	const sourceCode = context.getSourceCode();
 
 	return {


### PR DESCRIPTION
@sindresorhus  I'm not familiar with the `Stream` object, are they both reasonable to use?