### PR TITLE
`no-unsafe-regex`: Fix examples

### DIFF
--- a/docs/rules/no-unsafe-regex.md
+++ b/docs/rules/no-unsafe-regex.md
@@ -55,5 +55,5 @@ const regex = /^\d+(1337|404)*\d+$/i;
 ```
 
 ```js
-const regex = RegExp('a?'.repeat(25) + 'a'.repeat(25));
+const regex = new RegExp('a?'.repeat(25) + 'a'.repeat(25));
 ```

--- a/docs/rules/no-unsafe-regex.md
+++ b/docs/rules/no-unsafe-regex.md
@@ -10,11 +10,25 @@ Uses [safe-regex](https://github.com/substack/safe-regex) to disallow potentiall
 
 ```js
 const regex = /^(a?){25}(a){25}$/;
-const regex = RegExp('a?'.repeat(26) + 'a'.repeat(26));
+```
+
+```js
 const regex = /(x+x+)+y/;
+```
+
+```js
 const regex = /foo|(x+x+)+y/;
+```
+
+```js
 const regex = /(a+){10}y/;
+```
+
+```js
 const regex = /(a+){2}y/;
+```
+
+```js
 const regex = /(.*){1,32000}[bc]/;
 ```
 
@@ -22,9 +36,24 @@ const regex = /(.*){1,32000}[bc]/;
 
 ```js
 const regex = /\bOakland\b/;
+```
+
+```js
 const regex = /\b(Oakland|San Francisco)\b/i;
+```
+
+```js
 const regex = /^\d+1337\d+$/i;
+```
+
+```js
 const regex = /^\d+(1337|404)\d+$/i;
+```
+
+```js
 const regex = /^\d+(1337|404)*\d+$/i;
+```
+
+```js
 const regex = RegExp('a?'.repeat(25) + 'a'.repeat(25));
 ```


### PR DESCRIPTION
Fixes #1535