### PR TITLE
Allow `React.createContext(undefined)` in `no-useless-undefined`

### DIFF
--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -78,7 +78,9 @@ const shouldIgnore = node => {
 		// `array.push(undefined)`
 		|| name === 'push'
 		// `array.unshift(undefined)`
-		|| name === 'unshift';
+		|| name === 'unshift'
+		// `React.createContext(undefined)`
+		|| name === 'createContext';
 };
 
 const getFunction = scope => {

--- a/test/no-useless-undefined.mjs
+++ b/test/no-useless-undefined.mjs
@@ -51,6 +51,8 @@ test({
 		'array.push(undefined);',
 		'array.unshift(foo, undefined);',
 		'array.unshift(undefined);',
+		'createContext(undefined);',
+		'React.createContext(undefined);',
 
 		// `checkArguments: false`
 		{
@@ -276,6 +278,8 @@ test.typescript({
 		'const foo = (): string => undefined;',
 		'const foo = function (): undefined {return undefined}',
 		'export function foo(): undefined {return undefined}',
+		'createContext<T>(undefined);',
+		'React.createContext<T>(undefined);',
 		outdent`
 			const object = {
 				method(): undefined {
@@ -332,6 +336,8 @@ test.typescript({
 				}
 			}
 		`,
+		'createContext<T>(undefined);',
+		'React.createContext<T>(undefined);',
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Closes #1684 