### PR TITLE
`prefer-top-level-await`: Fix crash on `for..of` loop

### DIFF
--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -93,7 +93,8 @@ function create(context) {
 				? definition.node.init
 				: definition.node;
 			if (
-				!(
+				!value
+				|| !(
 					(
 						value.type === 'ArrowFunctionExpression'
 						|| value.type === 'FunctionExpression'

--- a/test/prefer-top-level-await.mjs
+++ b/test/prefer-top-level-await.mjs
@@ -138,6 +138,7 @@ test.snapshot({
 			const foo = async () => {};
 			await foo();
 		`,
+		'for (const statement of statements) { statement() };',
 	],
 	invalid: [
 		outdent`


### PR DESCRIPTION
Fixes #1945