### PR TITLE
Update abreviations to support next functions

### DIFF
--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -240,6 +240,8 @@ module.exports.defaultAllowList = {
 	// Next.js function
 	// https://nextjs.org/learn/basics/fetching-data-for-pages
 	getInitialProps: true,
+	getServerSideProps: true,
+	getStaticProps: true,
 	// React PropTypes
 	// https://reactjs.org/docs/typechecking-with-proptypes.html
 	propTypes: true,


### PR DESCRIPTION
Added these lines to prevent the rule from erroring on default next functions such as the following:
![image](https://user-images.githubusercontent.com/10339043/166128707-9ade3087-564d-444e-81e8-d8b0d33bf931.png)
