### PR TITLE
Add an internal ESLint rule `prefer-negative-boolean-attribute`

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,5 +169,17 @@
 				}
 			}
 		]
+	},
+	"npmpackagejsonlint": {
+		"rules": {
+			"prefer-caret-version-devDependencies": [
+				"error",
+				{
+					"exceptions": [
+						"eslint-plugin-internal-rules"
+					]
+				}
+			]
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"eslint": "^8.6.0",
 		"eslint-ava-rule-tester": "^4.0.0",
 		"eslint-plugin-eslint-plugin": "^4.1.0",
+		"eslint-plugin-internal-rules": "file:./scripts/internal-rules/",
 		"eslint-remote-tester": "^2.0.1",
 		"eslint-remote-tester-repositories": "^0.0.3",
 		"execa": "^6.0.0",
@@ -154,6 +155,17 @@
 					"eslint-plugin/require-meta-docs-url": "off",
 					"eslint-plugin/require-meta-has-suggestions": "off",
 					"eslint-plugin/require-meta-schema": "off"
+				}
+			},
+			{
+				"files": [
+					"rules/**/*.js"
+				],
+				"plugins": [
+					"internal-rules"
+				],
+				"rules": {
+					"internal-rules/prefer-negative-boolean-attribute": "error"
 				}
 			}
 		]

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -22,7 +22,7 @@ const selector = [
 		// `throw lib.FooError()`
 		[
 			'[callee.type="MemberExpression"]',
-			'[callee.computed!=true]',
+			'[callee.computed=false]',
 			'[callee.property.type="Identifier"]',
 			`[callee.property.name=/${customError.source}/]`,
 		].join(''),

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -22,7 +22,7 @@ const selector = [
 		// `throw lib.FooError()`
 		[
 			'[callee.type="MemberExpression"]',
-			'[callee.computed=false]',
+			'[callee.computed!=true]',
 			'[callee.property.type="Identifier"]',
 			`[callee.property.name=/${customError.source}/]`,
 		].join(''),

--- a/rules/utils/rule.js
+++ b/rules/utils/rule.js
@@ -142,7 +142,6 @@ function loadRules() {
 }
 
 module.exports = {
-	reportProblems,
 	loadRule,
 	loadRules,
 	checkVueTemplate,

--- a/rules/utils/rule.js
+++ b/rules/utils/rule.js
@@ -142,6 +142,7 @@ function loadRules() {
 }
 
 module.exports = {
+	reportProblems,
 	loadRule,
 	loadRules,
 	checkVueTemplate,

--- a/scripts/internal-rules/index.js
+++ b/scripts/internal-rules/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	rules: {
+		'prefer-negative-boolean-attribute': require('./prefer-negative-boolean-attribute.js'),
+	},
+};

--- a/scripts/internal-rules/package.json
+++ b/scripts/internal-rules/package.json
@@ -1,0 +1,6 @@
+{
+	"private": true,
+	"name": "eslint-plugin-internal-rules",
+	"description": "Internal rules",
+	"license": "MIT"
+}

--- a/scripts/internal-rules/prefer-negative-boolean-attribute.js
+++ b/scripts/internal-rules/prefer-negative-boolean-attribute.js
@@ -1,0 +1,44 @@
+'use strict';
+const path = require('path');
+
+const messageId = path.basename(__filename, '.js');
+
+const shouldReport = (string, value) => {
+	const index = string.indexOf(`=${value}]`);
+
+	if (index === -1) {
+		return false;
+	}
+
+	return string[index - 1] !== '!';
+}
+
+module.exports = {
+	create(context) {
+		return {
+			'TemplateElement, Literal'(node) {
+				const string = node.value;
+				if (typeof string !== 'string') {
+					return;
+				}
+
+				for (const value of [true, false]) {
+					if (shouldReport(string, value)) {
+						context.report({
+							node,
+							messageId,
+							data: {
+								preferred: String(!value)
+							}
+						})
+					}
+				}
+			}
+		}
+	},
+	meta: {
+		messages: {
+			[messageId]: 'Prefer use `[…!={{preferred}}]` in esquery selector.'
+		},
+	}
+};

--- a/scripts/internal-rules/prefer-negative-boolean-attribute.js
+++ b/scripts/internal-rules/prefer-negative-boolean-attribute.js
@@ -11,7 +11,7 @@ const shouldReport = (string, value) => {
 	}
 
 	return string[index - 1] !== '!';
-}
+};
 
 module.exports = {
 	create(context) {
@@ -28,17 +28,17 @@ module.exports = {
 							node,
 							messageId,
 							data: {
-								preferred: String(!value)
-							}
-						})
+								preferred: String(!value),
+							},
+						});
 					}
 				}
-			}
-		}
+			},
+		};
 	},
 	meta: {
 		messages: {
-			[messageId]: 'Prefer use `[…!={{preferred}}]` in esquery selector.'
+			[messageId]: 'Prefer use `[…!={{preferred}}]` in esquery selector.',
 		},
-	}
+	},
 };


### PR DESCRIPTION
Use positive `[...=true]` may cause problems, when `ecmaVersion` is not correct. #1146, https://github.com/fisker/eslint-plugin-prettier-doc/commit/f1b1c6f339a77ed306c64172c927849f0d78c7c3

Maybe I can try to make a proposal in [eslint-plugin-eslint-plugin](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin) later.