### PR TITLE
Make `template-indent` preserve trailing spaces

### DIFF
--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -67,9 +67,11 @@ const create = context => {
 		}
 
 		const dedented = stripIndent(joined);
+		const trimmed = dedented.replace(new RegExp(`^${eol}|${eol}[ \t]*$`, 'g'), '');
+
 		const fixed
 			= eol
-			+ indentString(dedented.trim(), 1, {indent: parentMargin + indent})
+			+ indentString(trimmed, 1, {indent: parentMargin + indent})
 			+ eol
 			+ parentMargin;
 

--- a/test/template-indent.mjs
+++ b/test/template-indent.mjs
@@ -486,6 +486,24 @@ test({
 				\`
 			`),
 		},
+		{
+			name: 'Lines with whitespaces are kept trimmed',
+			code: fixInput(`
+				outdent\`
+				••Line1
+				••
+				••Line2
+				\`
+			`),
+			errors,
+			output: fixInput(`
+				outdent\`
+				••Line1
+
+				••Line2
+				\`
+			`),
+		}
 	],
 	/** @type {import('eslint').RuleTester.ValidTestCase[]} */
 	valid: [
@@ -586,6 +604,33 @@ test({
 			••after
 			\`
 		`),
+		{
+			name: 'Trailing spaces in the last line are preserved',
+			code: fixInput(`
+				outdent\`
+				••Line with trailing spaces••••
+				\`
+			`),
+		},
+		{
+			name: 'Trailing spaces in non-last line are preserved',
+			code: fixInput(`
+				outdent\`
+				••Line with trailing spaces••••
+				••Line without trailing spaces
+				\`
+			`),
+		},
+		{
+			name: 'Empty lines are preserved',
+			code: fixInput(`
+				outdent\`
+				••Line1
+
+				••Line2
+				\`
+			`),
+		},
 	],
 });
 

--- a/test/template-indent.mjs
+++ b/test/template-indent.mjs
@@ -503,7 +503,7 @@ test({
 				••Line2
 				\`
 			`),
-		}
+		},
 	],
 	/** @type {import('eslint').RuleTester.ValidTestCase[]} */
 	valid: [


### PR DESCRIPTION
Fixes #1868

I realized that having it as a setting is not a right thing, because linter fixes should be essentially the same code, just restyled. Trimming trailing spaces essentially modifies the string and this should be considered as a bug.

Corresponding unit tests were added