### PR TITLE
add unopinionated preset

### DIFF
--- a/configs/unopinionated.js
+++ b/configs/unopinionated.js
@@ -1,0 +1,15 @@
+'use strict';
+const {rules, ...baseConfigs} = require('./recommended.js');
+
+module.exports = {
+	...baseConfigs,
+	rules: {
+		...Object.fromEntries(Object.entries(rules)
+		.filter(([ruleId, severity]) => severity === 'error')
+		),
+		'unicorn/no-array-for-each': 'off',
+		'unicorn/no-array-reduce': 'off',
+		'unicorn/no-null': 'off',
+		'unicorn/prefer-switch': 'off'
+	},
+};

--- a/configs/unopinionated.js
+++ b/configs/unopinionated.js
@@ -4,9 +4,7 @@ const {rules, ...baseConfigs} = require('./recommended.js');
 module.exports = {
 	...baseConfigs,
 	rules: {
-		...Object.fromEntries(Object.entries(rules)
-			.filter(([_ruleId, severity]) => severity === 'error'),
-		),
+		...Object.fromEntries(Object.entries(rules)),
 		'unicorn/no-array-for-each': 'off',
 		'unicorn/no-array-reduce': 'off',
 		'unicorn/no-null': 'off',

--- a/configs/unopinionated.js
+++ b/configs/unopinionated.js
@@ -5,11 +5,11 @@ module.exports = {
 	...baseConfigs,
 	rules: {
 		...Object.fromEntries(Object.entries(rules)
-		.filter(([ruleId, severity]) => severity === 'error')
+			.filter(([_ruleId, severity]) => severity === 'error'),
 		),
 		'unicorn/no-array-for-each': 'off',
 		'unicorn/no-array-reduce': 'off',
 		'unicorn/no-null': 'off',
-		'unicorn/prefer-switch': 'off'
+		'unicorn/prefer-switch': 'off',
 	},
 };


### PR DESCRIPTION
Hello,

I'd like to work on and resolve #896

Currently, I have disabled four rules

```
no-array-for-each
no-array-reduce
no-null
prefer-switch
```

I was also considering disabling 

```
switch-case-braces
empty-brace-spaces
```

as these are more related to style and should probably be handled by a formatter.

Lastly, as referenced in #1636, I'd like to suggest modifying `prevent-abbreviations` default setting to allow standard abbreviations such as `arg`, `args`, `db`, and `env`. There may be others but these are the immediate ones that came to mind. 

