### PR TITLE
`expiring-todo-comments`: Add `date` option

### DIFF
--- a/docs/rules/expiring-todo-comments.md
+++ b/docs/rules/expiring-todo-comments.md
@@ -325,3 +325,36 @@ As an example of this option, if you want this rule to **completely ignore** com
 	}
 ]
 ```
+
+### date
+
+Type: `string` (`date` format)\
+Default: `<today>`
+
+For TODOs with date deadlines, this option makes them trigger only if the deadline is later than the specified date. You could set this to a date in the future to find TODOs that expire soon, or set it far in the past if you want to ignore recently-expired TODOs.
+
+The format must match [json-schema's date](https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times).
+
+### examples
+
+Find tech debt that has grown up and gone to college by triggering the rule only for incredibly old TODOs:
+
+```js
+"unicorn/expiring-todo-comments": [
+	"error",
+	{
+		"date": "2000-01-01"
+	}
+]
+```
+
+Prepare for the future by triggering the rule on known Y3K bugs:
+
+```js
+"unicorn/expiring-todo-comments": [
+	"error",
+	{
+		"date": "3000-01-01"
+	}
+]
+```

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -186,8 +186,7 @@ function parseTodoMessage(todoString) {
 	return afterArguments;
 }
 
-function reachedDate(past) {
-	const now = new Date().toISOString().slice(0, 10);
+function reachedDate(past, now) {
 	return Date.parse(past) < Date.parse(now);
 }
 
@@ -249,6 +248,7 @@ const create = context => {
 		ignore: [],
 		ignoreDatesOnPullRequests: true,
 		allowWarningComments: true,
+		date: new Date().toISOString().slice(0, 10),
 		...context.options[0],
 	};
 
@@ -325,15 +325,15 @@ const create = context => {
 			});
 		} else if (dates.length === 1) {
 			uses++;
-			const [date] = dates;
+			const [expirationDate] = dates;
 
 			const shouldIgnore = options.ignoreDatesOnPullRequests && ci.isPR;
-			if (!shouldIgnore && reachedDate(date)) {
+			if (!shouldIgnore && reachedDate(expirationDate, options.date)) {
 				context.report({
 					loc: comment.loc,
 					messageId: MESSAGE_ID_EXPIRED_TODO,
 					data: {
-						expirationDate: date,
+						expirationDate,
 						message: parseTodoMessage(comment.value),
 					},
 				});
@@ -530,6 +530,10 @@ const schema = [
 			allowWarningComments: {
 				type: 'boolean',
 				default: false,
+			},
+			date: {
+				type: 'string',
+				format: 'date',
 			},
 		},
 	},

--- a/test/expiring-todo-comments.mjs
+++ b/test/expiring-todo-comments.mjs
@@ -392,9 +392,9 @@ test({
 			],
 		},
 		{
-			code: '// TODO [2999-12-31]: Y3K bug',
+			code: '// TODO [2999-12-01]: Y3K bug',
 			options: [{date: '3000-01-01'}],
-			errors: [expiredTodoError('2999-12-31', 'Y3K bug')],
+			errors: [expiredTodoError('2999-12-01', 'Y3K bug')],
 		},
 	],
 });

--- a/test/expiring-todo-comments.mjs
+++ b/test/expiring-todo-comments.mjs
@@ -393,7 +393,7 @@ test({
 		},
 		{
 			code: '// TODO [2999-12-01]: Y3K bug',
-			options: [{date: '3000-01-01'}],
+			options: [{date: '3000-01-01', ignoreDatesOnPullRequests: false}],
 			errors: [expiredTodoError('2999-12-01', 'Y3K bug')],
 		},
 	],

--- a/test/expiring-todo-comments.mjs
+++ b/test/expiring-todo-comments.mjs
@@ -110,6 +110,10 @@ test({
 			code: '// TODO [Issue-123] fix later',
 			options: [{allowWarningComments: false, ignore: [/issue-\d+/i]}],
 		},
+		{
+			code: '// TODO [2001-01-01]: quite old',
+			options: [{date: '2000-01-01'}],
+		},
 	],
 	invalid: [
 		{
@@ -386,6 +390,11 @@ test({
 			errors: [
 				noWarningCommentError('TODO Invalid'),
 			],
+		},
+		{
+			code: '// TODO [2999-12-31]: Y3K bug',
+			options: [{date: '3000-01-01'}],
+			errors: [expiredTodoError('2999-12-31', 'Y3K bug')],
 		},
 	],
 });


### PR DESCRIPTION
This could be useful a few ways:

1. Testing lint configs
2. Finding todos that expire _soon_ but not yet
3. Testing the rule itself
4. Finding _very_ out of date todos, e.g. by setting the date one year in the past

~@fisker @sindresorhus I'll add tests and docs once we've established the feature is something that would be considered~ Docs and tests added. I was going to make an issue but it was about the same amount of effort to make the (runtime) code change as PR. I did it in the GitHub UI 🙃 

👇 something like what I'll add to the docs

### date

Type: `string` (`date` format)\
Default: `<today>`

For TODOs with date deadlines, this option makes them trigger only if the deadline is later than the specified date. You could set this to a date in the future to find TODOs that expire soon, or set it far in the past if you want to ignore recently-expired TODOs.

The format must match [json-schema's date](https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times).

### examples

Find tech debt that has grown up and gone to college by triggering the rule for TODOs with old dates:

```js
"unicorn/expiring-todo-comments": [
	"error",
	{
		"date": "2000-01-01"
	}
]
```

Prepare for the future by triggering the rule for TODOs with dates from the next millennium:

```js
"unicorn/expiring-todo-comments": [
	"error",
	{
		"date": "3000-01-01"
	}
]
```