### PR TITLE
no-array-method-this-argument: Ignore lodash.{findLast,findLastIndex}

### DIFF
--- a/rules/no-array-method-this-argument.js
+++ b/rules/no-array-method-this-argument.js
@@ -31,10 +31,20 @@ const ignored = [
 	'underscore.find',
 	'R.find',
 
+	'lodash.findLast',
+	'_.findLast',
+	'underscore.findLast',
+	'R.findLast',
+
 	'lodash.findIndex',
 	'_.findIndex',
 	'underscore.findIndex',
 	'R.findIndex',
+
+	'lodash.findLastIndex',
+	'_.findLastIndex',
+	'underscore.findLastIndex',
+	'R.findLastIndex',
 
 	'lodash.flatMap',
 	'_.flatMap',


### PR DESCRIPTION
Fixes false positives from 3bc28ad517f7c8bf4eff42b9d7587d26b29557c7 (#1890).