### PR TITLE
Refactor to use simple selectors

### DIFF
--- a/rules/no-useless-length-check.js
+++ b/rules/no-useless-length-check.js
@@ -96,9 +96,9 @@ const create = context => {
 				})
 				&& node.callee.property.type === 'Identifier'
 			) {
-				if (node.callee.property.name == 'some') {
+				if (node.callee.property.name === 'some') {
 					arraySomeCalls.add(node);
-				} else if (node.callee.property.name == 'every') {
+				} else if (node.callee.property.name === 'every') {
 					arrayEveryCalls.add(node);
 				}
 			}

--- a/rules/no-useless-length-check.js
+++ b/rules/no-useless-length-check.js
@@ -1,7 +1,7 @@
 'use strict';
-const {methodCallSelector, matches, memberExpressionSelector} = require('./selectors/index.js');
-const isSameReference = require('./utils/is-same-reference.js');
-const {getParenthesizedRange} = require('./utils/parentheses.js');
+const {isMethodCall} = require('./ast/index.js');
+const {matches, memberExpressionSelector} = require('./selectors/index.js');
+const {getParenthesizedRange, isSameReference} = require('./utils/index.js');
 
 const messages = {
 	'non-zero': 'The non-empty check is useless as `Array#some()` returns `false` for an empty array.',
@@ -29,8 +29,6 @@ const nonZeroLengthCheckSelector = [
 	lengthCompareZeroSelector,
 	matches(['[operator=">"]', '[operator="!=="]']),
 ].join('');
-const arraySomeCallSelector = methodCallSelector('some');
-const arrayEveryCallSelector = methodCallSelector('every');
 
 function flatLogicalExpression(node) {
 	return [node.left, node.right].flatMap(child =>
@@ -89,11 +87,21 @@ const create = context => {
 		[nonZeroLengthCheckSelector](node) {
 			nonZeroLengthChecks.add(node);
 		},
-		[arraySomeCallSelector](node) {
-			arraySomeCalls.add(node);
-		},
-		[arrayEveryCallSelector](node) {
-			arrayEveryCalls.add(node);
+		CallExpression(node) {
+			if (
+				isMethodCall(node, {
+					optionalCall: false,
+					optionalMember: false,
+					computed: false,
+				})
+				&& node.callee.property.type === 'Identifier'
+			) {
+				if (node.callee.property.name == 'some') {
+					arraySomeCalls.add(node);
+				} else if (node.callee.property.name == 'every') {
+					arrayEveryCalls.add(node);
+				}
+			}
 		},
 		[logicalExpressionSelector](node) {
 			logicalExpressions.push(node);

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -1,11 +1,12 @@
 'use strict';
-const {methodCallSelector, matches, memberExpressionSelector} = require('./selectors/index.js');
 const {checkVueTemplate} = require('./utils/rule.js');
-const {isBooleanNode} = require('./utils/boolean.js');
-const {getParenthesizedRange} = require('./utils/parentheses.js');
-const {isNodeValueNotFunction} = require('./utils/index.js');
+const {
+	isBooleanNode,
+	getParenthesizedRange,
+	isNodeValueNotFunction,
+} = require('./utils/index.js');
 const {removeMemberExpressionProperty} = require('./fix/index.js');
-const {isLiteral, isUndefined} = require('./ast/index.js');
+const {isLiteral, isUndefined, isMethodCall, isMemberExpression} = require('./ast/index.js');
 
 const ERROR_ID_ARRAY_SOME = 'some';
 const SUGGESTION_ID_ARRAY_SOME = 'some-suggestion';
@@ -15,12 +16,6 @@ const messages = {
 	[SUGGESTION_ID_ARRAY_SOME]: 'Replace `.{{method}}(…)` with `.some(…)`.',
 	[ERROR_ID_ARRAY_FILTER]: 'Prefer `.some(…)` over non-zero length check from `.filter(…)`.',
 };
-
-const arrayFindOrFindLastCallSelector = methodCallSelector({
-	methods: ['find', 'findLast'],
-	minimumArguments: 1,
-	maximumArguments: 2,
-});
 
 const isCheckingUndefined = node =>
 	node.parent.type === 'BinaryExpression'
@@ -46,21 +41,19 @@ const isCheckingUndefined = node =>
 		)
 	);
 
-const arrayFilterCallSelector = [
-	'BinaryExpression',
-	'[right.type="Literal"]',
-	'[right.raw="0"]',
-	// We assume the user already follows `unicorn/explicit-length-check`. These are allowed in that rule.
-	matches(['[operator=">"]', '[operator="!=="]']),
-	' > ',
-	`${memberExpressionSelector('length')}.left`,
-	' > ',
-	`${methodCallSelector('filter')}.object`,
-].join('');
-
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
-	[arrayFindOrFindLastCallSelector](callExpression) {
+	CallExpression(callExpression) {
+		if (!isMethodCall(callExpression, {
+			methods: ['find', 'findLast'],
+			minimumArguments: 1,
+			maximumArguments: 2,
+			optionalCall: false,
+			optionalMember: false,
+		})) {
+			return;
+		}
+
 		const isCompare = isCheckingUndefined(callExpression);
 		if (!isCompare && !isBooleanNode(callExpression)) {
 			return;
@@ -94,7 +87,23 @@ const create = context => ({
 			],
 		};
 	},
-	[arrayFilterCallSelector](filterCall) {
+	BinaryExpression(binaryExpression) {
+		if (!(
+			// We assume the user already follows `unicorn/explicit-length-check`. These are allowed in that rule.
+			(binaryExpression.operator === '>' || binaryExpression.operator === '!==')
+			&& binaryExpression.right.type === 'Literal'
+			&& binaryExpression.right.raw === '0'
+			&& isMemberExpression(binaryExpression.left, {property: 'length', optional: false})
+			&& isMethodCall(binaryExpression.left.object, {
+				method: 'filter',
+				optionalCall: false,
+				optionalMember: false,
+			})
+		)) {
+			return;
+		}
+
+		const filterCall = binaryExpression.left.object;
 		const [firstArgument] = filterCall.arguments;
 		if (!firstArgument || isNodeValueNotFunction(firstArgument)) {
 			return;
@@ -109,7 +118,7 @@ const create = context => ({
 				yield fixer.replaceText(filterProperty, 'some');
 
 				const {sourceCode} = context;
-				const lengthNode = filterCall.parent;
+				const lengthNode = binaryExpression.left;
 				/*
 					Remove `.length`
 					`(( (( array.filter() )).length )) > (( 0 ))`
@@ -117,7 +126,6 @@ const create = context => ({
 				*/
 				yield removeMemberExpressionProperty(fixer, lengthNode, sourceCode);
 
-				const compareNode = lengthNode.parent;
 				/*
 					Remove `> 0`
 					`(( (( array.filter() )).length )) > (( 0 ))`
@@ -125,7 +133,7 @@ const create = context => ({
 				*/
 				yield fixer.removeRange([
 					getParenthesizedRange(lengthNode, sourceCode)[1],
-					compareNode.range[1],
+					binaryExpression.range[1],
 				]);
 
 				// The `BinaryExpression` always ends with a number or `)`, no need check for ASI

--- a/rules/prefer-modern-math-apis.js
+++ b/rules/prefer-modern-math-apis.js
@@ -130,12 +130,12 @@ const create = context => {
 
 	return {
 		CallExpression(callExpression) {
-			if (!isMethodCall({
+			if (!isMethodCall(callExpression, {
 				object: 'Math',
 				method: 'sqrt',
 				argumentsLength: 1,
 				optionalCall: false,
-				optionalMember: false
+				optionalMember: false,
 			})) {
 				return;
 			}

--- a/rules/prefer-reflect-apply.js
+++ b/rules/prefer-reflect-apply.js
@@ -1,17 +1,11 @@
 'use strict';
 const {getPropertyName} = require('@eslint-community/eslint-utils');
-const {not, methodCallSelector} = require('./selectors/index.js');
-const {isNullLiteral} = require('./ast/index.js');
+const {isNullLiteral, isMethodCall} = require('./ast/index.js');
 
 const MESSAGE_ID = 'prefer-reflect-apply';
 const messages = {
 	[MESSAGE_ID]: 'Prefer `Reflect.apply()` over `Function#apply()`.',
 };
-
-const selector = [
-	methodCallSelector({allowComputed: true}),
-	not(['Literal', 'ArrayExpression', 'ObjectExpression'].map(type => `[callee.object.type=${type}]`)),
-].join('');
 
 const isApplySignature = (argument1, argument2) => (
 	(
@@ -64,7 +58,19 @@ const fixFunctionPrototypeCall = (node, sourceCode) => {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
-	[selector](node) {
+	CallExpression(node) {
+		if (
+			!isMethodCall(node, {
+				optionalCall: false,
+				optionalMember: false,
+			})
+			|| node.callee.object.type === 'Literal'
+			|| node.callee.object.type === 'ArrayExpression'
+			|| node.callee.object.type === 'ObjectExpression'
+		) {
+			return;
+		}
+
 		const {sourceCode} = context;
 		const fix = fixDirectApplyCall(node, sourceCode) || fixFunctionPrototypeCall(node, sourceCode);
 		if (fix) {

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -134,7 +134,7 @@ const create = context => ({
 
 			yield problem;
 		}
-	}
+	},
 });
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -2,7 +2,7 @@
 const {isParenthesized, getStaticValue} = require('@eslint-community/eslint-utils');
 const {checkVueTemplate} = require('./utils/rule.js');
 const {methodCallSelector} = require('./selectors/index.js');
-const {isRegexLiteral, isNewExpression} = require('./ast/index.js');
+const {isRegexLiteral, isNewExpression, isMethodCall} = require('./ast/index.js');
 const {isBooleanNode} = require('./utils/boolean.js');
 const shouldAddParenthesesToMemberExpressionObject = require('./utils/should-add-parentheses-to-member-expression-object.js');
 
@@ -18,9 +18,11 @@ const messages = {
 const cases = [
 	{
 		type: REGEXP_EXEC,
-		selector: methodCallSelector({
+		test: node => isMethodCall(node, {
 			method: 'exec',
 			argumentsLength: 1,
+			optionalCall: false,
+			optionalMember: false,
 		}),
 		getNodes: node => ({
 			stringNode: node.arguments[0],
@@ -31,9 +33,11 @@ const cases = [
 	},
 	{
 		type: STRING_MATCH,
-		selector: methodCallSelector({
+		test: node => isMethodCall(node, {
 			method: 'match',
 			argumentsLength: 1,
+			optionalCall: false,
+			optionalMember: false,
 		}),
 		getNodes: node => ({
 			stringNode: node.callee.object,
@@ -87,20 +91,22 @@ const isRegExpWithoutGlobalFlag = (node, scope) => {
 };
 
 /** @param {import('eslint').Rule.RuleContext} context */
-const create = context => Object.fromEntries(
-	cases.map(checkCase => [
-		checkCase.selector,
-		node => {
-			if (!isBooleanNode(node)) {
-				return;
+const create = context => ({
+	* CallExpression(node) {
+		if (!isBooleanNode(node)) {
+			return;
+		}
+
+		for (const {type, test, getNodes, fix} of cases) {
+			if (!test(node)) {
+				continue;
 			}
 
-			const {type, getNodes, fix} = checkCase;
 			const nodes = getNodes(node);
 			const {methodNode, regexpNode} = nodes;
 
 			if (regexpNode.type === 'Literal' && !regexpNode.regex) {
-				return;
+				continue;
 			}
 
 			const problem = {
@@ -125,10 +131,10 @@ const create = context => Object.fromEntries(
 				];
 			}
 
-			return problem;
-		},
-	]),
-);
+			yield problem;
+		}
+	}
+});
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {

--- a/rules/prefer-regexp-test.js
+++ b/rules/prefer-regexp-test.js
@@ -1,10 +1,11 @@
 'use strict';
 const {isParenthesized, getStaticValue} = require('@eslint-community/eslint-utils');
 const {checkVueTemplate} = require('./utils/rule.js');
-const {methodCallSelector} = require('./selectors/index.js');
 const {isRegexLiteral, isNewExpression, isMethodCall} = require('./ast/index.js');
-const {isBooleanNode} = require('./utils/boolean.js');
-const shouldAddParenthesesToMemberExpressionObject = require('./utils/should-add-parentheses-to-member-expression-object.js');
+const {
+	isBooleanNode,
+	shouldAddParenthesesToMemberExpressionObject,
+} = require('./utils/index.js');
 
 const REGEXP_EXEC = 'regexp-exec';
 const STRING_MATCH = 'string-match';

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -30,6 +30,7 @@ const parseEsquerySelector = selector => {
 	if (!parsedEsquerySelectors.has(selector)) {
 		parsedEsquerySelectors.set(selector, esquery.parse(selector));
 	}
+
 	return parsedEsquerySelectors.get(selector);
 };
 

--- a/rules/utils/index.js
+++ b/rules/utils/index.js
@@ -29,6 +29,7 @@ module.exports = {
 	isOnSameLine: require('./is-on-same-line.js'),
 	isParenthesized,
 	isSameIdentifier: require('./is-same-identifier.js'),
+	isSameReference: require('./is-same-reference.js'),
 	isShadowed: require('./is-shadowed.js'),
 	isValueNotUsable: require('./is-value-not-usable.js'),
 	needsSemicolon: require('./needs-semicolon.js'),

--- a/rules/utils/index.js
+++ b/rules/utils/index.js
@@ -12,15 +12,18 @@ const {
 	isObjectPrototypeProperty,
 } = require('./array-or-object-prototype-property.js');
 const {isNodeMatches, isNodeMatchesNameOrPath} = require('./is-node-matches.js');
+const {isBooleanNode, getBooleanAncestor} = require('./boolean.js');
 
 module.exports = {
 	escapeString: require('./escape-string.js'),
+	getBooleanAncestor,
 	getParentheses,
 	getParenthesizedRange,
 	getParenthesizedText,
 	getParenthesizedTimes,
 	getVariableIdentifiers: require('./get-variable-identifiers.js'),
 	isArrayPrototypeProperty,
+	isBooleanNode,
 	isNodeMatches,
 	isNodeMatchesNameOrPath,
 	isNodeValueNotDomNode: require('./is-node-value-not-dom-node.js'),


### PR DESCRIPTION
`template-indent` is much faster now.


```
Rule                                | Time (ms) | Relative
:-----------------------------------|----------:|--------:
unicorn/template-indent             |   614.063 |    22.8%
```

```
Rule                                | Time (ms) | Relative
:-----------------------------------|----------:|--------:
unicorn/template-indent             |    89.357 |     3.5%
```