### PR TITLE
`no-await-expression-member`: Fix crash on typescript parser

### DIFF
--- a/rules/no-await-expression-member.js
+++ b/rules/no-await-expression-member.js
@@ -53,6 +53,7 @@ const create = context => {
 				&& memberExpression.parent.init === memberExpression
 				&& memberExpression.parent.id.type === 'Identifier'
 				&& memberExpression.parent.id.name === property.name
+				&& !memberExpression.parent.id.typeAnnotation
 			) {
 				problem.fix = function * (fixer) {
 					const variable = memberExpression.parent.id;

--- a/rules/no-await-expression-member.js
+++ b/rules/no-await-expression-member.js
@@ -30,6 +30,7 @@ const create = context => {
 				&& memberExpression.parent.type === 'VariableDeclarator'
 				&& memberExpression.parent.init === memberExpression
 				&& memberExpression.parent.id.type === 'Identifier'
+				&& !memberExpression.parent.id.typeAnnotation
 			) {
 				problem.fix = function * (fixer) {
 					const variable = memberExpression.parent.id;

--- a/test/no-await-expression-member.mjs
+++ b/test/no-await-expression-member.mjs
@@ -54,5 +54,9 @@ test.typescript({
 			code: 'const foo: Type = (await promise)[0]',
 			errors: 1,
 		},
+		{
+			code: 'const foo: Type | A = (await promise).foo',
+			errors: 1,
+		},
 	],
 });

--- a/test/no-await-expression-member.mjs
+++ b/test/no-await-expression-member.mjs
@@ -49,5 +49,10 @@ test.typescript({
 	valid: [
 		'function foo () {return (await promise) as string;}',
 	],
-	invalid: [],
+	invalid: [
+		{
+			code: 'const foo: Type = (await promise)[0]',
+			errors: 1,
+		},
+	],
 });


### PR DESCRIPTION
Found in #1906