### PR TITLE
Set `template-indent` to `error`

### DIFF
--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -113,7 +113,7 @@ module.exports = {
 		// See #1396
 		'unicorn/require-post-message-target-origin': 'off',
 		'unicorn/string-content': 'off',
-		'unicorn/template-indent': 'warn',
+		'unicorn/template-indent': 'error',
 		'unicorn/text-encoding-identifier-case': 'error',
 		'unicorn/throw-new-error': 'error',
 	},


### PR DESCRIPTION
This rule has auto-fix, when user save file with this probem, `"warn"` will also cause ESLint fix the template string, may commit unrelated change.