### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/rules/numeric-separators-style.md
+++ b/docs/rules/numeric-separators-style.md
@@ -50,7 +50,7 @@ Example:
 
 ```js
 // eslint unicorn/numeric-separators-style: ["error", {"onlyIfContainsSeparator": true, "binary": {"onlyIfContainsSeparator": false}]
-const number = 100000; // Pass, this number does not contains separators
+const number = 100000; // Pass, this number does not contain separators
 const binary = 0b101010001; // Fail, `binary` type don't require separators
 const hexadecimal = 0xD_EED_BEE_F; // Fail, it contain separators and it's incorrectly grouped
 ```


### PR DESCRIPTION
'does not contains' is grammatically incorrect

<!--
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
-->
