### PR TITLE
`filename-case`: Add `includePath` option

### DIFF
--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -105,3 +105,20 @@ Don't forget that you must escape special characters that you don't want to be i
 	}
 ]
 ```
+
+### includePath
+
+Type: `boolean`\
+Default: `false`
+
+Checks the path for case style, in addition to the filename.
+
+```js
+"unicorn/filename-case": [
+	"error",
+	{
+		"case": "kebabCase",
+		"includePath": true,
+	}
+]
+```

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -1,6 +1,5 @@
 'use strict';
 const path = require('node:path');
-const process = require('node:process');
 const {camelCase, kebabCase, snakeCase, upperFirst} = require('lodash');
 const cartesianProductSamples = require('./utils/cartesian-product-samples.js');
 
@@ -157,7 +156,7 @@ const create = context => {
 			const extension = path.extname(filenameWithExtension);
 			const filename = path.basename(filenameWithExtension, extension);
 
-			const relativeFilenameWithExtension = path.relative(process.cwd(), filenameWithExtension);
+			const relativeFilenameWithExtension = path.relative(context.getCwd(), filenameWithExtension);
 			const dirname = path.dirname(relativeFilenameWithExtension);
 			const directoryAndFilename = dirname + path.sep + filename;
 

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -162,7 +162,19 @@ const create = context => {
 
 			const base = filename + extension;
 
-			if (ignoredByDefault.has(base) || ignore.some(regexp => regexp.test(includePath ? relativeFilenameWithExtension : base))) {
+			if (ignoredByDefault.has(base)) {
+				return;
+			}
+
+			const hasIgnoreMatch = ignore.some(regexp => {
+				if (includePath) {
+					return relativeFilenameWithExtension.split(path.sep).some((part => regexp.test(part)));
+				}
+
+				return regexp.test(base);
+			});
+
+			if (hasIgnoreMatch) {
 				return;
 			}
 

--- a/test/filename-case.mjs
+++ b/test/filename-case.mjs
@@ -246,7 +246,7 @@ test({
 						kebabCase: true,
 					},
 					includePath: true,
-					ignore: [/Src/],
+					ignore: [/^Foo/],
 				},
 			],
 		),

--- a/test/filename-case.mjs
+++ b/test/filename-case.mjs
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import process from 'node:process';
 import {getTester} from './utils/test.mjs';
 
 const {test} = getTester(import.meta);
@@ -234,6 +236,20 @@ test({
 				ignore: [/FOOBAR\.js/u, /BaRbAz\.js/u],
 			},
 		]),
+		testCase('Src/Foo/foo-bar.js'),
+		testCaseWithOptions(
+			'Src/Foo/foo-bar.js',
+			undefined,
+			[
+				{
+					cases: {
+						kebabCase: true,
+					},
+					includePath: true,
+					ignore: [/Src/],
+				},
+			],
+		),
 		// Ignored
 		...['index.js', 'index.mjs', 'index.cjs', 'index.ts', 'index.tsx', 'index.vue'].flatMap(
 			filename => ['camelCase', 'snakeCase', 'kebabCase', 'pascalCase'].map(chosenCase => testCase(filename, chosenCase)),
@@ -546,6 +562,50 @@ test({
 				kebabCase: true,
 			},
 			'Filename is not in camel case, pascal case, or kebab case. Rename it to `1.js`.',
+		),
+		testCaseWithOptions(
+			'Src/Foo/foo-bar.js',
+			'Filename is not in camel case or snake case. Rename it to `src/foo/fooBar.js` or `src/foo/foo_bar.js`.',
+			[
+				{
+					cases: {
+						camelCase: true,
+						snakeCase: true,
+					},
+					includePath: true,
+				},
+			],
+		),
+		testCaseWithOptions(
+			'src_/foo_Bar/foo-bar.js',
+			'Filename is not in kebab case. Rename it to `src/foo-bar/foo-bar.js`.',
+			[
+				{
+					case: 'kebabCase',
+					includePath: true,
+				},
+			],
+		),
+		testCaseWithOptions(
+			'Src/foo/foo-Bar.js',
+			'Filename is not in kebab case. Rename it to `src/foo/foo-bar.js`.',
+			[
+				{
+					case: 'kebabCase',
+					includePath: true,
+					ignore: [/bar/],
+				},
+			],
+		),
+		testCaseWithOptions(
+			path.join(process.cwd(), 'Src/foo/foo-Bar.js'),
+			'Filename is not in kebab case. Rename it to `src/foo/foo-bar.js`.',
+			[
+				{
+					case: 'kebabCase',
+					includePath: true,
+				},
+			],
 		),
 	],
 });

--- a/test/filename-case.mjs
+++ b/test/filename-case.mjs
@@ -565,7 +565,7 @@ test({
 		),
 		testCaseWithOptions(
 			'Src/Foo/foo-bar.js',
-			`Filename is not in camel case or snake case. Rename it to \`${path.join('src','foo','fooBar.js')}\` or \`${path.join('src','foo','foo_bar.js')}\`.`,
+			`Filename is not in camel case or snake case. Rename it to \`${path.join('src', 'foo', 'fooBar.js')}\` or \`${path.join('src', 'foo', 'foo_bar.js')}\`.`,
 			[
 				{
 					cases: {
@@ -599,7 +599,7 @@ test({
 		),
 		testCaseWithOptions(
 			path.join(process.cwd(), 'Src/foo/foo-Bar.js'),
-			`Filename is not in kebab case. Rename it to \`${path.join('src','foo','foo-bar.js')}\`.`,
+			`Filename is not in kebab case. Rename it to \`${path.join('src', 'foo', 'foo-bar.js')}\`.`,
 			[
 				{
 					case: 'kebabCase',

--- a/test/filename-case.mjs
+++ b/test/filename-case.mjs
@@ -565,7 +565,7 @@ test({
 		),
 		testCaseWithOptions(
 			'Src/Foo/foo-bar.js',
-			'Filename is not in camel case or snake case. Rename it to `src/foo/fooBar.js` or `src/foo/foo_bar.js`.',
+			`Filename is not in camel case or snake case. Rename it to \`${path.join('src','foo','fooBar.js')}\` or \`${path.join('src','foo','foo_bar.js')}\`.`,
 			[
 				{
 					cases: {
@@ -578,7 +578,7 @@ test({
 		),
 		testCaseWithOptions(
 			'src_/foo_Bar/foo-bar.js',
-			'Filename is not in kebab case. Rename it to `src/foo-bar/foo-bar.js`.',
+			`Filename is not in kebab case. Rename it to \`${path.join('src', 'foo-bar', 'foo-bar.js')}\`.`,
 			[
 				{
 					case: 'kebabCase',
@@ -588,7 +588,7 @@ test({
 		),
 		testCaseWithOptions(
 			'Src/foo/foo-Bar.js',
-			'Filename is not in kebab case. Rename it to `src/foo/foo-bar.js`.',
+			`Filename is not in kebab case. Rename it to \`${path.join('src', 'foo', 'foo-bar.js')}\`.`,
 			[
 				{
 					case: 'kebabCase',
@@ -599,7 +599,7 @@ test({
 		),
 		testCaseWithOptions(
 			path.join(process.cwd(), 'Src/foo/foo-Bar.js'),
-			'Filename is not in kebab case. Rename it to `src/foo/foo-bar.js`.',
+			`Filename is not in kebab case. Rename it to \`${path.join('src','foo','foo-bar.js')}\`.`,
 			[
 				{
 					case: 'kebabCase',


### PR DESCRIPTION
This PR aims to resolve #686 by allowing the rule to also lint paths.

I've added varied test cases, and have manually tested locally against a production project.