### PR TITLE
Replace `_.uniq` with native

### DIFF
--- a/rules/utils/get-references.js
+++ b/rules/utils/get-references.js
@@ -1,9 +1,9 @@
 'use strict';
-const {uniq} = require('lodash');
+
 const getScopes = require('./get-scopes.js');
 
-const getReferences = scope => uniq(
+const getReferences = scope => [...new Set(
 	getScopes(scope).flatMap(({references}) => references),
-);
+)];
 
 module.exports = getReferences;

--- a/rules/utils/get-variable-identifiers.js
+++ b/rules/utils/get-variable-identifiers.js
@@ -1,8 +1,7 @@
 'use strict';
-const {uniq} = require('lodash');
 
 // Get identifiers of given variable
-module.exports = ({identifiers, references}) => uniq([
+module.exports = ({identifiers, references}) => [...new Set([
 	...identifiers,
 	...references.map(({identifier}) => identifier),
-]);
+])];


### PR DESCRIPTION
At some point, it might be worth trying to replace the other lodash functions too, they should be ~ 6 cases only.