### PR TITLE
`prefer-node-protocol`: Don't suggest `node:` prefix for punycode

### DIFF
--- a/rules/prefer-node-protocol.js
+++ b/rules/prefer-node-protocol.js
@@ -26,6 +26,7 @@ const create = () => ({
 			typeof value !== 'string'
 			|| value.startsWith('node:')
 			|| !isBuiltinModule(value)
+			|| value === 'punycode'
 		) {
 			return;
 		}

--- a/test/prefer-node-protocol.mjs
+++ b/test/prefer-node-protocol.mjs
@@ -9,6 +9,7 @@ test.snapshot({
 		'import fs from "./fs";',
 		'import fs from "unknown-builtin-module";',
 		'import fs from "node:fs";',
+		'import punycode from "punycode";',
 		outdent`
 			async function foo() {
 				const fs = await import(fs);
@@ -74,6 +75,7 @@ test.snapshot({
 		'const fs = require();',
 		'const fs = require(...["fs"]);',
 		'const fs = require("unicorn");',
+		'const fs = require("punycode");',
 	],
 	invalid: [
 		'const {promises} = require("fs")',


### PR DESCRIPTION
The [`punycode` core module](https://nodejs.org/api/punycode.html) is deprecated since Node 7.0.0. There is a [same-name npm module](https://www.npmjs.com/package/punycode) which is the recommended alternative. I think this situation is one-of-a-kind for core modules, so I added a simple condition to ignore it.

Related: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1931