### PR TITLE
Simplify `isMemberExpression` and `isMethodCall`

### DIFF
--- a/rules/ast/is-member-expression.js
+++ b/rules/ast/is-member-expression.js
@@ -49,13 +49,7 @@ function isMemberExpression(node, options) {
 	}
 
 	if (
-		(computed === true && (node.computed !== computed))
-		|| (
-			computed === false
-			// `node.computed` can be `undefined` in some parsers
-			&& node.computed
-		)
-		|| (optional === true && (node.optional !== optional))
+		(optional === true && (node.optional !== optional))
 		|| (
 			optional === false
 			// `node.optional` can be `undefined` in some parsers
@@ -68,9 +62,23 @@ function isMemberExpression(node, options) {
 	if (
 		Array.isArray(properties)
 		&& properties.length > 0
-		&& (
+	) {
+		if (
 			node.property.type !== 'Identifier'
 			|| !properties.includes(node.property.name)
+		) {
+			return false;
+		}
+
+		computed ??= false;
+	}
+
+	if (
+		(computed === true && (node.computed !== computed))
+		|| (
+			computed === false
+			// `node.computed` can be `undefined` in some parsers
+			&& node.computed
 		)
 	) {
 		return false;

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -144,7 +144,6 @@ function create(context) {
 				!isMemberExpression(memberExpression, {
 					properties: ['length', 'size'],
 					optional: false,
-					computed: false,
 				})
 				|| memberExpression.object.type === 'ThisExpression'
 			) {

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -405,7 +405,6 @@ const create = context => {
 			if (
 				!isMethodCall(node, {
 					method: 'forEach',
-					computed: false,
 				})
 				|| isNodeMatches(node.callee.object, ignoredObjects)
 			) {

--- a/rules/no-array-method-this-argument.js
+++ b/rules/no-array-method-this-argument.js
@@ -122,7 +122,6 @@ const create = context => {
 					argumentsLength: 2,
 					optionalCall: false,
 					optionalMember: false,
-					computed: false,
 				})
 				|| isNodeMatches(callExpression.callee, ignored)
 				|| isNodeValueNotFunction(callExpression.arguments[0])

--- a/rules/no-array-push-push.js
+++ b/rules/no-array-push-push.js
@@ -21,7 +21,6 @@ const isArrayPushCall = node =>
 		method: 'push',
 		optionalCall: false,
 		optionalMember: false,
-		computed: false,
 	});
 
 function getFirstArrayPushCall(secondCall, sourceCode) {

--- a/rules/no-console-spaces.js
+++ b/rules/no-console-spaces.js
@@ -45,7 +45,6 @@ const create = context => {
 					minimumArguments: 1,
 					optionalCall: false,
 					optionalMember: false,
-					computed: false,
 				})
 			) {
 				return;

--- a/rules/prefer-dom-node-append.js
+++ b/rules/prefer-dom-node-append.js
@@ -15,7 +15,6 @@ const create = () => ({
 				method: 'appendChild',
 				argumentsLength: 1,
 				optionalCall: false,
-				computed: false,
 			})
 			|| isNodeValueNotDomNode(node.callee.object)
 			|| isNodeValueNotDomNode(node.arguments[0])

--- a/rules/prefer-dom-node-remove.js
+++ b/rules/prefer-dom-node-remove.js
@@ -36,7 +36,6 @@ const create = context => {
 					method: 'removeChild',
 					argumentsLength: 1,
 					optionalCall: false,
-					computed: false,
 				})
 				|| isNodeValueNotDomNode(node.callee.object)
 				|| isNodeValueNotDomNode(node.arguments[0])

--- a/rules/prefer-dom-node-text-content.js
+++ b/rules/prefer-dom-node-text-content.js
@@ -25,7 +25,6 @@ const create = () => ({
 		if (
 			!isMemberExpression(memberExpression, {
 				property: 'innerText',
-				computed: false,
 			})
 		) {
 			return;

--- a/rules/prefer-query-selector.js
+++ b/rules/prefer-query-selector.js
@@ -95,7 +95,6 @@ const create = () => ({
 				argumentsLength: 1,
 				optionalCall: false,
 				optionalMember: false,
-				computed: false,
 			})
 			|| isNodeValueNotDomNode(node.callee.object)
 		) {

--- a/rules/prefer-set-size.js
+++ b/rules/prefer-set-size.js
@@ -67,7 +67,6 @@ const create = context => {
 				!isMemberExpression(node, {
 					property: 'length',
 					optional: false,
-					computed: false,
 				})
 				|| node.object.type !== 'ArrayExpression'
 				|| node.object.elements.length !== 1

--- a/rules/utils/is-node-value-not-function.js
+++ b/rules/utils/is-node-value-not-function.js
@@ -35,7 +35,6 @@ const isNodeValueNotFunction = node => (
 			method: 'bind',
 			optionalCall: false,
 			optionalMember: false,
-			computed: false,
 		}))
 	)
 );


### PR DESCRIPTION
Forbid `computed` when MemberExpression.property is checked