### PR TITLE
`prevent-abbreviations`: Skip fix when variable is JSX component

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -215,7 +215,13 @@ const isExportedIdentifier = identifier => {
 	return false;
 };
 
-const shouldFix = variable => !getVariableIdentifiers(variable).some(identifier => isExportedIdentifier(identifier));
+const shouldFix = variable => getVariableIdentifiers(variable)
+	.every(identifier =>
+		!isExportedIdentifier(identifier)
+		// In typescript parser, only `JSXOpeningElement` is added to variable
+		// `<foo></foo>` -> `<bar></foo>` will cause parse error
+		&& identifier.type !== 'JSXIdentifier'
+	);
 
 const isDefaultOrNamespaceImportName = identifier => {
 	if (

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -220,7 +220,7 @@ const shouldFix = variable => getVariableIdentifiers(variable)
 		!isExportedIdentifier(identifier)
 		// In typescript parser, only `JSXOpeningElement` is added to variable
 		// `<foo></foo>` -> `<bar></foo>` will cause parse error
-		&& identifier.type !== 'JSXIdentifier'
+		&& identifier.type !== 'JSXIdentifier',
 	);
 
 const isDefaultOrNamespaceImportName = identifier => {

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1869,7 +1869,7 @@ test.typescript({
 	},
 	valid: [],
 	invalid: [
-		// `jsx` https://github.com/microsoft/fluentui/blob/ead191a8368bf64ecabffce5ea0e02565f449a95/packages/fluentui/docs/src/views/FocusTrapZoneDoc.tsx#L10
+		// https://github.com/microsoft/fluentui/blob/ead191a8368bf64ecabffce5ea0e02565f449a95/packages/fluentui/docs/src/views/FocusTrapZoneDoc.tsx#L10
 		{
 			code: outdent`
 				import DocPage from '../components/DocPage';

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1858,6 +1858,30 @@ test.typescript({
 	],
 });
 
+// JSX
+test.typescript({
+	testerOptions: {
+		parserOptions: {
+			ecmaFeatures: {
+				jsx: true,
+			},
+		},
+	},
+	valid: [],
+	invalid: [
+		// `jsx` https://github.com/microsoft/fluentui/blob/ead191a8368bf64ecabffce5ea0e02565f449a95/packages/fluentui/docs/src/views/FocusTrapZoneDoc.tsx#L10
+		{
+			code: outdent`
+				import DocPage from '../components/DocPage';
+				export default () => (
+					<DocPage title="Focus Trap Zone"></DocPage>
+				);
+			`,
+			errors: 1,
+		},
+	],
+});
+
 // Filename
 test({
 	valid: [


### PR DESCRIPTION
Found this during #1906 https://github.com/sindresorhus/eslint-plugin-unicorn/actions/runs/3087777937/jobs/4993499473#step:5:644