### PR TITLE
`better-regexp`: Don't fix if `.source` or `.toString()` is used

### DIFF
--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -51,15 +51,32 @@ const create = context => {
 				return;
 			}
 
-			return {
+			const problem = {
 				node,
 				messageId: MESSAGE_ID,
 				data: {
 					original,
 					optimized,
 				},
-				fix: fixer => fixer.replaceText(node, optimized),
 			};
+
+			if (
+				node.parent.type === 'MemberExpression'
+				&& node.parent.object === node
+				&& !node.parent.optional
+				&& !node.parent.computed
+				&& node.parent.property.type === 'Identifier'
+				&& (
+					node.parent.property.name === 'toString'
+					|| node.parent.property.name === 'source'
+				)
+			) {
+				return problem;
+			}
+
+			return Object.assign(problem, {
+				fix: fixer => fixer.replaceText(node, optimized),
+			});
 		},
 		[newRegExp](node) {
 			const [patternNode, flagsNode] = node.arguments;

--- a/test/better-regex.mjs
+++ b/test/better-regex.mjs
@@ -311,5 +311,15 @@ test({
 			],
 			parser: require.resolve('@typescript-eslint/parser'),
 		},
+
+		// Not fixable
+		{
+			code: 'const foo = /[0-9]/.toString',
+			errors: createError('/[0-9]/', '/\\d/'),
+		},
+		{
+			code: 'const foo = /[0-9]/.source',
+			errors: createError('/[0-9]/', '/\\d/'),
+		},
 	],
 });


### PR DESCRIPTION
Fixes #1878