### PR TITLE
`prevent-abbreviations`: Skip fix for variables used in Vue template

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -448,7 +448,12 @@ const create = context => {
 			node: definition.name,
 		};
 
-		if (variableReplacements.total === 1 && shouldFix(variable) && variableReplacements.samples[0]) {
+		if (
+			variableReplacements.total === 1
+			&& shouldFix(variable)
+			&& variableReplacements.samples[0]
+			&& !variable.references.some(reference => reference.vueUsedInTemplate)
+		) {
 			const [replacement] = variableReplacements.samples;
 
 			for (const scope of scopes) {

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -2002,5 +2002,36 @@ test({
 			],
 		},
 	],
+});
 
+test.vue({
+	valid: [],
+	invalid: [
+		{
+			code: outdent`
+				<template>
+					<button @click="goToPrev"/>
+				</template>
+				<script setup>
+				const goToPrev = () => {}
+				</script>
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				<template><button/></template>
+				<script setup>
+				const goToPrev = () => {}
+				</script>
+			`,
+			output: outdent`
+				<template><button/></template>
+				<script setup>
+				const goToPrevious = () => {}
+				</script>
+			`,
+			errors: 1,
+		},
+	],
 });


### PR DESCRIPTION
Fixes #2005