### PR TITLE
`prefer-negative-index`: Remove `ArrayBuffer#at`

### DIFF
--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -43,7 +43,6 @@ const methods = new Map([
 			supportObjects: new Set([
 				'Array',
 				'String',
-				'ArrayBuffer',
 				...typedArray,
 			]),
 		},


### PR DESCRIPTION
Mistake in #1894, there is no `.at` in `ArrayBuffer`