### PR TITLE
Remove issue reference from prefer-node-protocol

### DIFF
--- a/docs/rules/prefer-node-protocol.md
+++ b/docs/rules/prefer-node-protocol.md
@@ -9,8 +9,6 @@
 
 When importing builtin modules, it's better to use the [`node:` protocol](https://nodejs.org/api/esm.html#node-imports) as it makes it perfectly clear that the package is a Node.js builtin module.
 
-And don't forget to [upvote this issue](https://github.com/nodejs/node/issues/38343) if you agree.
-
 ## Fail
 
 ```js


### PR DESCRIPTION
The issue about making the Node.js docs follow this rule was fixed in April, so no need to upvote it anymore