### PR TITLE
`consistent-destructuring`: Add `exceptions` option

### DIFF
--- a/docs/rules/consistent-destructuring.md
+++ b/docs/rules/consistent-destructuring.md
@@ -57,3 +57,17 @@ console.log(a, foo.b());
 const {a} = foo.bar;
 console.log(foo.bar);
 ```
+
+## Options
+
+### exceptions
+
+Type: `string[]`
+
+Pass `exceptions` to disable linting of certain expressions.
+
+```js
+/* eslint unicorn/consistent-destructuring: ["error", {exceptions: ["this.state"]}] */
+const {someMethod} = this;
+console.log(this.state);
+```

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -55,6 +55,7 @@ const isChildInParentScope = (child, parent) => {
 const create = context => {
 	const source = context.getSourceCode();
 	const declarations = new Map();
+	const exceptions = context.options[0]?.exceptions;
 
 	return {
 		[declaratorSelector](node) {
@@ -95,6 +96,10 @@ const create = context => {
 
 			const expression = source.getText(node);
 			const member = source.getText(node.property);
+
+			if (exceptions?.includes(expression)) {
+				return;
+			}
 
 			// Member might already be destructured
 			const destructuredMember = destructurings.find(property =>
@@ -150,6 +155,21 @@ const create = context => {
 	};
 };
 
+const schema = [
+	{
+		type: 'object',
+		additionalProperties: false,
+		properties: {
+			exceptions: {
+				type: 'array',
+				items: {
+					type: 'string',
+				},
+			},
+		},
+	},
+];
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
@@ -160,6 +180,7 @@ module.exports = {
 		},
 		fixable: 'code',
 		hasSuggestions: true,
+		schema,
 		messages: {
 			[MESSAGE_ID]: 'Use destructured variables over properties.',
 			[MESSAGE_ID_SUGGEST]: 'Replace `{{expression}}` with destructured property `{{property}}`.',

--- a/test/consistent-destructuring.mjs
+++ b/test/consistent-destructuring.mjs
@@ -214,11 +214,10 @@ test({
 			options: [{
 				exceptions: ['this.state'],
 			}],
-			code: 
-				outdent`
-					const {someMethod} = this;
-					console.log(this.state);
-				`,
+			code: outdent`
+				const {someMethod} = this;
+				console.log(this.state);
+			`,
 		},
 	],
 	invalid: [

--- a/test/consistent-destructuring.mjs
+++ b/test/consistent-destructuring.mjs
@@ -210,6 +210,16 @@ test({
 			const {a: b} = foo;
 			console.log(foo.b);
 		`,
+		{
+			options: [{
+				exceptions: ['this.state'],
+			}],
+			code: 
+				outdent`
+					const {someMethod} = this;
+					console.log(this.state);
+				`,
+		},
 	],
 	invalid: [
 		invalidTestCase({


### PR DESCRIPTION
This pull request fixes #1501. Certain expressions can be specified as exceptions so that they will not be reported by the rule.