### PR TITLE
Remove use of deprecated methods, require eslint>=8.40.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"yaml": "^2.2.1"
 	},
 	"peerDependencies": {
-		"eslint": ">=8.38.0"
+		"eslint": ">=8.40.0"
 	},
 	"ava": {
 		"files": [

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -60,7 +60,7 @@ const create = context => {
 				return;
 			}
 
-			const scope = context.getSourceCode().getScope(node);
+			const scope = context.sourceCode.getScope(node);
 			const variable = findVariable(scope, node);
 
 			// This was reported https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1075#issuecomment-768072967

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -53,7 +53,7 @@ const isChildInParentScope = (child, parent) => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const declarations = new Map();
 
 	return {

--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -53,7 +53,7 @@ const isChildInParentScope = (child, parent) => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const declarations = new Map();
 
 	return {

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -149,7 +149,7 @@ function checkNode(node, scopeManager) {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {checkArrowFunctions} = {checkArrowFunctions: true, ...context.options[0]};
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const {scopeManager} = sourceCode;
 
 	const functions = [];

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -149,7 +149,7 @@ function checkNode(node, scopeManager) {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {checkArrowFunctions} = {checkArrowFunctions: true, ...context.options[0]};
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const {scopeManager} = sourceCode;
 
 	const functions = [];

--- a/rules/empty-brace-spaces.js
+++ b/rules/empty-brace-spaces.js
@@ -19,7 +19,7 @@ const selector = matches([
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const filter = node.type === 'RecordExpression'
 			? token => token.type === 'Punctuator' && (token.value === '#{' || token.value === '{|')
 			: isOpeningBraceToken;

--- a/rules/empty-brace-spaces.js
+++ b/rules/empty-brace-spaces.js
@@ -19,7 +19,7 @@ const selector = matches([
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const filter = node.type === 'RecordExpression'
 			? token => token.type === 'Punctuator' && (token.value === '#{' || token.value === '{|')
 			: isOpeningBraceToken;

--- a/rules/error-message.js
+++ b/rules/error-message.js
@@ -28,7 +28,7 @@ const selector = callOrNewExpressionSelector([
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](expression) {
-		const scope = context.getSourceCode().getScope(expression);
+		const scope = context.sourceCode.getScope(expression);
 		if (isShadowed(scope, expression.callee)) {
 			return;
 		}

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -263,7 +263,7 @@ const create = context => {
 		pattern => pattern instanceof RegExp ? pattern : new RegExp(pattern, 'u'),
 	);
 
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const comments = sourceCode.getAllComments();
 	const unusedComments = comments
 		.filter(token => token.type !== 'Shebang')

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -263,7 +263,7 @@ const create = context => {
 		pattern => pattern instanceof RegExp ? pattern : new RegExp(pattern, 'u'),
 	);
 
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const comments = sourceCode.getAllComments();
 	const unusedComments = comments
 		.filter(token => token.type !== 'Shebang')
@@ -290,7 +290,6 @@ const create = context => {
 			...sourceCode,
 			getAllComments: () => options.allowWarningComments ? [] : unusedComments,
 		},
-		getSourceCode: () => fakeContext.sourceCode,
 	};
 	const rules = baseRule.create(fakeContext);
 

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -99,7 +99,7 @@ function create(context) {
 		...context.options[0],
 	};
 	const nonZeroStyle = nonZeroStyles.get(options['non-zero']);
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	function getProblem({node, isZeroLengthCheck, lengthNode, autoFix}) {
 		const {code, test} = isZeroLengthCheck ? zeroStyle : nonZeroStyle;

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -99,7 +99,7 @@ function create(context) {
 		...context.options[0],
 	};
 	const nonZeroStyle = nonZeroStyles.get(options['non-zero']);
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	function getProblem({node, isZeroLengthCheck, lengthNode, autoFix}) {
 		const {code, test} = isZeroLengthCheck ? zeroStyle : nonZeroStyle;

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -167,7 +167,7 @@ const create = context => {
 		),
 	);
 
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	const report = (node, moduleName, actualImportStyles, allowedImportStyles, isRequire = false) => {
 		if (!allowedImportStyles || allowedImportStyles.size === 0) {

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -167,7 +167,7 @@ const create = context => {
 		),
 	);
 
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	const report = (node, moduleName, actualImportStyles, allowedImportStyles, isRequire = false) => {
 		if (!allowedImportStyles || allowedImportStyles.size === 0) {

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -49,7 +49,7 @@ function enforceCallExpression({node, path: [name]}, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const newExpressionTracker = new GlobalReferenceTracker({
 		objects: builtins.disallowNew,
 		type: GlobalReferenceTracker.CONSTRUCT,

--- a/rules/new-for-builtins.js
+++ b/rules/new-for-builtins.js
@@ -49,7 +49,7 @@ function enforceCallExpression({node, path: [name]}, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const newExpressionTracker = new GlobalReferenceTracker({
 		objects: builtins.disallowNew,
 		type: GlobalReferenceTracker.CONSTRUCT,

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -174,7 +174,7 @@ function getProblem(context, node, method, options) {
 				parameters: suggestionParameters,
 			},
 			fix(fixer) {
-				const sourceCode = context.getSourceCode();
+				const sourceCode = context.sourceCode;
 				let nodeText = sourceCode.getText(node);
 				if (isParenthesized(node, sourceCode) || type === 'ConditionalExpression') {
 					nodeText = `(${nodeText})`;

--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -174,7 +174,7 @@ function getProblem(context, node, method, options) {
 				parameters: suggestionParameters,
 			},
 			fix(fixer) {
-				const sourceCode = context.sourceCode;
+				const {sourceCode} = context;
 				let nodeText = sourceCode.getText(node);
 				if (isParenthesized(node, sourceCode) || type === 'ConditionalExpression') {
 					nodeText = `(${nodeText})`;

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -80,7 +80,7 @@ function shouldSwitchReturnStatementToBlockStatement(returnStatement) {
 }
 
 function getFixFunction(callExpression, functionInfo, context) {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const [callback] = callExpression.arguments;
 	const parameters = callback.params;
 	const iterableObject = callExpression.callee.object;
@@ -386,7 +386,7 @@ const create = context => {
 	const callExpressions = [];
 	const allIdentifiers = [];
 	const functionInfo = new Map();
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		':function'(node) {

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -80,7 +80,7 @@ function shouldSwitchReturnStatementToBlockStatement(returnStatement) {
 }
 
 function getFixFunction(callExpression, functionInfo, context) {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const [callback] = callExpression.arguments;
 	const parameters = callback.params;
 	const iterableObject = callExpression.callee.object;
@@ -386,7 +386,7 @@ const create = context => {
 	const callExpressions = [];
 	const allIdentifiers = [];
 	const functionInfo = new Map();
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		':function'(node) {

--- a/rules/no-array-method-this-argument.js
+++ b/rules/no-array-method-this-argument.js
@@ -119,7 +119,7 @@ function useBoundFunction(callExpression, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[selector](callExpression) {

--- a/rules/no-array-method-this-argument.js
+++ b/rules/no-array-method-this-argument.js
@@ -119,7 +119,7 @@ function useBoundFunction(callExpression, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[selector](callExpression) {

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -52,7 +52,7 @@ function create(context) {
 		'process.stderr',
 		...ignore,
 	];
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[selector](secondExpression) {

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -52,7 +52,7 @@ function create(context) {
 		'process.stderr',
 		...ignore,
 	];
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[selector](secondExpression) {

--- a/rules/no-await-expression-member.js
+++ b/rules/no-await-expression-member.js
@@ -12,7 +12,7 @@ const messages = {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		'MemberExpression[object.type="AwaitExpression"]'(memberExpression) {

--- a/rules/no-await-expression-member.js
+++ b/rules/no-await-expression-member.js
@@ -12,7 +12,7 @@ const messages = {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		'MemberExpression[object.type="AwaitExpression"]'(memberExpression) {

--- a/rules/no-console-spaces.js
+++ b/rules/no-console-spaces.js
@@ -30,7 +30,7 @@ const hasTrailingSpace = value => value.length > 1 && value.charAt(value.length 
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const getProblem = (node, method, position) => {
 		const index = position === 'leading'
 			? node.range[0] + 1

--- a/rules/no-console-spaces.js
+++ b/rules/no-console-spaces.js
@@ -30,7 +30,7 @@ const hasTrailingSpace = value => value.length > 1 && value.charAt(value.length 
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const getProblem = (node, method, position) => {
 		const index = position === 'leading'
 			? node.range[0] + 1

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -29,7 +29,7 @@ const create = context => {
 				return;
 			}
 
-			const sourceCode = context.getSourceCode();
+			const sourceCode = context.sourceCode;
 			const comments = sourceCode.getAllComments();
 
 			if (hasTripeSlashDirectives(comments)) {

--- a/rules/no-empty-file.js
+++ b/rules/no-empty-file.js
@@ -29,7 +29,7 @@ const create = context => {
 				return;
 			}
 
-			const sourceCode = context.sourceCode;
+			const {sourceCode} = context;
 			const comments = sourceCode.getAllComments();
 
 			if (hasTripeSlashDirectives(comments)) {

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -262,7 +262,7 @@ const getReferencesInChildScopes = (scope, name) =>
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const {scopeManager, text: sourceCodeText} = sourceCode;
 
 	return {

--- a/rules/no-for-loop.js
+++ b/rules/no-for-loop.js
@@ -262,7 +262,7 @@ const getReferencesInChildScopes = (scope, name) =>
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const {scopeManager, text: sourceCodeText} = sourceCode;
 
 	return {

--- a/rules/no-instanceof-array.js
+++ b/rules/no-instanceof-array.js
@@ -18,7 +18,7 @@ const selector = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[selector](node) {

--- a/rules/no-instanceof-array.js
+++ b/rules/no-instanceof-array.js
@@ -18,7 +18,7 @@ const selector = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[selector](node) {

--- a/rules/no-invalid-remove-event-listener.js
+++ b/rules/no-invalid-remove-event-listener.js
@@ -28,7 +28,7 @@ const create = context => ({
 		if (['ArrowFunctionExpression', 'FunctionExpression'].includes(listener.type)) {
 			return {
 				node: listener,
-				loc: getFunctionHeadLocation(listener, context.getSourceCode()),
+				loc: getFunctionHeadLocation(listener, context.sourceCode),
 				messageId: MESSAGE_ID,
 			};
 		}

--- a/rules/no-lonely-if.js
+++ b/rules/no-lonely-if.js
@@ -122,7 +122,7 @@ function fix(innerIfStatement, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[selector](node) {

--- a/rules/no-lonely-if.js
+++ b/rules/no-lonely-if.js
@@ -122,7 +122,7 @@ function fix(innerIfStatement, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[selector](node) {

--- a/rules/no-negated-condition.js
+++ b/rules/no-negated-condition.js
@@ -89,7 +89,7 @@ const create = context => ({
 			messageId: MESSAGE_ID,
 			/** @param {import('eslint').Rule.RuleFixer} fixer */
 			* fix(fixer) {
-				const sourceCode = context.sourceCode;
+				const {sourceCode} = context;
 				yield * convertNegatedCondition(fixer, node, sourceCode);
 				yield * swapConsequentAndAlternate(fixer, node, sourceCode);
 

--- a/rules/no-negated-condition.js
+++ b/rules/no-negated-condition.js
@@ -89,7 +89,7 @@ const create = context => ({
 			messageId: MESSAGE_ID,
 			/** @param {import('eslint').Rule.RuleFixer} fixer */
 			* fix(fixer) {
-				const sourceCode = context.getSourceCode();
+				const sourceCode = context.sourceCode;
 				yield * convertNegatedCondition(fixer, node, sourceCode);
 				yield * swapConsequentAndAlternate(fixer, node, sourceCode);
 

--- a/rules/no-nested-ternary.js
+++ b/rules/no-nested-ternary.js
@@ -12,7 +12,7 @@ const nestTernarySelector = level => `:not(ConditionalExpression)${' > Condition
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[nestTernarySelector(3)]: node =>

--- a/rules/no-nested-ternary.js
+++ b/rules/no-nested-ternary.js
@@ -12,7 +12,7 @@ const nestTernarySelector = level => `:not(ConditionalExpression)${' > Condition
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[nestTernarySelector(3)]: node =>

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -28,7 +28,7 @@ function getProblem(context, node) {
 
 	const [argumentNode] = node.arguments;
 
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	let text = sourceCode.getText(argumentNode);
 	if (isParenthesized(argumentNode, sourceCode)) {
 		text = `(${text})`;

--- a/rules/no-new-array.js
+++ b/rules/no-new-array.js
@@ -28,7 +28,7 @@ function getProblem(context, node) {
 
 	const [argumentNode] = node.arguments;
 
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	let text = sourceCode.getText(argumentNode);
 	if (isParenthesized(argumentNode, sourceCode)) {
 		text = `(${text})`;

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -52,7 +52,7 @@ function fix(node, sourceCode, method) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	return {
 		[newExpressionSelector('Buffer')](node) {
 			const method = inferMethod(node.arguments, sourceCode.getScope(node));

--- a/rules/no-new-buffer.js
+++ b/rules/no-new-buffer.js
@@ -52,7 +52,7 @@ function fix(node, sourceCode, method) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	return {
 		[newExpressionSelector('Buffer')](node) {
 			const method = inferMethod(node.arguments, sourceCode.getScope(node));

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -31,7 +31,7 @@ const processExitCallSelector = methodCallSelector({
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const startsWithHashBang = context.getSourceCode().lines[0].indexOf('#!') === 0;
+	const startsWithHashBang = context.sourceCode.lines[0].indexOf('#!') === 0;
 
 	if (startsWithHashBang) {
 		return {};

--- a/rules/no-static-only-class.js
+++ b/rules/no-static-only-class.js
@@ -197,7 +197,7 @@ function switchClassToObject(node, sourceCode) {
 }
 
 function create(context) {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[selector](node) {

--- a/rules/no-static-only-class.js
+++ b/rules/no-static-only-class.js
@@ -197,7 +197,7 @@ function switchClassToObject(node, sourceCode) {
 }
 
 function create(context) {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[selector](node) {

--- a/rules/no-thenable.js
+++ b/rules/no-thenable.js
@@ -90,7 +90,7 @@ const cases = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return Object.fromEntries(
 		cases.map(({selector, test, messageId, getNodes}) => [

--- a/rules/no-thenable.js
+++ b/rules/no-thenable.js
@@ -90,7 +90,7 @@ const cases = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return Object.fromEntries(
 		cases.map(({selector, test, messageId, getNodes}) => [

--- a/rules/no-typeof-undefined.js
+++ b/rules/no-typeof-undefined.js
@@ -35,7 +35,7 @@ const create = context => {
 		checkGlobalVariables: false,
 		...context.options[0],
 	};
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[selector](binaryExpression) {

--- a/rules/no-typeof-undefined.js
+++ b/rules/no-typeof-undefined.js
@@ -35,7 +35,7 @@ const create = context => {
 		checkGlobalVariables: false,
 		...context.options[0],
 	};
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[selector](binaryExpression) {

--- a/rules/no-unnecessary-await.js
+++ b/rules/no-unnecessary-await.js
@@ -46,7 +46,7 @@ const create = context => ({
 			return;
 		}
 
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const awaitToken = sourceCode.getFirstToken(node);
 		const problem = {
 			node,

--- a/rules/no-unnecessary-await.js
+++ b/rules/no-unnecessary-await.js
@@ -46,7 +46,7 @@ const create = context => ({
 			return;
 		}
 
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const awaitToken = sourceCode.getFirstToken(node);
 		const problem = {
 			node,

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -13,7 +13,7 @@ const isCommaFollowedWithComma = (element, index, array) =>
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		'ArrayPattern[elements.length>=3]'(node) {

--- a/rules/no-unreadable-array-destructuring.js
+++ b/rules/no-unreadable-array-destructuring.js
@@ -13,7 +13,7 @@ const isCommaFollowedWithComma = (element, index, array) =>
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		'ArrayPattern[elements.length>=3]'(node) {

--- a/rules/no-unreadable-iife.js
+++ b/rules/no-unreadable-iife.js
@@ -21,7 +21,7 @@ const selector = [
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		if (!isParenthesized(node, sourceCode)) {
 			return;
 		}

--- a/rules/no-unreadable-iife.js
+++ b/rules/no-unreadable-iife.js
@@ -21,7 +21,7 @@ const selector = [
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		if (!isParenthesized(node, sourceCode)) {
 			return;
 		}

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -80,7 +80,7 @@ const isUnusedVariable = variable => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const getPropertyDisplayName = property => {
 		if (property.key.type === 'Identifier') {
 			return property.key.name;

--- a/rules/no-unused-properties.js
+++ b/rules/no-unused-properties.js
@@ -80,7 +80,7 @@ const isUnusedVariable = variable => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const getPropertyDisplayName = property => {
 		if (property.key.type === 'Identifier') {
 			return property.key.name;

--- a/rules/no-useless-fallback-in-spread.js
+++ b/rules/no-useless-fallback-in-spread.js
@@ -34,7 +34,7 @@ const create = context => ({
 			messageId: MESSAGE_ID,
 			/** @param {import('eslint').Rule.RuleFixer} fixer */
 			* fix(fixer) {
-				const sourceCode = context.sourceCode;
+				const {sourceCode} = context;
 				const logicalExpression = emptyObject.parent;
 				const {left} = logicalExpression;
 				const isLeftObjectParenthesized = isParenthesized(left, sourceCode);

--- a/rules/no-useless-fallback-in-spread.js
+++ b/rules/no-useless-fallback-in-spread.js
@@ -34,7 +34,7 @@ const create = context => ({
 			messageId: MESSAGE_ID,
 			/** @param {import('eslint').Rule.RuleFixer} fixer */
 			* fix(fixer) {
-				const sourceCode = context.getSourceCode();
+				const sourceCode = context.sourceCode;
 				const logicalExpression = emptyObject.parent;
 				const {left} = logicalExpression;
 				const isLeftObjectParenthesized = isParenthesized(left, sourceCode);

--- a/rules/no-useless-length-check.js
+++ b/rules/no-useless-length-check.js
@@ -114,7 +114,7 @@ const create = context => {
 					messageId: zeroLengthChecks.has(node) ? 'zero' : 'non-zero',
 					/** @param {import('eslint').Rule.RuleFixer} fixer */
 					fix(fixer) {
-						const sourceCode = context.sourceCode;
+						const {sourceCode} = context;
 						const {left, right} = node.parent;
 						const leftRange = getParenthesizedRange(left, sourceCode);
 						const rightRange = getParenthesizedRange(right, sourceCode);

--- a/rules/no-useless-length-check.js
+++ b/rules/no-useless-length-check.js
@@ -114,7 +114,7 @@ const create = context => {
 					messageId: zeroLengthChecks.has(node) ? 'zero' : 'non-zero',
 					/** @param {import('eslint').Rule.RuleFixer} fixer */
 					fix(fixer) {
-						const sourceCode = context.getSourceCode();
+						const sourceCode = context.sourceCode;
 						const {left, right} = node.parent;
 						const leftRange = getParenthesizedRange(left, sourceCode);
 						const rightRange = getParenthesizedRange(right, sourceCode);

--- a/rules/no-useless-promise-resolve-reject.js
+++ b/rules/no-useless-promise-resolve-reject.js
@@ -173,7 +173,7 @@ function fix(callExpression, isInTryStatement, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[selector](callExpression) {

--- a/rules/no-useless-promise-resolve-reject.js
+++ b/rules/no-useless-promise-resolve-reject.js
@@ -173,7 +173,7 @@ function fix(callExpression, isInTryStatement, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[selector](callExpression) {

--- a/rules/no-useless-spread.js
+++ b/rules/no-useless-spread.js
@@ -186,7 +186,7 @@ function * unwrapSingleArraySpread(fixer, arrayExpression, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[uselessSpreadInListSelector](spreadObject) {

--- a/rules/no-useless-spread.js
+++ b/rules/no-useless-spread.js
@@ -186,7 +186,7 @@ function * unwrapSingleArraySpread(fixer, arrayExpression, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[uselessSpreadInListSelector](spreadObject) {

--- a/rules/no-useless-switch-case.js
+++ b/rules/no-useless-switch-case.js
@@ -43,7 +43,7 @@ const create = context => ({
 		for (const node of uselessCases) {
 			yield {
 				node,
-				loc: getSwitchCaseHeadLocation(node, context.getSourceCode()),
+				loc: getSwitchCaseHeadLocation(node, context.sourceCode),
 				messageId: MESSAGE_ID_ERROR,
 				suggest: [
 					{

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -108,7 +108,7 @@ const isFunctionBindCall = node =>
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	const listener = (fix, checkFunctionReturnType) => node => {
 		if (checkFunctionReturnType) {

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -108,7 +108,7 @@ const isFunctionBindCall = node =>
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	const listener = (fix, checkFunctionReturnType) => node => {
 		if (checkFunctionReturnType) {

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -39,7 +39,7 @@ const create = context => ({
 		// End of fractions
 		const end = node.range[0] + before.length + dotAndFractions.length;
 		const start = end - (raw.length - formatted.length);
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		return {
 			loc: toLocation([start, end], sourceCode),
 			messageId: isDanglingDot ? MESSAGE_DANGLING_DOT : MESSAGE_ZERO_FRACTION,

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -39,7 +39,7 @@ const create = context => ({
 		// End of fractions
 		const end = node.range[0] + before.length + dotAndFractions.length;
 		const start = end - (raw.length - formatted.length);
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		return {
 			loc: toLocation([start, end], sourceCode),
 			messageId: isDanglingDot ? MESSAGE_DANGLING_DOT : MESSAGE_ZERO_FRACTION,

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -137,7 +137,7 @@ const create = context => {
 				&& node.parent.type === 'ExpressionStatement'
 				&& node.parent.expression === node
 			) {
-				fix = fixer => fixCode(fixer, context.getSourceCode(), node, memberExpression);
+				fix = fixer => fixCode(fixer, context.sourceCode, node, memberExpression);
 			}
 
 			return {

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -256,7 +256,7 @@ const isDestructuringFirstElement = node => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const {
 		checkFromLast,
 	} = {

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -256,7 +256,7 @@ const isDestructuringFirstElement = node => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const {
 		checkFromLast,
 	} = {

--- a/rules/prefer-array-flat-map.js
+++ b/rules/prefer-array-flat-map.js
@@ -27,7 +27,7 @@ const create = context => ({
 			return;
 		}
 
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const mapProperty = mapCallExpression.callee.property;
 
 		return {

--- a/rules/prefer-array-flat-map.js
+++ b/rules/prefer-array-flat-map.js
@@ -27,7 +27,7 @@ const create = context => ({
 			return;
 		}
 
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const mapProperty = mapCallExpression.callee.property;
 
 		return {

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -182,7 +182,7 @@ function create(context) {
 		...context.options[0],
 	};
 	const functions = [...configFunctions, ...lodashFlattenFunctions];
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const listeners = {};
 
 	const cases = [

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -182,7 +182,7 @@ function create(context) {
 		...context.options[0],
 	};
 	const functions = [...configFunctions, ...lodashFlattenFunctions];
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const listeners = {};
 
 	const cases = [

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -80,7 +80,7 @@ const create = context => ({
 							return;
 						}
 
-						const parenthesizedRange = getParenthesizedRange(callExpression, context.getSourceCode());
+						const parenthesizedRange = getParenthesizedRange(callExpression, context.sourceCode);
 						yield fixer.replaceTextRange([parenthesizedRange[1], callExpression.parent.range[1]], '');
 
 						if (callExpression.parent.operator === '!=' || callExpression.parent.operator === '!==') {
@@ -102,7 +102,7 @@ const create = context => ({
 				// `.filter` to `.some`
 				yield fixer.replaceText(filterProperty, 'some');
 
-				const sourceCode = context.getSourceCode();
+				const sourceCode = context.sourceCode;
 				const lengthNode = filterCall.parent;
 				/*
 					Remove `.length`

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -102,7 +102,7 @@ const create = context => ({
 				// `.filter` to `.some`
 				yield fixer.replaceText(filterProperty, 'some');
 
-				const sourceCode = context.sourceCode;
+				const {sourceCode} = context;
 				const lengthNode = filterCall.parent;
 				/*
 					Remove `.length`

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -145,7 +145,7 @@ function create(context) {
 		...context.options[0],
 	};
 	const getLastFunctions = [...getLastElementFunctions, ...lodashLastFunctions];
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[indexAccess](node) {

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -145,7 +145,7 @@ function create(context) {
 		...context.options[0],
 	};
 	const getLastFunctions = [...getLastElementFunctions, ...lodashLastFunctions];
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[indexAccess](node) {

--- a/rules/prefer-date-now.js
+++ b/rules/prefer-date-now.js
@@ -90,7 +90,7 @@ const create = context => ({
 		return getProblem(
 			node.operator === '-' ? node.argument : node,
 			{},
-			context.getSourceCode(),
+			context.sourceCode,
 		);
 	},
 	[assignmentExpressionSelector](node) {

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -127,7 +127,7 @@ const fixDefaultExpression = (fixer, sourceCode, node) => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const functionStack = [];
 
 	const checkExpression = (node, left, right, assignment) => {

--- a/rules/prefer-default-parameters.js
+++ b/rules/prefer-default-parameters.js
@@ -127,7 +127,7 @@ const fixDefaultExpression = (fixer, sourceCode, node) => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const functionStack = [];
 
 	const checkExpression = (node, left, right, assignment) => {

--- a/rules/prefer-dom-node-dataset.js
+++ b/rules/prefer-dom-node-dataset.js
@@ -37,7 +37,7 @@ const create = context => ({
 		const method = node.callee.property.name;
 		const name = dashToCamelCase(attributeName.slice(5));
 
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		let text = '';
 		const datasetText = `${sourceCode.getText(node.callee.object)}.dataset`;
 		switch (method) {

--- a/rules/prefer-dom-node-dataset.js
+++ b/rules/prefer-dom-node-dataset.js
@@ -37,7 +37,7 @@ const create = context => ({
 		const method = node.callee.property.name;
 		const name = dashToCamelCase(attributeName.slice(5));
 
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		let text = '';
 		const datasetText = `${sourceCode.getText(node.callee.object)}.dataset`;
 		switch (method) {

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -25,7 +25,7 @@ const selector = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[selector](node) {

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -25,7 +25,7 @@ const selector = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[selector](node) {

--- a/rules/prefer-export-from.js
+++ b/rules/prefer-export-from.js
@@ -312,7 +312,7 @@ const schema = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 function create(context) {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const {ignoreUsedVariables} = {ignoreUsedVariables: false, ...context.options[0]};
 	const importDeclarations = new Set();
 	const exportDeclarations = [];

--- a/rules/prefer-export-from.js
+++ b/rules/prefer-export-from.js
@@ -312,7 +312,7 @@ const schema = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 function create(context) {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const {ignoreUsedVariables} = {ignoreUsedVariables: false, ...context.options[0]};
 	const importDeclarations = new Set();
 	const exportDeclarations = [];

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -15,7 +15,7 @@ const isLiteralZero = node => isLiteral(node, 0);
 const isNegativeResult = node => ['===', '==', '<'].includes(node.operator);
 
 const getProblem = (context, node, target, argumentsNodes) => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const memberExpressionNode = target.parent;
 	const dotToken = sourceCode.getTokenBefore(memberExpressionNode.property);
 	const targetSource = sourceCode.getText().slice(memberExpressionNode.range[0], dotToken.range[0]);

--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -15,7 +15,7 @@ const isLiteralZero = node => isLiteral(node, 0);
 const isNegativeResult = node => ['===', '==', '<'].includes(node.operator);
 
 const getProblem = (context, node, target, argumentsNodes) => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const memberExpressionNode = target.parent;
 	const dotToken = sourceCode.getTokenBefore(memberExpressionNode.property);
 	const targetSource = sourceCode.getText().slice(memberExpressionNode.range[0], dotToken.range[0]);

--- a/rules/prefer-json-parse-buffer.js
+++ b/rules/prefer-json-parse-buffer.js
@@ -108,7 +108,7 @@ function isUtf8Encoding(node, scope) {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[jsonParseArgumentSelector](node) {
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const scope = sourceCode.getScope(node);
 		node = getIdentifierDeclaration(node, scope);
 		if (

--- a/rules/prefer-json-parse-buffer.js
+++ b/rules/prefer-json-parse-buffer.js
@@ -108,7 +108,7 @@ function isUtf8Encoding(node, scope) {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[jsonParseArgumentSelector](node) {
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const scope = sourceCode.getScope(node);
 		node = getIdentifierDeclaration(node, scope);
 		if (

--- a/rules/prefer-keyboard-event-key.js
+++ b/rules/prefer-keyboard-event-key.js
@@ -25,7 +25,7 @@ const getEventNodeAndReferences = (context, node) => {
 	switch (callback?.type) {
 		case 'ArrowFunctionExpression':
 		case 'FunctionExpression': {
-			const eventVariable = context.getSourceCode().getDeclaredVariables(callback)[0];
+			const eventVariable = context.sourceCode.getDeclaredVariables(callback)[0];
 			const references = eventVariable?.references;
 			return {
 				event: callback.params[0],

--- a/rules/prefer-logical-operator-over-ternary.js
+++ b/rules/prefer-logical-operator-over-ternary.js
@@ -110,7 +110,7 @@ function getProblem({
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		ConditionalExpression(conditionalExpression) {

--- a/rules/prefer-logical-operator-over-ternary.js
+++ b/rules/prefer-logical-operator-over-ternary.js
@@ -110,7 +110,7 @@ function getProblem({
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		ConditionalExpression(conditionalExpression) {

--- a/rules/prefer-math-trunc.js
+++ b/rules/prefer-math-trunc.js
@@ -31,7 +31,7 @@ const bitwiseNotUnaryExpressionSelector = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	const mathTruncFunctionCall = node => {
 		const text = sourceCode.getText(node);

--- a/rules/prefer-math-trunc.js
+++ b/rules/prefer-math-trunc.js
@@ -31,7 +31,7 @@ const bitwiseNotUnaryExpressionSelector = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	const mathTruncFunctionCall = node => {
 		const text = sourceCode.getText(node);

--- a/rules/prefer-modern-math-apis.js
+++ b/rules/prefer-modern-math-apis.js
@@ -57,7 +57,7 @@ function createLogCallTimesConstantCheck({constantName, replacementMethod}) {
 				replacement,
 				description,
 			},
-			fix: fixer => fixer.replaceText(node, `Math.${replacementMethod}(${getParenthesizedText(valueNode, context.getSourceCode())})`),
+			fix: fixer => fixer.replaceText(node, `Math.${replacementMethod}(${getParenthesizedText(valueNode, context.sourceCode)})`),
 		};
 	};
 }
@@ -90,7 +90,7 @@ function createLogCallDivideConstantCheck({constantName, replacementMethod}) {
 		return {
 			...message,
 			node,
-			fix: fixer => fixer.replaceText(node, `Math.${replacementMethod}(${getParenthesizedText(valueNode, context.getSourceCode())})`),
+			fix: fixer => fixer.replaceText(node, `Math.${replacementMethod}(${getParenthesizedText(valueNode, context.sourceCode)})`),
 		};
 	};
 }

--- a/rules/prefer-module.js
+++ b/rules/prefer-module.js
@@ -221,7 +221,7 @@ function create(context) {
 		return;
 	}
 
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		'ExpressionStatement[directive="use strict"]'(node) {

--- a/rules/prefer-module.js
+++ b/rules/prefer-module.js
@@ -221,7 +221,7 @@ function create(context) {
 		return;
 	}
 
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		'ExpressionStatement[directive="use strict"]'(node) {

--- a/rules/prefer-native-coercion-functions.js
+++ b/rules/prefer-native-coercion-functions.js
@@ -137,7 +137,7 @@ const create = context => ({
 			return;
 		}
 
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const {replacementFunction, fix} = problem;
 
 		problem = {

--- a/rules/prefer-native-coercion-functions.js
+++ b/rules/prefer-native-coercion-functions.js
@@ -137,7 +137,7 @@ const create = context => ({
 			return;
 		}
 
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const {replacementFunction, fix} = problem;
 
 		problem = {

--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -179,7 +179,7 @@ const create = context => ({
 			messageId: MESSAGE_ID,
 			data: {method},
 			* fix(fixer) {
-				const sourceCode = context.getSourceCode();
+				const sourceCode = context.sourceCode;
 				for (const node of removableNodes) {
 					yield removeLengthNode(node, fixer, sourceCode);
 				}

--- a/rules/prefer-negative-index.js
+++ b/rules/prefer-negative-index.js
@@ -179,7 +179,7 @@ const create = context => ({
 			messageId: MESSAGE_ID,
 			data: {method},
 			* fix(fixer) {
-				const sourceCode = context.sourceCode;
+				const {sourceCode} = context;
 				for (const node of removableNodes) {
 					yield removeLengthNode(node, fixer, sourceCode);
 				}

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -81,7 +81,7 @@ const create = context => {
 		checkInfinity: true,
 		...context.options[0],
 	};
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	let objects = Object.keys(globalObjects);
 	if (!checkInfinity) {

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -81,7 +81,7 @@ const create = context => {
 		checkInfinity: true,
 		...context.options[0],
 	};
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	let objects = Object.keys(globalObjects);
 	if (!checkInfinity) {

--- a/rules/prefer-object-from-entries.js
+++ b/rules/prefer-object-from-entries.js
@@ -177,7 +177,7 @@ function create(context) {
 		...context.options[0],
 	};
 	const functions = [...configFunctions, ...lodashFromPairsFunctions];
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const listeners = {};
 	const arrayReduce = new Map();
 

--- a/rules/prefer-object-from-entries.js
+++ b/rules/prefer-object-from-entries.js
@@ -177,7 +177,7 @@ function create(context) {
 		...context.options[0],
 	};
 	const functions = [...configFunctions, ...lodashFromPairsFunctions];
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const listeners = {};
 	const arrayReduce = new Map();
 

--- a/rules/prefer-optional-catch-binding.js
+++ b/rules/prefer-optional-catch-binding.js
@@ -18,7 +18,7 @@ const selector = [
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const variables = sourceCode.getDeclaredVariables(node.parent);
 
 		if (variables.some(variable => variable.references.length > 0)) {

--- a/rules/prefer-optional-catch-binding.js
+++ b/rules/prefer-optional-catch-binding.js
@@ -18,7 +18,7 @@ const selector = [
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const variables = sourceCode.getDeclaredVariables(node.parent);
 
 		if (variables.some(variable => variable.references.length > 0)) {

--- a/rules/prefer-prototype-methods.js
+++ b/rules/prefer-prototype-methods.js
@@ -41,7 +41,7 @@ function create(context) {
 	return {
 		[selector](node) {
 			const constructorName = node.object.type === 'ArrayExpression' ? 'Array' : 'Object';
-			const sourceCode = context.getSourceCode();
+			const sourceCode = context.sourceCode;
 			const methodName = getPropertyName(node, sourceCode.getScope(node));
 
 			return {

--- a/rules/prefer-prototype-methods.js
+++ b/rules/prefer-prototype-methods.js
@@ -41,7 +41,7 @@ function create(context) {
 	return {
 		[selector](node) {
 			const constructorName = node.object.type === 'ArrayExpression' ? 'Array' : 'Object';
-			const sourceCode = context.sourceCode;
+			const {sourceCode} = context;
 			const methodName = getPropertyName(node, sourceCode.getScope(node));
 
 			return {

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -65,7 +65,7 @@ const fixFunctionPrototypeCall = (node, sourceCode) => {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const fix = fixDirectApplyCall(node, sourceCode) || fixFunctionPrototypeCall(node, sourceCode);
 		if (fix) {
 			return {

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -65,7 +65,7 @@ const fixFunctionPrototypeCall = (node, sourceCode) => {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const fix = fixDirectApplyCall(node, sourceCode) || fixFunctionPrototypeCall(node, sourceCode);
 		if (fix) {
 			return {

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -108,7 +108,7 @@ const create = context => Object.fromEntries(
 				messageId: type,
 			};
 
-			const sourceCode = context.sourceCode;
+			const {sourceCode} = context;
 			const fixFunction = fixer => fix(fixer, nodes, sourceCode);
 
 			if (

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -108,7 +108,7 @@ const create = context => Object.fromEntries(
 				messageId: type,
 			};
 
-			const sourceCode = context.getSourceCode();
+			const sourceCode = context.sourceCode;
 			const fixFunction = fixer => fix(fixer, nodes, sourceCode);
 
 			if (

--- a/rules/prefer-set-has.js
+++ b/rules/prefer-set-has.js
@@ -115,7 +115,7 @@ const isMultipleCall = (identifier, node) => {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	[selector](node) {
-		const variable = findVariable(context.getSourceCode().getScope(node), node);
+		const variable = findVariable(context.sourceCode.getScope(node), node);
 
 		// This was reported https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1075#issuecomment-768073342
 		// But can't reproduce, just ignore this case

--- a/rules/prefer-set-size.js
+++ b/rules/prefer-set-size.js
@@ -67,7 +67,7 @@ function fix(sourceCode, lengthAccessNodes) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[lengthAccessSelector](node) {

--- a/rules/prefer-set-size.js
+++ b/rules/prefer-set-size.js
@@ -67,7 +67,7 @@ function fix(sourceCode, lengthAccessNodes) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[lengthAccessSelector](node) {

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -325,7 +325,7 @@ function isNotArray(node, scope) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[arrayFromCallSelector](node) {

--- a/rules/prefer-spread.js
+++ b/rules/prefer-spread.js
@@ -325,7 +325,7 @@ function isNotArray(node, scope) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[arrayFromCallSelector](node) {

--- a/rules/prefer-string-replace-all.js
+++ b/rules/prefer-string-replace-all.js
@@ -86,7 +86,7 @@ const create = context => ({
 			callee: {property},
 		} = node;
 
-		if (!isRegExpWithGlobalFlag(pattern, context.getSourceCode().getScope(pattern))) {
+		if (!isRegExpWithGlobalFlag(pattern, context.sourceCode.getScope(pattern))) {
 			return;
 		}
 

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -45,7 +45,7 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 		return;
 	}
 
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const scope = sourceCode.getScope(node);
 	const firstArgumentStaticResult = getStaticValue(firstArgument, scope);
 	const secondArgumentRange = getParenthesizedRange(secondArgument, sourceCode);
@@ -82,7 +82,7 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 }
 
 function * fixSubstringArguments({node, fixer, context, abort}) {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const [firstArgument, secondArgument] = node.arguments;
 
 	const firstNumber = firstArgument ? getNumericValue(firstArgument) : undefined;

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -45,7 +45,7 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 		return;
 	}
 
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const scope = sourceCode.getScope(node);
 	const firstArgumentStaticResult = getStaticValue(firstArgument, scope);
 	const secondArgumentRange = getParenthesizedRange(secondArgument, sourceCode);
@@ -82,7 +82,7 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 }
 
 function * fixSubstringArguments({node, fixer, context, abort}) {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const [firstArgument, secondArgument] = node.arguments;
 
 	const firstNumber = firstArgument ? getNumericValue(firstArgument) : undefined;

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -61,7 +61,7 @@ const checkRegex = ({pattern, flags}) => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[regexTestSelector](node) {

--- a/rules/prefer-string-starts-ends-with.js
+++ b/rules/prefer-string-starts-ends-with.js
@@ -61,7 +61,7 @@ const checkRegex = ({pattern, flags}) => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[regexTestSelector](node) {

--- a/rules/prefer-switch.js
+++ b/rules/prefer-switch.js
@@ -256,7 +256,7 @@ const create = context => {
 		insertBreakInDefaultCase: false,
 		...context.options[0],
 	};
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const ifStatements = new Set();
 	const breakStatements = [];
 	const checked = new Set();

--- a/rules/prefer-switch.js
+++ b/rules/prefer-switch.js
@@ -256,7 +256,7 @@ const create = context => {
 		insertBreakInDefaultCase: false,
 		...context.options[0],
 	};
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const ifStatements = new Set();
 	const breakStatements = [];
 	const checked = new Set();

--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -46,7 +46,7 @@ const isSingleLineNode = node => node.loc.start.line === node.loc.end.line;
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const onlySingleLine = context.options[0] === 'only-single-line';
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const scopeToNamesGeneratedByFixer = new WeakMap();
 	const isSafeName = (name, scopes) => scopes.every(scope => {
 		const generatedNames = scopeToNamesGeneratedByFixer.get(scope);

--- a/rules/prefer-ternary.js
+++ b/rules/prefer-ternary.js
@@ -46,7 +46,7 @@ const isSingleLineNode = node => node.loc.start.line === node.loc.end.line;
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const onlySingleLine = context.options[0] === 'only-single-line';
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const scopeToNamesGeneratedByFixer = new WeakMap();
 	const isSafeName = (name, scopes) => scopes.every(scope => {
 		const generatedNames = scopeToNamesGeneratedByFixer.get(scope);

--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -63,7 +63,7 @@ function create(context) {
 		return;
 	}
 
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		[promise](node) {

--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -63,7 +63,7 @@ function create(context) {
 		return;
 	}
 
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		[promise](node) {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -544,7 +544,7 @@ const create = context => {
 				return;
 			}
 
-			checkScope(context.getSourceCode().getScope(program));
+			checkScope(context.sourceCode.getScope(program));
 		},
 	};
 };

--- a/rules/relative-url-style.js
+++ b/rules/relative-url-style.js
@@ -126,7 +126,7 @@ const create = context => {
 			return;
 		}
 
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const fix = (style === 'never' ? removeDotSlash : addDotSlash)(node, sourceCode);
 
 		if (!fix) {

--- a/rules/relative-url-style.js
+++ b/rules/relative-url-style.js
@@ -126,7 +126,7 @@ const create = context => {
 			return;
 		}
 
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const fix = (style === 'never' ? removeDotSlash : addDotSlash)(node, sourceCode);
 
 		if (!fix) {

--- a/rules/require-array-join-separator.js
+++ b/rules/require-array-join-separator.js
@@ -23,7 +23,7 @@ const selector = matches([
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	return {
 		[selector](node) {
 			const [penultimateToken, lastToken] = sourceCode.getLastTokens(node, 2);

--- a/rules/require-array-join-separator.js
+++ b/rules/require-array-join-separator.js
@@ -23,7 +23,7 @@ const selector = matches([
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	return {
 		[selector](node) {
 			const [penultimateToken, lastToken] = sourceCode.getLastTokens(node, 2);

--- a/rules/require-number-to-fixed-digits-argument.js
+++ b/rules/require-number-to-fixed-digits-argument.js
@@ -17,7 +17,7 @@ const mathToFixed = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	return {
 		[mathToFixed](node) {
 			const [

--- a/rules/require-number-to-fixed-digits-argument.js
+++ b/rules/require-number-to-fixed-digits-argument.js
@@ -17,7 +17,7 @@ const mathToFixed = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	return {
 		[mathToFixed](node) {
 			const [

--- a/rules/require-post-message-target-origin.js
+++ b/rules/require-post-message-target-origin.js
@@ -11,7 +11,7 @@ const messages = {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 function create(context) {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	return {
 		[methodCallSelector({method: 'postMessage', argumentsLength: 1})](node) {
 			const [penultimateToken, lastToken] = sourceCode.getLastTokens(node, 2);

--- a/rules/require-post-message-target-origin.js
+++ b/rules/require-post-message-target-origin.js
@@ -11,7 +11,7 @@ const messages = {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 function create(context) {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	return {
 		[methodCallSelector({method: 'postMessage', argumentsLength: 1})](node) {
 			const [penultimateToken, lastToken] = sourceCode.getLastTokens(node, 2);

--- a/rules/shared/simple-array-search-rule.js
+++ b/rules/shared/simple-array-search-rule.js
@@ -60,7 +60,7 @@ function simpleArraySearchRule({method, replacement}) {
 	].join('');
 
 	function createListeners(context) {
-		const sourceCode = context.getSourceCode();
+		const sourceCode = context.sourceCode;
 		const {scopeManager} = sourceCode;
 
 		return {

--- a/rules/shared/simple-array-search-rule.js
+++ b/rules/shared/simple-array-search-rule.js
@@ -60,7 +60,7 @@ function simpleArraySearchRule({method, replacement}) {
 	].join('');
 
 	function createListeners(context) {
-		const sourceCode = context.sourceCode;
+		const {sourceCode} = context;
 		const {scopeManager} = sourceCode;
 
 		return {

--- a/rules/switch-case-braces.js
+++ b/rules/switch-case-braces.js
@@ -37,7 +37,7 @@ function * addBraces(fixer, node, sourceCode) {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const isBracesRequired = context.options[0] !== 'avoid';
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 
 	return {
 		SwitchCase(node) {

--- a/rules/switch-case-braces.js
+++ b/rules/switch-case-braces.js
@@ -37,7 +37,7 @@ function * addBraces(fixer, node, sourceCode) {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const isBracesRequired = context.options[0] !== 'avoid';
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 
 	return {
 		SwitchCase(node) {

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -18,7 +18,7 @@ const jestInlineSnapshotSelector = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.sourceCode;
+	const {sourceCode} = context;
 	const options = {
 		tags: ['outdent', 'dedent', 'gql', 'sql', 'html', 'styled'],
 		functions: ['dedent', 'stripIndent'],

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -18,7 +18,7 @@ const jestInlineSnapshotSelector = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const sourceCode = context.getSourceCode();
+	const sourceCode = context.sourceCode;
 	const options = {
 		tags: ['outdent', 'dedent', 'gql', 'sql', 'html', 'styled'],
 		functions: ['dedent', 'stripIndent'],

--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -34,7 +34,7 @@ const create = context => ({
 	[selector]: node => ({
 		node,
 		messageId,
-		fix: fixer => switchCallExpressionToNewExpression(node, context.getSourceCode(), fixer),
+		fix: fixer => switchCallExpressionToNewExpression(node, context.sourceCode, fixer),
 	}),
 });
 

--- a/rules/utils/global-reference-tracker.js
+++ b/rules/utils/global-reference-tracker.js
@@ -56,7 +56,7 @@ class GlobalReferenceTracker {
 
 	createListeners(context) {
 		return {
-			'Program:exit': program => this.track(context.getSourceCode().getScope(program)),
+			'Program:exit': program => this.track(context.sourceCode.getScope(program)),
 		};
 	}
 }

--- a/scripts/internal-rules/fix-snapshot-test.js
+++ b/scripts/internal-rules/fix-snapshot-test.js
@@ -75,7 +75,7 @@ function getFixMarkComment(snapshotTestCall, sourceCode) {
 
 module.exports = {
 	create(context) {
-		const sourceCode = context.getSourceCode();
+		const {sourceCode} = context;
 
 		return {
 			[snapshotTestCallSelector](snapshotTestCall) {

--- a/scripts/internal-rules/prefer-disallow-over-forbid.js
+++ b/scripts/internal-rules/prefer-disallow-over-forbid.js
@@ -71,7 +71,7 @@ module.exports = {
 					const range = [start, start + word.length];
 					context.report({
 						node,
-						loc: toLocation(range, context.getSourceCode()),
+						loc: toLocation(range, context.sourceCode),
 						messageId,
 						data: {original, replacement},
 						fix: fixer => fixer.replaceTextRange(range, replacement),


### PR DESCRIPTION
`context.{getSourceCode,getFilename,getPhysicalFilename}()` has been deprecated. https://github.com/eslint/eslint/releases/tag/v8.40.0
