### PR TITLE
fix(expiring-todo-comments): support monorepos

### DIFF
--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -52,8 +52,16 @@ const messages = {
 function getPackageHelpers(dirname) {
 	// We don't need to normalize the package.json data, because we are only using 2 properties and those 2 properties
 	// aren't validated by the normalization. But when this plugin is used in a monorepo, the name field in the
-	// package.json is invalid and would make this plugin throw an error. See also #1871
-	const packageResult = readPkgUp.sync({normalize: false, cwd: dirname});
+	// package.json can be invalid and would make this plugin throw an error. See also #1871
+	/** @type {readPkgUp.ReadResult | undefined} */
+	let packageResult;
+	try {
+		packageResult = readPkgUp.sync({normalize: false, cwd: dirname});
+	} catch {
+		// This can happen if package.json files have comments in them etc.
+		packageResult = undefined;
+	}
+
 	const hasPackage = Boolean(packageResult);
 	const packageJson = packageResult ? packageResult.packageJson : {};
 

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('node:path');
 const readPkgUp = require('read-pkg-up');
 const semver = require('semver');
 const ci = require('ci-info');
@@ -47,47 +48,143 @@ const messages = {
 		'Unexpected \'{{matchedTerm}}\' comment without any conditions: \'{{comment}}\'.',
 };
 
-// We don't need to normalize the package.json data, because we are only using 2 properties and those 2 properties
-// aren't validated by the normalization. But when this plugin is used in a monorepo, the name field in the
-// package.json is invalid and would make this plugin throw an error. See also #1871
-const packageResult = readPkgUp.sync({normalize: false});
-const hasPackage = Boolean(packageResult);
-const packageJson = hasPackage ? packageResult.packageJson : {};
+/** @param {string} dirname */
+function getPackageHelpers(dirname) {
+	// We don't need to normalize the package.json data, because we are only using 2 properties and those 2 properties
+	// aren't validated by the normalization. But when this plugin is used in a monorepo, the name field in the
+	// package.json is invalid and would make this plugin throw an error. See also #1871
+	const packageResult = readPkgUp.sync({normalize: false, cwd: dirname});
+	const hasPackage = Boolean(packageResult);
+	const packageJson = packageResult ? packageResult.packageJson : {};
 
-const packageDependencies = {
-	...packageJson.dependencies,
-	...packageJson.devDependencies,
-};
+	const packageDependencies = {
+		...packageJson.dependencies,
+		...packageJson.devDependencies,
+	};
+
+	function parseTodoWithArguments(string, {terms}) {
+		const lowerCaseString = string.toLowerCase();
+		const lowerCaseTerms = terms.map(term => term.toLowerCase());
+		const hasTerm = lowerCaseTerms.some(term => lowerCaseString.includes(term));
+
+		if (!hasTerm) {
+			return false;
+		}
+
+		const TODO_ARGUMENT_RE = /\[(?<rawArguments>[^}]+)]/i;
+		const result = TODO_ARGUMENT_RE.exec(string);
+
+		if (!result) {
+			return false;
+		}
+
+		const {rawArguments} = result.groups;
+
+		const parsedArguments = rawArguments
+			.split(',')
+			.map(argument => parseArgument(argument.trim()));
+
+		return createArgumentGroup(parsedArguments);
+	}
+
+	function parseArgument(argumentString, dirname) {
+		const {hasPackage} = getPackageHelpers(dirname);
+		if (ISO8601_DATE.test(argumentString)) {
+			return {
+				type: 'dates',
+				value: argumentString,
+			};
+		}
+
+		if (hasPackage && DEPENDENCY_INCLUSION_RE.test(argumentString)) {
+			const condition = argumentString[0] === '+' ? 'in' : 'out';
+			const name = argumentString.slice(1).trim();
+
+			return {
+				type: 'dependencies',
+				value: {
+					name,
+					condition,
+				},
+			};
+		}
+
+		if (hasPackage && VERSION_COMPARISON_RE.test(argumentString)) {
+			const {groups} = VERSION_COMPARISON_RE.exec(argumentString);
+			const name = groups.name.trim();
+			const condition = groups.condition.trim();
+			const version = groups.version.trim();
+
+			const hasEngineKeyword = name.indexOf('engine:') === 0;
+			const isNodeEngine = hasEngineKeyword && name === 'engine:node';
+
+			if (hasEngineKeyword && isNodeEngine) {
+				return {
+					type: 'engines',
+					value: {
+						condition,
+						version,
+					},
+				};
+			}
+
+			if (!hasEngineKeyword) {
+				return {
+					type: 'dependencies',
+					value: {
+						name,
+						condition,
+						version,
+					},
+				};
+			}
+		}
+
+		if (hasPackage && PKG_VERSION_RE.test(argumentString)) {
+			const result = PKG_VERSION_RE.exec(argumentString);
+			const {condition, version} = result.groups;
+
+			return {
+				type: 'packageVersions',
+				value: {
+					condition: condition.trim(),
+					version: version.trim(),
+				},
+			};
+		}
+
+		// Currently being ignored as integration tests pointed
+		// some TODO comments have `[random data like this]`
+		return {
+			type: 'unknowns',
+			value: argumentString,
+		};
+	}
+
+	function parseTodoMessage(todoString) {
+		// @example "TODO [...]: message here"
+		// @example "TODO [...] message here"
+		const argumentsEnd = todoString.indexOf(']');
+
+		const afterArguments = todoString.slice(argumentsEnd + 1).trim();
+
+		// Check if have to skip colon
+		// @example "TODO [...]: message here"
+		const dropColon = afterArguments[0] === ':';
+		if (dropColon) {
+			return afterArguments.slice(1).trim();
+		}
+
+		return afterArguments;
+	}
+
+	return {packageResult, hasPackage, packageJson, packageDependencies, parseArgument, parseTodoMessage, parseTodoWithArguments};
+}
 
 const DEPENDENCY_INCLUSION_RE = /^[+-]\s*@?\S+\/?\S+/;
 const VERSION_COMPARISON_RE = /^(?<name>@?\S\/?\S+)@(?<condition>>|>=)(?<version>\d+(?:\.\d+){0,2}(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?)/i;
 const PKG_VERSION_RE = /^(?<condition>>|>=)(?<version>\d+(?:\.\d+){0,2}(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?)\s*$/;
 const ISO8601_DATE = /\d{4}-\d{2}-\d{2}/;
-
-function parseTodoWithArguments(string, {terms}) {
-	const lowerCaseString = string.toLowerCase();
-	const lowerCaseTerms = terms.map(term => term.toLowerCase());
-	const hasTerm = lowerCaseTerms.some(term => lowerCaseString.includes(term));
-
-	if (!hasTerm) {
-		return false;
-	}
-
-	const TODO_ARGUMENT_RE = /\[(?<rawArguments>[^}]+)]/i;
-	const result = TODO_ARGUMENT_RE.exec(string);
-
-	if (!result) {
-		return false;
-	}
-
-	const {rawArguments} = result.groups;
-
-	const parsedArguments = rawArguments
-		.split(',')
-		.map(argument => parseArgument(argument.trim()));
-
-	return createArgumentGroup(parsedArguments);
-}
 
 function createArgumentGroup(arguments_) {
 	const groups = {};
@@ -97,96 +194,6 @@ function createArgumentGroup(arguments_) {
 	}
 
 	return groups;
-}
-
-function parseArgument(argumentString) {
-	if (ISO8601_DATE.test(argumentString)) {
-		return {
-			type: 'dates',
-			value: argumentString,
-		};
-	}
-
-	if (hasPackage && DEPENDENCY_INCLUSION_RE.test(argumentString)) {
-		const condition = argumentString[0] === '+' ? 'in' : 'out';
-		const name = argumentString.slice(1).trim();
-
-		return {
-			type: 'dependencies',
-			value: {
-				name,
-				condition,
-			},
-		};
-	}
-
-	if (hasPackage && VERSION_COMPARISON_RE.test(argumentString)) {
-		const {groups} = VERSION_COMPARISON_RE.exec(argumentString);
-		const name = groups.name.trim();
-		const condition = groups.condition.trim();
-		const version = groups.version.trim();
-
-		const hasEngineKeyword = name.indexOf('engine:') === 0;
-		const isNodeEngine = hasEngineKeyword && name === 'engine:node';
-
-		if (hasEngineKeyword && isNodeEngine) {
-			return {
-				type: 'engines',
-				value: {
-					condition,
-					version,
-				},
-			};
-		}
-
-		if (!hasEngineKeyword) {
-			return {
-				type: 'dependencies',
-				value: {
-					name,
-					condition,
-					version,
-				},
-			};
-		}
-	}
-
-	if (hasPackage && PKG_VERSION_RE.test(argumentString)) {
-		const result = PKG_VERSION_RE.exec(argumentString);
-		const {condition, version} = result.groups;
-
-		return {
-			type: 'packageVersions',
-			value: {
-				condition: condition.trim(),
-				version: version.trim(),
-			},
-		};
-	}
-
-	// Currently being ignored as integration tests pointed
-	// some TODO comments have `[random data like this]`
-	return {
-		type: 'unknowns',
-		value: argumentString,
-	};
-}
-
-function parseTodoMessage(todoString) {
-	// @example "TODO [...]: message here"
-	// @example "TODO [...] message here"
-	const argumentsEnd = todoString.indexOf(']');
-
-	const afterArguments = todoString.slice(argumentsEnd + 1).trim();
-
-	// Check if have to skip colon
-	// @example "TODO [...]: message here"
-	const dropColon = afterArguments[0] === ':';
-	if (dropColon) {
-		return afterArguments.slice(1).trim();
-	}
-
-	return afterArguments;
 }
 
 function reachedDate(past, now) {
@@ -262,6 +269,9 @@ const create = context => {
 	const ignoreRegexes = options.ignore.map(
 		pattern => pattern instanceof RegExp ? pattern : new RegExp(pattern, 'u'),
 	);
+
+	const dirname = path.dirname(context.filename);
+	const {packageJson, packageDependencies, parseArgument, parseTodoMessage, parseTodoWithArguments} = getPackageHelpers(dirname);
 
 	const {sourceCode} = context;
 	const comments = sourceCode.getAllComments();


### PR DESCRIPTION
Fixes #403
Maybe related: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1871

The basic change: pass the file-being-linted dirname rather than cwd to `read-pkg-up`. Using cwd meant it would find a monorepo's root package directory. Basically this:

```diff
- packageResult = readPkgUp.sync({normalize: false});
+ packageResult = readPkgUp.sync({normalize: false, cwd: dirname});
```

For review, worth viewing without whitespace, since a few functions were indented to live inside a helper which knows about the file-being-linted's directory name: https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2159/files?w=1

I haven't added tests because I didn't see any that were actually exercising `read-pkg-up` so far, but maybe I missed something?

This could introduce new errors, or make others go away, so I think it qualifies as a breaking change. I think it makes sense for the dependency to depend on the package.json nearest the file being linted though.