### PR TITLE
Require ESLint 8

### DIFF
--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = {
 	env: {
-		es6: true,
+		es2021: true,
 	},
 	parserOptions: {
 		ecmaVersion: 'latest',

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"c8": "^7.11.0",
 		"chalk": "^5.0.0",
 		"enquirer": "^2.3.6",
-		"eslint": "^8.6.0",
+		"eslint": "^8.8.0",
 		"eslint-ava-rule-tester": "^4.0.0",
 		"eslint-plugin-eslint-plugin": "^4.1.0",
 		"eslint-remote-tester": "^2.0.1",
@@ -89,7 +89,7 @@
 		"xo": "^0.47.0"
 	},
 	"peerDependencies": {
-		"eslint": ">=7.32.0"
+		"eslint": ">=8.8.0"
 	},
 	"ava": {
 		"files": [

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Use a [preset config](#preset-configs) or configure each rules in `package.json`
 	"name": "my-awesome-project",
 	"eslintConfig": {
 		"env": {
-			"es6": true
+			"es2021": true
 		},
 		"parserOptions": {
 			"ecmaVersion": "latest",

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -124,11 +124,16 @@ test('validate configuration', async t => {
 
 	// `env`
 	{
+		// https://github.com/eslint/eslint/blob/32ac37a76b2e009a8f106229bc7732671d358189/conf/globals.js#L19
 		const testObjects = [
 			'undefinedGlobalObject',
-			// `es2015`(`es6`) globals https://github.com/eslint/eslint/blob/32ac37a76b2e009a8f106229bc7732671d358189/conf/globals.js#L74
+			// `es3`
+			'Array',
+			// `es5`
+			'JSON',
+			// `es2015`(`es6`)
 			'Promise',
-			// `es2021` globals https://github.com/eslint/eslint/blob/32ac37a76b2e009a8f106229bc7732671d358189/conf/globals.js#L120
+			// `es2021`
 			'WeakRef',
 		];
 		const baseOptions = {
@@ -147,8 +152,8 @@ test('validate configuration', async t => {
 			return messages.map(({message}) => message.match(/^'(?<object>.*)' is not defined\.$/).groups.object);
 		};
 
-		t.deepEqual(await getUndefinedGlobals(), testObjects);
-		t.deepEqual(await getUndefinedGlobals({baseConfig: eslintPluginUnicorn.configs.recommended}), testObjects.slice(0, 1));
+		t.deepEqual(await getUndefinedGlobals(), ['undefinedGlobalObject', 'Promise', 'WeakRef']);
+		t.deepEqual(await getUndefinedGlobals({baseConfig: eslintPluginUnicorn.configs.recommended}), ['undefinedGlobalObject']);
 	}
 
 	// `sourceType`

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -2,6 +2,7 @@ import fs, {promises as fsAsync} from 'node:fs';
 import path from 'node:path';
 import test from 'ava';
 import {ESLint} from 'eslint';
+import * as eslintrc from '@eslint/eslintrc'
 import eslintPluginUnicorn from '../index.js';
 import {RULE_NOTICE_MARK, getRuleNoticesSectionBody} from '../scripts/rule-notices.mjs';
 import {RULES_TABLE_MARK, getRulesTable} from '../scripts/rules-table.mjs';
@@ -154,6 +155,15 @@ test('validate configuration', async t => {
 
 		t.deepEqual(await getUndefinedGlobals(), ['undefinedGlobalObject', 'Promise', 'WeakRef']);
 		t.deepEqual(await getUndefinedGlobals({baseConfig: eslintPluginUnicorn.configs.recommended}), ['undefinedGlobalObject']);
+
+		const availableEnvironments = [...eslintrc.Legacy.environments.keys()].filter(name => /^es(?:\d+)$/.test(name));
+		const recommendedEnvironments = Object.keys(eslintPluginUnicorn.configs.recommended.env);
+		t.is(recommendedEnvironments.length, 1);
+		t.is(
+			availableEnvironments[availableEnvironments.length - 1],
+			recommendedEnvironments[0],
+			`env should be the latest es version`,
+		);
 	}
 
 	// `sourceType`

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -2,7 +2,7 @@ import fs, {promises as fsAsync} from 'node:fs';
 import path from 'node:path';
 import test from 'ava';
 import {ESLint} from 'eslint';
-import * as eslintrc from '@eslint/eslintrc'
+import * as eslintrc from '@eslint/eslintrc';
 import eslintPluginUnicorn from '../index.js';
 import {RULE_NOTICE_MARK, getRuleNoticesSectionBody} from '../scripts/rule-notices.mjs';
 import {RULES_TABLE_MARK, getRulesTable} from '../scripts/rules-table.mjs';
@@ -156,13 +156,13 @@ test('validate configuration', async t => {
 		t.deepEqual(await getUndefinedGlobals(), ['undefinedGlobalObject', 'Promise', 'WeakRef']);
 		t.deepEqual(await getUndefinedGlobals({baseConfig: eslintPluginUnicorn.configs.recommended}), ['undefinedGlobalObject']);
 
-		const availableEnvironments = [...eslintrc.Legacy.environments.keys()].filter(name => /^es(?:\d+)$/.test(name));
+		const availableEnvironments = [...eslintrc.Legacy.environments.keys()].filter(name => /^es\d+$/.test(name));
 		const recommendedEnvironments = Object.keys(eslintPluginUnicorn.configs.recommended.env);
 		t.is(recommendedEnvironments.length, 1);
 		t.is(
 			availableEnvironments[availableEnvironments.length - 1],
 			recommendedEnvironments[0],
-			`env should be the latest es version`,
+			'env should be the latest es version',
 		);
 	}
 


### PR DESCRIPTION
- Use `es2021: true` instead of `es6: true`.
- Add tests to validate it actually works
- Drop support for ESLint v7

Can't use `es2022`
```text
Error {
    message: `--config:
        Environment key "es2022" is unknown
    `,
  }
```

Actually, I was going to remove `env`, I thought setting `ecmaVersion` auto enables those envs, I'll investigate.