### PR TITLE
Mention Node version support in `prefer-node-protocol` rule

### DIFF
--- a/docs/rules/prefer-node-protocol.md
+++ b/docs/rules/prefer-node-protocol.md
@@ -9,6 +9,12 @@
 
 When importing builtin modules, it's better to use the [`node:` protocol](https://nodejs.org/api/esm.html#node-imports) as it makes it perfectly clear that the package is a Node.js builtin module.
 
+Note that Node.js support for this feature began in:
+
+> v16.0.0, v14.18.0 (`require()`)
+>
+> v14.13.1, v12.20.0 (`import`)
+
 ## Fail
 
 ```js


### PR DESCRIPTION
Document the supported Node versions for the node protocol import feature to reduce potential confusion or mistaken adoption of this lint rule.

While eslint-plugin-unicorn only supports Node 14.18 and above:

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/20e959ffadeca007697534f1ad58c45d29cfdb04/package.json#L14

Some libraries that intend to support all versions of Node 14 might accidentally adopt this lint rule since it's very common to only test against the latest Node 14 and not necessarily against early versions of it.

Fixes #1867.
