### PR TITLE
add `elems` to abbreviations

### DIFF
--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -84,6 +84,9 @@ module.exports.defaultReplacements = {
 	elem: {
 		element: true,
 	},
+	elems: {
+		elements: true,
+	},
 	env: {
 		environment: true,
 	},


### PR DESCRIPTION
`elements` is often abbreviated as `elems`. E.g. `const fooElems = document.querySelectorAll('.foo')`.

<!--
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
-->
