### PR TITLE
Update `eslint-remote-tester.config.js`

### DIFF
--- a/test/smoke/eslint-remote-tester.config.js
+++ b/test/smoke/eslint-remote-tester.config.js
@@ -10,7 +10,7 @@ module.exports = {
 	pathIgnorePattern: getPathIgnorePattern(),
 
 	/** Extensions of files under scanning */
-	extensions: ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts', 'jsx', 'tsx'],
+	extensions: ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts', 'jsx', 'tsx', 'vue'],
 
 	/** Maximum amount of tasks ran concurrently */
 	concurrentTasks: 3,

--- a/test/smoke/eslint-remote-tester.config.js
+++ b/test/smoke/eslint-remote-tester.config.js
@@ -10,7 +10,7 @@ module.exports = {
 	pathIgnorePattern: getPathIgnorePattern(),
 
 	/** Extensions of files under scanning */
-	extensions: ['js', 'jsx', 'ts', 'tsx'],
+	extensions: ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts', 'jsx', 'tsx'],
 
 	/** Maximum amount of tasks ran concurrently */
 	concurrentTasks: 3,
@@ -24,13 +24,8 @@ module.exports = {
 	/** ESLint configuration */
 	eslintrc: {
 		root: true,
-		env: {
-			es6: true,
-		},
 		parser: '@typescript-eslint/parser',
 		parserOptions: {
-			ecmaVersion: 'latest',
-			sourceType: 'module',
 			ecmaFeatures: {
 				jsx: true,
 			},


### PR DESCRIPTION
- Add more extensions
- We already have `env` and `parserOptions` in 'plugin:unicorn/all', we should be able to remove them 

//cc @AriPerkkio