### PR TITLE
`no-useless-promise-resolve-reject`: Fix typo in lint message

### DIFF
--- a/rules/no-useless-promise-resolve-reject.js
+++ b/rules/no-useless-promise-resolve-reject.js
@@ -5,7 +5,7 @@ const {getParenthesizedRange} = require('./utils/parentheses.js');
 const MESSAGE_ID_RESOLVE = 'resolve';
 const MESSAGE_ID_REJECT = 'reject';
 const messages = {
-	[MESSAGE_ID_RESOLVE]: 'Prefer `{{type}} value` over `{{type}} Promise.resolve(error)`.',
+	[MESSAGE_ID_RESOLVE]: 'Prefer `{{type}} value` over `{{type}} Promise.resolve(value)`.',
 	[MESSAGE_ID_REJECT]: 'Prefer `throw error` over `{{type}} Promise.reject(error)`.',
 };
 


### PR DESCRIPTION
Existing error message: ``Prefer `return value` over `return Promise.resolve(error)` ``

This is a little unexpected since it's returning a value rather than an error.

This PR is makes the message read as: ``Prefer `return value` over `return Promise.resolve(value)` ``