### PR TITLE
Remove direct dependency on lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"lint:md": "markdownlint \"**/*.md\"",
 		"lint:package-json": "npmPkgJsonLint .",
 		"run-rules-on-codebase": "node ./test/run-rules-on-codebase/lint.mjs",
+		"bundle-lodash": "echo \"export {defaultsDeep, camelCase, kebabCase, snakeCase, upperFirst, lowerFirst} from 'lodash-es';\" | npx esbuild --bundle --outfile=rules/utils/lodash.js --format=cjs",
 		"smoke": "eslint-remote-tester --config ./test/smoke/eslint-remote-tester.config.js",
 		"test": "npm-run-all --continue-on-error lint test:*",
 		"test:js": "c8 ava"
@@ -54,7 +55,6 @@
 		"indent-string": "^4.0.0",
 		"is-builtin-module": "^3.2.1",
 		"jsesc": "^3.0.2",
-		"lodash": "^4.17.21",
 		"pluralize": "^8.0.0",
 		"read-pkg-up": "^7.0.1",
 		"regexp-tree": "^0.1.27",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
 		"ignores": [
 			".cache-eslint-remote-tester",
 			"eslint-remote-tester-results",
+			"rules/utils/lodash.js",
 			"test/integration/{fixtures,fixtures-local}/**"
 		],
 		"rules": {

--- a/rules/ast/is-method-call.js
+++ b/rules/ast/is-method-call.js
@@ -1,5 +1,4 @@
 'use strict';
-const {pick} = require('lodash');
 const isMemberExpression = require('./is-member-expression.js');
 const {isCallExpression} = require('./call-or-new-expression.js');
 
@@ -46,11 +45,16 @@ function isMethodCall(node, options) {
 
 	return (
 		isCallExpression(node, {
-			...pick(options, ['argumentsLength', 'minimumArguments', 'maximumArguments', 'allowSpreadElement']),
+			argumentsLength: options.argumentsLength,
+			minimumArguments: options.minimumArguments,
+			maximumArguments: options.maximumArguments,
+			allowSpreadElement: options.allowSpreadElement,
 			optional: optionalCall,
 		})
 		&& isMemberExpression(node.callee, {
-			...pick(options, ['object', 'objects', 'computed']),
+			object: options.object,
+			objects: options.objects,
+			computed: options.computed,
 			property: method,
 			properties: methods,
 			optional: optionalMember,

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -1,5 +1,5 @@
 'use strict';
-const {upperFirst} = require('lodash');
+const {upperFirst} = require('./utils/lodash');
 
 const MESSAGE_ID_INVALID_EXPORT = 'invalidExport';
 const messages = {

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -1,5 +1,5 @@
 'use strict';
-const {upperFirst} = require('./utils/lodash');
+const {upperFirst} = require('./utils/lodash.js');
 
 const MESSAGE_ID_INVALID_EXPORT = 'invalidExport';
 const messages = {

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('node:path');
-const {camelCase, kebabCase, snakeCase, upperFirst} = require('./utils/lodash');
+const {camelCase, kebabCase, snakeCase, upperFirst} = require('./utils/lodash.js');
 const cartesianProductSamples = require('./utils/cartesian-product-samples.js');
 
 const MESSAGE_ID = 'filename-case';

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('node:path');
-const {camelCase, kebabCase, snakeCase, upperFirst} = require('lodash');
+const {camelCase, kebabCase, snakeCase, upperFirst} = require('./utils/lodash');
 const cartesianProductSamples = require('./utils/cartesian-product-samples.js');
 
 const MESSAGE_ID = 'filename-case';

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -1,5 +1,5 @@
 'use strict';
-const {defaultsDeep} = require('lodash');
+const {defaultsDeep} = require('./utils/lodash');
 const {getStringIfConstant} = require('@eslint-community/eslint-utils');
 const {isCallExpression} = require('./ast/index.js');
 

--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -1,5 +1,5 @@
 'use strict';
-const {defaultsDeep} = require('./utils/lodash');
+const {defaultsDeep} = require('./utils/lodash.js');
 const {getStringIfConstant} = require('@eslint-community/eslint-utils');
 const {isCallExpression} = require('./ast/index.js');
 

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('node:path');
-const {defaultsDeep, upperFirst, lowerFirst} = require('./utils/lodash');
+const {defaultsDeep, upperFirst, lowerFirst} = require('./utils/lodash.js');
 const avoidCapture = require('./utils/avoid-capture.js');
 const cartesianProductSamples = require('./utils/cartesian-product-samples.js');
 const isShorthandPropertyValue = require('./utils/is-shorthand-property-value.js');

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('node:path');
-const {defaultsDeep, upperFirst, lowerFirst} = require('lodash');
+const {defaultsDeep, upperFirst, lowerFirst} = require('./utils/lodash');
 const avoidCapture = require('./utils/avoid-capture.js');
 const cartesianProductSamples = require('./utils/cartesian-product-samples.js');
 const isShorthandPropertyValue = require('./utils/is-shorthand-property-value.js');

--- a/rules/utils/lodash.js
+++ b/rules/utils/lodash.js
@@ -1,0 +1,1589 @@
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// <stdin>
+var stdin_exports = {};
+__export(stdin_exports, {
+  camelCase: () => camelCase_default,
+  defaultsDeep: () => defaultsDeep_default,
+  kebabCase: () => kebabCase_default,
+  lowerFirst: () => lowerFirst_default,
+  snakeCase: () => snakeCase_default,
+  upperFirst: () => upperFirst_default
+});
+module.exports = __toCommonJS(stdin_exports);
+
+// node_modules/lodash-es/_freeGlobal.js
+var freeGlobal = typeof global == "object" && global && global.Object === Object && global;
+var freeGlobal_default = freeGlobal;
+
+// node_modules/lodash-es/_root.js
+var freeSelf = typeof self == "object" && self && self.Object === Object && self;
+var root = freeGlobal_default || freeSelf || Function("return this")();
+var root_default = root;
+
+// node_modules/lodash-es/_Symbol.js
+var Symbol2 = root_default.Symbol;
+var Symbol_default = Symbol2;
+
+// node_modules/lodash-es/_getRawTag.js
+var objectProto = Object.prototype;
+var hasOwnProperty = objectProto.hasOwnProperty;
+var nativeObjectToString = objectProto.toString;
+var symToStringTag = Symbol_default ? Symbol_default.toStringTag : void 0;
+function getRawTag(value) {
+  var isOwn = hasOwnProperty.call(value, symToStringTag), tag = value[symToStringTag];
+  try {
+    value[symToStringTag] = void 0;
+    var unmasked = true;
+  } catch (e) {
+  }
+  var result = nativeObjectToString.call(value);
+  if (unmasked) {
+    if (isOwn) {
+      value[symToStringTag] = tag;
+    } else {
+      delete value[symToStringTag];
+    }
+  }
+  return result;
+}
+var getRawTag_default = getRawTag;
+
+// node_modules/lodash-es/_objectToString.js
+var objectProto2 = Object.prototype;
+var nativeObjectToString2 = objectProto2.toString;
+function objectToString(value) {
+  return nativeObjectToString2.call(value);
+}
+var objectToString_default = objectToString;
+
+// node_modules/lodash-es/_baseGetTag.js
+var nullTag = "[object Null]";
+var undefinedTag = "[object Undefined]";
+var symToStringTag2 = Symbol_default ? Symbol_default.toStringTag : void 0;
+function baseGetTag(value) {
+  if (value == null) {
+    return value === void 0 ? undefinedTag : nullTag;
+  }
+  return symToStringTag2 && symToStringTag2 in Object(value) ? getRawTag_default(value) : objectToString_default(value);
+}
+var baseGetTag_default = baseGetTag;
+
+// node_modules/lodash-es/isObjectLike.js
+function isObjectLike(value) {
+  return value != null && typeof value == "object";
+}
+var isObjectLike_default = isObjectLike;
+
+// node_modules/lodash-es/isSymbol.js
+var symbolTag = "[object Symbol]";
+function isSymbol(value) {
+  return typeof value == "symbol" || isObjectLike_default(value) && baseGetTag_default(value) == symbolTag;
+}
+var isSymbol_default = isSymbol;
+
+// node_modules/lodash-es/_arrayMap.js
+function arrayMap(array, iteratee) {
+  var index = -1, length = array == null ? 0 : array.length, result = Array(length);
+  while (++index < length) {
+    result[index] = iteratee(array[index], index, array);
+  }
+  return result;
+}
+var arrayMap_default = arrayMap;
+
+// node_modules/lodash-es/isArray.js
+var isArray = Array.isArray;
+var isArray_default = isArray;
+
+// node_modules/lodash-es/_baseToString.js
+var INFINITY = 1 / 0;
+var symbolProto = Symbol_default ? Symbol_default.prototype : void 0;
+var symbolToString = symbolProto ? symbolProto.toString : void 0;
+function baseToString(value) {
+  if (typeof value == "string") {
+    return value;
+  }
+  if (isArray_default(value)) {
+    return arrayMap_default(value, baseToString) + "";
+  }
+  if (isSymbol_default(value)) {
+    return symbolToString ? symbolToString.call(value) : "";
+  }
+  var result = value + "";
+  return result == "0" && 1 / value == -INFINITY ? "-0" : result;
+}
+var baseToString_default = baseToString;
+
+// node_modules/lodash-es/isObject.js
+function isObject(value) {
+  var type = typeof value;
+  return value != null && (type == "object" || type == "function");
+}
+var isObject_default = isObject;
+
+// node_modules/lodash-es/identity.js
+function identity(value) {
+  return value;
+}
+var identity_default = identity;
+
+// node_modules/lodash-es/isFunction.js
+var asyncTag = "[object AsyncFunction]";
+var funcTag = "[object Function]";
+var genTag = "[object GeneratorFunction]";
+var proxyTag = "[object Proxy]";
+function isFunction(value) {
+  if (!isObject_default(value)) {
+    return false;
+  }
+  var tag = baseGetTag_default(value);
+  return tag == funcTag || tag == genTag || tag == asyncTag || tag == proxyTag;
+}
+var isFunction_default = isFunction;
+
+// node_modules/lodash-es/_coreJsData.js
+var coreJsData = root_default["__core-js_shared__"];
+var coreJsData_default = coreJsData;
+
+// node_modules/lodash-es/_isMasked.js
+var maskSrcKey = function() {
+  var uid = /[^.]+$/.exec(coreJsData_default && coreJsData_default.keys && coreJsData_default.keys.IE_PROTO || "");
+  return uid ? "Symbol(src)_1." + uid : "";
+}();
+function isMasked(func) {
+  return !!maskSrcKey && maskSrcKey in func;
+}
+var isMasked_default = isMasked;
+
+// node_modules/lodash-es/_toSource.js
+var funcProto = Function.prototype;
+var funcToString = funcProto.toString;
+function toSource(func) {
+  if (func != null) {
+    try {
+      return funcToString.call(func);
+    } catch (e) {
+    }
+    try {
+      return func + "";
+    } catch (e) {
+    }
+  }
+  return "";
+}
+var toSource_default = toSource;
+
+// node_modules/lodash-es/_baseIsNative.js
+var reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+var reIsHostCtor = /^\[object .+?Constructor\]$/;
+var funcProto2 = Function.prototype;
+var objectProto3 = Object.prototype;
+var funcToString2 = funcProto2.toString;
+var hasOwnProperty2 = objectProto3.hasOwnProperty;
+var reIsNative = RegExp(
+  "^" + funcToString2.call(hasOwnProperty2).replace(reRegExpChar, "\\$&").replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, "$1.*?") + "$"
+);
+function baseIsNative(value) {
+  if (!isObject_default(value) || isMasked_default(value)) {
+    return false;
+  }
+  var pattern = isFunction_default(value) ? reIsNative : reIsHostCtor;
+  return pattern.test(toSource_default(value));
+}
+var baseIsNative_default = baseIsNative;
+
+// node_modules/lodash-es/_getValue.js
+function getValue(object, key) {
+  return object == null ? void 0 : object[key];
+}
+var getValue_default = getValue;
+
+// node_modules/lodash-es/_getNative.js
+function getNative(object, key) {
+  var value = getValue_default(object, key);
+  return baseIsNative_default(value) ? value : void 0;
+}
+var getNative_default = getNative;
+
+// node_modules/lodash-es/_baseCreate.js
+var objectCreate = Object.create;
+var baseCreate = function() {
+  function object() {
+  }
+  return function(proto) {
+    if (!isObject_default(proto)) {
+      return {};
+    }
+    if (objectCreate) {
+      return objectCreate(proto);
+    }
+    object.prototype = proto;
+    var result = new object();
+    object.prototype = void 0;
+    return result;
+  };
+}();
+var baseCreate_default = baseCreate;
+
+// node_modules/lodash-es/_apply.js
+function apply(func, thisArg, args) {
+  switch (args.length) {
+    case 0:
+      return func.call(thisArg);
+    case 1:
+      return func.call(thisArg, args[0]);
+    case 2:
+      return func.call(thisArg, args[0], args[1]);
+    case 3:
+      return func.call(thisArg, args[0], args[1], args[2]);
+  }
+  return func.apply(thisArg, args);
+}
+var apply_default = apply;
+
+// node_modules/lodash-es/_copyArray.js
+function copyArray(source, array) {
+  var index = -1, length = source.length;
+  array || (array = Array(length));
+  while (++index < length) {
+    array[index] = source[index];
+  }
+  return array;
+}
+var copyArray_default = copyArray;
+
+// node_modules/lodash-es/_shortOut.js
+var HOT_COUNT = 800;
+var HOT_SPAN = 16;
+var nativeNow = Date.now;
+function shortOut(func) {
+  var count = 0, lastCalled = 0;
+  return function() {
+    var stamp = nativeNow(), remaining = HOT_SPAN - (stamp - lastCalled);
+    lastCalled = stamp;
+    if (remaining > 0) {
+      if (++count >= HOT_COUNT) {
+        return arguments[0];
+      }
+    } else {
+      count = 0;
+    }
+    return func.apply(void 0, arguments);
+  };
+}
+var shortOut_default = shortOut;
+
+// node_modules/lodash-es/constant.js
+function constant(value) {
+  return function() {
+    return value;
+  };
+}
+var constant_default = constant;
+
+// node_modules/lodash-es/_defineProperty.js
+var defineProperty = function() {
+  try {
+    var func = getNative_default(Object, "defineProperty");
+    func({}, "", {});
+    return func;
+  } catch (e) {
+  }
+}();
+var defineProperty_default = defineProperty;
+
+// node_modules/lodash-es/_baseSetToString.js
+var baseSetToString = !defineProperty_default ? identity_default : function(func, string) {
+  return defineProperty_default(func, "toString", {
+    "configurable": true,
+    "enumerable": false,
+    "value": constant_default(string),
+    "writable": true
+  });
+};
+var baseSetToString_default = baseSetToString;
+
+// node_modules/lodash-es/_setToString.js
+var setToString = shortOut_default(baseSetToString_default);
+var setToString_default = setToString;
+
+// node_modules/lodash-es/_isIndex.js
+var MAX_SAFE_INTEGER = 9007199254740991;
+var reIsUint = /^(?:0|[1-9]\d*)$/;
+function isIndex(value, length) {
+  var type = typeof value;
+  length = length == null ? MAX_SAFE_INTEGER : length;
+  return !!length && (type == "number" || type != "symbol" && reIsUint.test(value)) && (value > -1 && value % 1 == 0 && value < length);
+}
+var isIndex_default = isIndex;
+
+// node_modules/lodash-es/_baseAssignValue.js
+function baseAssignValue(object, key, value) {
+  if (key == "__proto__" && defineProperty_default) {
+    defineProperty_default(object, key, {
+      "configurable": true,
+      "enumerable": true,
+      "value": value,
+      "writable": true
+    });
+  } else {
+    object[key] = value;
+  }
+}
+var baseAssignValue_default = baseAssignValue;
+
+// node_modules/lodash-es/eq.js
+function eq(value, other) {
+  return value === other || value !== value && other !== other;
+}
+var eq_default = eq;
+
+// node_modules/lodash-es/_assignValue.js
+var objectProto4 = Object.prototype;
+var hasOwnProperty3 = objectProto4.hasOwnProperty;
+function assignValue(object, key, value) {
+  var objValue = object[key];
+  if (!(hasOwnProperty3.call(object, key) && eq_default(objValue, value)) || value === void 0 && !(key in object)) {
+    baseAssignValue_default(object, key, value);
+  }
+}
+var assignValue_default = assignValue;
+
+// node_modules/lodash-es/_copyObject.js
+function copyObject(source, props, object, customizer) {
+  var isNew = !object;
+  object || (object = {});
+  var index = -1, length = props.length;
+  while (++index < length) {
+    var key = props[index];
+    var newValue = customizer ? customizer(object[key], source[key], key, object, source) : void 0;
+    if (newValue === void 0) {
+      newValue = source[key];
+    }
+    if (isNew) {
+      baseAssignValue_default(object, key, newValue);
+    } else {
+      assignValue_default(object, key, newValue);
+    }
+  }
+  return object;
+}
+var copyObject_default = copyObject;
+
+// node_modules/lodash-es/_overRest.js
+var nativeMax = Math.max;
+function overRest(func, start, transform) {
+  start = nativeMax(start === void 0 ? func.length - 1 : start, 0);
+  return function() {
+    var args = arguments, index = -1, length = nativeMax(args.length - start, 0), array = Array(length);
+    while (++index < length) {
+      array[index] = args[start + index];
+    }
+    index = -1;
+    var otherArgs = Array(start + 1);
+    while (++index < start) {
+      otherArgs[index] = args[index];
+    }
+    otherArgs[start] = transform(array);
+    return apply_default(func, this, otherArgs);
+  };
+}
+var overRest_default = overRest;
+
+// node_modules/lodash-es/_baseRest.js
+function baseRest(func, start) {
+  return setToString_default(overRest_default(func, start, identity_default), func + "");
+}
+var baseRest_default = baseRest;
+
+// node_modules/lodash-es/isLength.js
+var MAX_SAFE_INTEGER2 = 9007199254740991;
+function isLength(value) {
+  return typeof value == "number" && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER2;
+}
+var isLength_default = isLength;
+
+// node_modules/lodash-es/isArrayLike.js
+function isArrayLike(value) {
+  return value != null && isLength_default(value.length) && !isFunction_default(value);
+}
+var isArrayLike_default = isArrayLike;
+
+// node_modules/lodash-es/_isIterateeCall.js
+function isIterateeCall(value, index, object) {
+  if (!isObject_default(object)) {
+    return false;
+  }
+  var type = typeof index;
+  if (type == "number" ? isArrayLike_default(object) && isIndex_default(index, object.length) : type == "string" && index in object) {
+    return eq_default(object[index], value);
+  }
+  return false;
+}
+var isIterateeCall_default = isIterateeCall;
+
+// node_modules/lodash-es/_createAssigner.js
+function createAssigner(assigner) {
+  return baseRest_default(function(object, sources) {
+    var index = -1, length = sources.length, customizer = length > 1 ? sources[length - 1] : void 0, guard = length > 2 ? sources[2] : void 0;
+    customizer = assigner.length > 3 && typeof customizer == "function" ? (length--, customizer) : void 0;
+    if (guard && isIterateeCall_default(sources[0], sources[1], guard)) {
+      customizer = length < 3 ? void 0 : customizer;
+      length = 1;
+    }
+    object = Object(object);
+    while (++index < length) {
+      var source = sources[index];
+      if (source) {
+        assigner(object, source, index, customizer);
+      }
+    }
+    return object;
+  });
+}
+var createAssigner_default = createAssigner;
+
+// node_modules/lodash-es/_isPrototype.js
+var objectProto5 = Object.prototype;
+function isPrototype(value) {
+  var Ctor = value && value.constructor, proto = typeof Ctor == "function" && Ctor.prototype || objectProto5;
+  return value === proto;
+}
+var isPrototype_default = isPrototype;
+
+// node_modules/lodash-es/_baseTimes.js
+function baseTimes(n, iteratee) {
+  var index = -1, result = Array(n);
+  while (++index < n) {
+    result[index] = iteratee(index);
+  }
+  return result;
+}
+var baseTimes_default = baseTimes;
+
+// node_modules/lodash-es/_baseIsArguments.js
+var argsTag = "[object Arguments]";
+function baseIsArguments(value) {
+  return isObjectLike_default(value) && baseGetTag_default(value) == argsTag;
+}
+var baseIsArguments_default = baseIsArguments;
+
+// node_modules/lodash-es/isArguments.js
+var objectProto6 = Object.prototype;
+var hasOwnProperty4 = objectProto6.hasOwnProperty;
+var propertyIsEnumerable = objectProto6.propertyIsEnumerable;
+var isArguments = baseIsArguments_default(function() {
+  return arguments;
+}()) ? baseIsArguments_default : function(value) {
+  return isObjectLike_default(value) && hasOwnProperty4.call(value, "callee") && !propertyIsEnumerable.call(value, "callee");
+};
+var isArguments_default = isArguments;
+
+// node_modules/lodash-es/stubFalse.js
+function stubFalse() {
+  return false;
+}
+var stubFalse_default = stubFalse;
+
+// node_modules/lodash-es/isBuffer.js
+var freeExports = typeof exports == "object" && exports && !exports.nodeType && exports;
+var freeModule = freeExports && typeof module == "object" && module && !module.nodeType && module;
+var moduleExports = freeModule && freeModule.exports === freeExports;
+var Buffer2 = moduleExports ? root_default.Buffer : void 0;
+var nativeIsBuffer = Buffer2 ? Buffer2.isBuffer : void 0;
+var isBuffer = nativeIsBuffer || stubFalse_default;
+var isBuffer_default = isBuffer;
+
+// node_modules/lodash-es/_baseIsTypedArray.js
+var argsTag2 = "[object Arguments]";
+var arrayTag = "[object Array]";
+var boolTag = "[object Boolean]";
+var dateTag = "[object Date]";
+var errorTag = "[object Error]";
+var funcTag2 = "[object Function]";
+var mapTag = "[object Map]";
+var numberTag = "[object Number]";
+var objectTag = "[object Object]";
+var regexpTag = "[object RegExp]";
+var setTag = "[object Set]";
+var stringTag = "[object String]";
+var weakMapTag = "[object WeakMap]";
+var arrayBufferTag = "[object ArrayBuffer]";
+var dataViewTag = "[object DataView]";
+var float32Tag = "[object Float32Array]";
+var float64Tag = "[object Float64Array]";
+var int8Tag = "[object Int8Array]";
+var int16Tag = "[object Int16Array]";
+var int32Tag = "[object Int32Array]";
+var uint8Tag = "[object Uint8Array]";
+var uint8ClampedTag = "[object Uint8ClampedArray]";
+var uint16Tag = "[object Uint16Array]";
+var uint32Tag = "[object Uint32Array]";
+var typedArrayTags = {};
+typedArrayTags[float32Tag] = typedArrayTags[float64Tag] = typedArrayTags[int8Tag] = typedArrayTags[int16Tag] = typedArrayTags[int32Tag] = typedArrayTags[uint8Tag] = typedArrayTags[uint8ClampedTag] = typedArrayTags[uint16Tag] = typedArrayTags[uint32Tag] = true;
+typedArrayTags[argsTag2] = typedArrayTags[arrayTag] = typedArrayTags[arrayBufferTag] = typedArrayTags[boolTag] = typedArrayTags[dataViewTag] = typedArrayTags[dateTag] = typedArrayTags[errorTag] = typedArrayTags[funcTag2] = typedArrayTags[mapTag] = typedArrayTags[numberTag] = typedArrayTags[objectTag] = typedArrayTags[regexpTag] = typedArrayTags[setTag] = typedArrayTags[stringTag] = typedArrayTags[weakMapTag] = false;
+function baseIsTypedArray(value) {
+  return isObjectLike_default(value) && isLength_default(value.length) && !!typedArrayTags[baseGetTag_default(value)];
+}
+var baseIsTypedArray_default = baseIsTypedArray;
+
+// node_modules/lodash-es/_baseUnary.js
+function baseUnary(func) {
+  return function(value) {
+    return func(value);
+  };
+}
+var baseUnary_default = baseUnary;
+
+// node_modules/lodash-es/_nodeUtil.js
+var freeExports2 = typeof exports == "object" && exports && !exports.nodeType && exports;
+var freeModule2 = freeExports2 && typeof module == "object" && module && !module.nodeType && module;
+var moduleExports2 = freeModule2 && freeModule2.exports === freeExports2;
+var freeProcess = moduleExports2 && freeGlobal_default.process;
+var nodeUtil = function() {
+  try {
+    var types = freeModule2 && freeModule2.require && freeModule2.require("util").types;
+    if (types) {
+      return types;
+    }
+    return freeProcess && freeProcess.binding && freeProcess.binding("util");
+  } catch (e) {
+  }
+}();
+var nodeUtil_default = nodeUtil;
+
+// node_modules/lodash-es/isTypedArray.js
+var nodeIsTypedArray = nodeUtil_default && nodeUtil_default.isTypedArray;
+var isTypedArray = nodeIsTypedArray ? baseUnary_default(nodeIsTypedArray) : baseIsTypedArray_default;
+var isTypedArray_default = isTypedArray;
+
+// node_modules/lodash-es/_arrayLikeKeys.js
+var objectProto7 = Object.prototype;
+var hasOwnProperty5 = objectProto7.hasOwnProperty;
+function arrayLikeKeys(value, inherited) {
+  var isArr = isArray_default(value), isArg = !isArr && isArguments_default(value), isBuff = !isArr && !isArg && isBuffer_default(value), isType = !isArr && !isArg && !isBuff && isTypedArray_default(value), skipIndexes = isArr || isArg || isBuff || isType, result = skipIndexes ? baseTimes_default(value.length, String) : [], length = result.length;
+  for (var key in value) {
+    if ((inherited || hasOwnProperty5.call(value, key)) && !(skipIndexes && // Safari 9 has enumerable `arguments.length` in strict mode.
+    (key == "length" || // Node.js 0.10 has enumerable non-index properties on buffers.
+    isBuff && (key == "offset" || key == "parent") || // PhantomJS 2 has enumerable non-index properties on typed arrays.
+    isType && (key == "buffer" || key == "byteLength" || key == "byteOffset") || // Skip index properties.
+    isIndex_default(key, length)))) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+var arrayLikeKeys_default = arrayLikeKeys;
+
+// node_modules/lodash-es/_overArg.js
+function overArg(func, transform) {
+  return function(arg) {
+    return func(transform(arg));
+  };
+}
+var overArg_default = overArg;
+
+// node_modules/lodash-es/_nativeKeysIn.js
+function nativeKeysIn(object) {
+  var result = [];
+  if (object != null) {
+    for (var key in Object(object)) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+var nativeKeysIn_default = nativeKeysIn;
+
+// node_modules/lodash-es/_baseKeysIn.js
+var objectProto8 = Object.prototype;
+var hasOwnProperty6 = objectProto8.hasOwnProperty;
+function baseKeysIn(object) {
+  if (!isObject_default(object)) {
+    return nativeKeysIn_default(object);
+  }
+  var isProto = isPrototype_default(object), result = [];
+  for (var key in object) {
+    if (!(key == "constructor" && (isProto || !hasOwnProperty6.call(object, key)))) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+var baseKeysIn_default = baseKeysIn;
+
+// node_modules/lodash-es/keysIn.js
+function keysIn(object) {
+  return isArrayLike_default(object) ? arrayLikeKeys_default(object, true) : baseKeysIn_default(object);
+}
+var keysIn_default = keysIn;
+
+// node_modules/lodash-es/_nativeCreate.js
+var nativeCreate = getNative_default(Object, "create");
+var nativeCreate_default = nativeCreate;
+
+// node_modules/lodash-es/_hashClear.js
+function hashClear() {
+  this.__data__ = nativeCreate_default ? nativeCreate_default(null) : {};
+  this.size = 0;
+}
+var hashClear_default = hashClear;
+
+// node_modules/lodash-es/_hashDelete.js
+function hashDelete(key) {
+  var result = this.has(key) && delete this.__data__[key];
+  this.size -= result ? 1 : 0;
+  return result;
+}
+var hashDelete_default = hashDelete;
+
+// node_modules/lodash-es/_hashGet.js
+var HASH_UNDEFINED = "__lodash_hash_undefined__";
+var objectProto9 = Object.prototype;
+var hasOwnProperty7 = objectProto9.hasOwnProperty;
+function hashGet(key) {
+  var data = this.__data__;
+  if (nativeCreate_default) {
+    var result = data[key];
+    return result === HASH_UNDEFINED ? void 0 : result;
+  }
+  return hasOwnProperty7.call(data, key) ? data[key] : void 0;
+}
+var hashGet_default = hashGet;
+
+// node_modules/lodash-es/_hashHas.js
+var objectProto10 = Object.prototype;
+var hasOwnProperty8 = objectProto10.hasOwnProperty;
+function hashHas(key) {
+  var data = this.__data__;
+  return nativeCreate_default ? data[key] !== void 0 : hasOwnProperty8.call(data, key);
+}
+var hashHas_default = hashHas;
+
+// node_modules/lodash-es/_hashSet.js
+var HASH_UNDEFINED2 = "__lodash_hash_undefined__";
+function hashSet(key, value) {
+  var data = this.__data__;
+  this.size += this.has(key) ? 0 : 1;
+  data[key] = nativeCreate_default && value === void 0 ? HASH_UNDEFINED2 : value;
+  return this;
+}
+var hashSet_default = hashSet;
+
+// node_modules/lodash-es/_Hash.js
+function Hash(entries) {
+  var index = -1, length = entries == null ? 0 : entries.length;
+  this.clear();
+  while (++index < length) {
+    var entry = entries[index];
+    this.set(entry[0], entry[1]);
+  }
+}
+Hash.prototype.clear = hashClear_default;
+Hash.prototype["delete"] = hashDelete_default;
+Hash.prototype.get = hashGet_default;
+Hash.prototype.has = hashHas_default;
+Hash.prototype.set = hashSet_default;
+var Hash_default = Hash;
+
+// node_modules/lodash-es/_listCacheClear.js
+function listCacheClear() {
+  this.__data__ = [];
+  this.size = 0;
+}
+var listCacheClear_default = listCacheClear;
+
+// node_modules/lodash-es/_assocIndexOf.js
+function assocIndexOf(array, key) {
+  var length = array.length;
+  while (length--) {
+    if (eq_default(array[length][0], key)) {
+      return length;
+    }
+  }
+  return -1;
+}
+var assocIndexOf_default = assocIndexOf;
+
+// node_modules/lodash-es/_listCacheDelete.js
+var arrayProto = Array.prototype;
+var splice = arrayProto.splice;
+function listCacheDelete(key) {
+  var data = this.__data__, index = assocIndexOf_default(data, key);
+  if (index < 0) {
+    return false;
+  }
+  var lastIndex = data.length - 1;
+  if (index == lastIndex) {
+    data.pop();
+  } else {
+    splice.call(data, index, 1);
+  }
+  --this.size;
+  return true;
+}
+var listCacheDelete_default = listCacheDelete;
+
+// node_modules/lodash-es/_listCacheGet.js
+function listCacheGet(key) {
+  var data = this.__data__, index = assocIndexOf_default(data, key);
+  return index < 0 ? void 0 : data[index][1];
+}
+var listCacheGet_default = listCacheGet;
+
+// node_modules/lodash-es/_listCacheHas.js
+function listCacheHas(key) {
+  return assocIndexOf_default(this.__data__, key) > -1;
+}
+var listCacheHas_default = listCacheHas;
+
+// node_modules/lodash-es/_listCacheSet.js
+function listCacheSet(key, value) {
+  var data = this.__data__, index = assocIndexOf_default(data, key);
+  if (index < 0) {
+    ++this.size;
+    data.push([key, value]);
+  } else {
+    data[index][1] = value;
+  }
+  return this;
+}
+var listCacheSet_default = listCacheSet;
+
+// node_modules/lodash-es/_ListCache.js
+function ListCache(entries) {
+  var index = -1, length = entries == null ? 0 : entries.length;
+  this.clear();
+  while (++index < length) {
+    var entry = entries[index];
+    this.set(entry[0], entry[1]);
+  }
+}
+ListCache.prototype.clear = listCacheClear_default;
+ListCache.prototype["delete"] = listCacheDelete_default;
+ListCache.prototype.get = listCacheGet_default;
+ListCache.prototype.has = listCacheHas_default;
+ListCache.prototype.set = listCacheSet_default;
+var ListCache_default = ListCache;
+
+// node_modules/lodash-es/_Map.js
+var Map = getNative_default(root_default, "Map");
+var Map_default = Map;
+
+// node_modules/lodash-es/_mapCacheClear.js
+function mapCacheClear() {
+  this.size = 0;
+  this.__data__ = {
+    "hash": new Hash_default(),
+    "map": new (Map_default || ListCache_default)(),
+    "string": new Hash_default()
+  };
+}
+var mapCacheClear_default = mapCacheClear;
+
+// node_modules/lodash-es/_isKeyable.js
+function isKeyable(value) {
+  var type = typeof value;
+  return type == "string" || type == "number" || type == "symbol" || type == "boolean" ? value !== "__proto__" : value === null;
+}
+var isKeyable_default = isKeyable;
+
+// node_modules/lodash-es/_getMapData.js
+function getMapData(map, key) {
+  var data = map.__data__;
+  return isKeyable_default(key) ? data[typeof key == "string" ? "string" : "hash"] : data.map;
+}
+var getMapData_default = getMapData;
+
+// node_modules/lodash-es/_mapCacheDelete.js
+function mapCacheDelete(key) {
+  var result = getMapData_default(this, key)["delete"](key);
+  this.size -= result ? 1 : 0;
+  return result;
+}
+var mapCacheDelete_default = mapCacheDelete;
+
+// node_modules/lodash-es/_mapCacheGet.js
+function mapCacheGet(key) {
+  return getMapData_default(this, key).get(key);
+}
+var mapCacheGet_default = mapCacheGet;
+
+// node_modules/lodash-es/_mapCacheHas.js
+function mapCacheHas(key) {
+  return getMapData_default(this, key).has(key);
+}
+var mapCacheHas_default = mapCacheHas;
+
+// node_modules/lodash-es/_mapCacheSet.js
+function mapCacheSet(key, value) {
+  var data = getMapData_default(this, key), size = data.size;
+  data.set(key, value);
+  this.size += data.size == size ? 0 : 1;
+  return this;
+}
+var mapCacheSet_default = mapCacheSet;
+
+// node_modules/lodash-es/_MapCache.js
+function MapCache(entries) {
+  var index = -1, length = entries == null ? 0 : entries.length;
+  this.clear();
+  while (++index < length) {
+    var entry = entries[index];
+    this.set(entry[0], entry[1]);
+  }
+}
+MapCache.prototype.clear = mapCacheClear_default;
+MapCache.prototype["delete"] = mapCacheDelete_default;
+MapCache.prototype.get = mapCacheGet_default;
+MapCache.prototype.has = mapCacheHas_default;
+MapCache.prototype.set = mapCacheSet_default;
+var MapCache_default = MapCache;
+
+// node_modules/lodash-es/toString.js
+function toString(value) {
+  return value == null ? "" : baseToString_default(value);
+}
+var toString_default = toString;
+
+// node_modules/lodash-es/_getPrototype.js
+var getPrototype = overArg_default(Object.getPrototypeOf, Object);
+var getPrototype_default = getPrototype;
+
+// node_modules/lodash-es/isPlainObject.js
+var objectTag2 = "[object Object]";
+var funcProto3 = Function.prototype;
+var objectProto11 = Object.prototype;
+var funcToString3 = funcProto3.toString;
+var hasOwnProperty9 = objectProto11.hasOwnProperty;
+var objectCtorString = funcToString3.call(Object);
+function isPlainObject(value) {
+  if (!isObjectLike_default(value) || baseGetTag_default(value) != objectTag2) {
+    return false;
+  }
+  var proto = getPrototype_default(value);
+  if (proto === null) {
+    return true;
+  }
+  var Ctor = hasOwnProperty9.call(proto, "constructor") && proto.constructor;
+  return typeof Ctor == "function" && Ctor instanceof Ctor && funcToString3.call(Ctor) == objectCtorString;
+}
+var isPlainObject_default = isPlainObject;
+
+// node_modules/lodash-es/_baseSlice.js
+function baseSlice(array, start, end) {
+  var index = -1, length = array.length;
+  if (start < 0) {
+    start = -start > length ? 0 : length + start;
+  }
+  end = end > length ? length : end;
+  if (end < 0) {
+    end += length;
+  }
+  length = start > end ? 0 : end - start >>> 0;
+  start >>>= 0;
+  var result = Array(length);
+  while (++index < length) {
+    result[index] = array[index + start];
+  }
+  return result;
+}
+var baseSlice_default = baseSlice;
+
+// node_modules/lodash-es/_castSlice.js
+function castSlice(array, start, end) {
+  var length = array.length;
+  end = end === void 0 ? length : end;
+  return !start && end >= length ? array : baseSlice_default(array, start, end);
+}
+var castSlice_default = castSlice;
+
+// node_modules/lodash-es/_hasUnicode.js
+var rsAstralRange = "\\ud800-\\udfff";
+var rsComboMarksRange = "\\u0300-\\u036f";
+var reComboHalfMarksRange = "\\ufe20-\\ufe2f";
+var rsComboSymbolsRange = "\\u20d0-\\u20ff";
+var rsComboRange = rsComboMarksRange + reComboHalfMarksRange + rsComboSymbolsRange;
+var rsVarRange = "\\ufe0e\\ufe0f";
+var rsZWJ = "\\u200d";
+var reHasUnicode = RegExp("[" + rsZWJ + rsAstralRange + rsComboRange + rsVarRange + "]");
+function hasUnicode(string) {
+  return reHasUnicode.test(string);
+}
+var hasUnicode_default = hasUnicode;
+
+// node_modules/lodash-es/_asciiToArray.js
+function asciiToArray(string) {
+  return string.split("");
+}
+var asciiToArray_default = asciiToArray;
+
+// node_modules/lodash-es/_unicodeToArray.js
+var rsAstralRange2 = "\\ud800-\\udfff";
+var rsComboMarksRange2 = "\\u0300-\\u036f";
+var reComboHalfMarksRange2 = "\\ufe20-\\ufe2f";
+var rsComboSymbolsRange2 = "\\u20d0-\\u20ff";
+var rsComboRange2 = rsComboMarksRange2 + reComboHalfMarksRange2 + rsComboSymbolsRange2;
+var rsVarRange2 = "\\ufe0e\\ufe0f";
+var rsAstral = "[" + rsAstralRange2 + "]";
+var rsCombo = "[" + rsComboRange2 + "]";
+var rsFitz = "\\ud83c[\\udffb-\\udfff]";
+var rsModifier = "(?:" + rsCombo + "|" + rsFitz + ")";
+var rsNonAstral = "[^" + rsAstralRange2 + "]";
+var rsRegional = "(?:\\ud83c[\\udde6-\\uddff]){2}";
+var rsSurrPair = "[\\ud800-\\udbff][\\udc00-\\udfff]";
+var rsZWJ2 = "\\u200d";
+var reOptMod = rsModifier + "?";
+var rsOptVar = "[" + rsVarRange2 + "]?";
+var rsOptJoin = "(?:" + rsZWJ2 + "(?:" + [rsNonAstral, rsRegional, rsSurrPair].join("|") + ")" + rsOptVar + reOptMod + ")*";
+var rsSeq = rsOptVar + reOptMod + rsOptJoin;
+var rsSymbol = "(?:" + [rsNonAstral + rsCombo + "?", rsCombo, rsRegional, rsSurrPair, rsAstral].join("|") + ")";
+var reUnicode = RegExp(rsFitz + "(?=" + rsFitz + ")|" + rsSymbol + rsSeq, "g");
+function unicodeToArray(string) {
+  return string.match(reUnicode) || [];
+}
+var unicodeToArray_default = unicodeToArray;
+
+// node_modules/lodash-es/_stringToArray.js
+function stringToArray(string) {
+  return hasUnicode_default(string) ? unicodeToArray_default(string) : asciiToArray_default(string);
+}
+var stringToArray_default = stringToArray;
+
+// node_modules/lodash-es/_createCaseFirst.js
+function createCaseFirst(methodName) {
+  return function(string) {
+    string = toString_default(string);
+    var strSymbols = hasUnicode_default(string) ? stringToArray_default(string) : void 0;
+    var chr = strSymbols ? strSymbols[0] : string.charAt(0);
+    var trailing = strSymbols ? castSlice_default(strSymbols, 1).join("") : string.slice(1);
+    return chr[methodName]() + trailing;
+  };
+}
+var createCaseFirst_default = createCaseFirst;
+
+// node_modules/lodash-es/upperFirst.js
+var upperFirst = createCaseFirst_default("toUpperCase");
+var upperFirst_default = upperFirst;
+
+// node_modules/lodash-es/capitalize.js
+function capitalize(string) {
+  return upperFirst_default(toString_default(string).toLowerCase());
+}
+var capitalize_default = capitalize;
+
+// node_modules/lodash-es/_arrayReduce.js
+function arrayReduce(array, iteratee, accumulator, initAccum) {
+  var index = -1, length = array == null ? 0 : array.length;
+  if (initAccum && length) {
+    accumulator = array[++index];
+  }
+  while (++index < length) {
+    accumulator = iteratee(accumulator, array[index], index, array);
+  }
+  return accumulator;
+}
+var arrayReduce_default = arrayReduce;
+
+// node_modules/lodash-es/_basePropertyOf.js
+function basePropertyOf(object) {
+  return function(key) {
+    return object == null ? void 0 : object[key];
+  };
+}
+var basePropertyOf_default = basePropertyOf;
+
+// node_modules/lodash-es/_deburrLetter.js
+var deburredLetters = {
+  // Latin-1 Supplement block.
+  "\xC0": "A",
+  "\xC1": "A",
+  "\xC2": "A",
+  "\xC3": "A",
+  "\xC4": "A",
+  "\xC5": "A",
+  "\xE0": "a",
+  "\xE1": "a",
+  "\xE2": "a",
+  "\xE3": "a",
+  "\xE4": "a",
+  "\xE5": "a",
+  "\xC7": "C",
+  "\xE7": "c",
+  "\xD0": "D",
+  "\xF0": "d",
+  "\xC8": "E",
+  "\xC9": "E",
+  "\xCA": "E",
+  "\xCB": "E",
+  "\xE8": "e",
+  "\xE9": "e",
+  "\xEA": "e",
+  "\xEB": "e",
+  "\xCC": "I",
+  "\xCD": "I",
+  "\xCE": "I",
+  "\xCF": "I",
+  "\xEC": "i",
+  "\xED": "i",
+  "\xEE": "i",
+  "\xEF": "i",
+  "\xD1": "N",
+  "\xF1": "n",
+  "\xD2": "O",
+  "\xD3": "O",
+  "\xD4": "O",
+  "\xD5": "O",
+  "\xD6": "O",
+  "\xD8": "O",
+  "\xF2": "o",
+  "\xF3": "o",
+  "\xF4": "o",
+  "\xF5": "o",
+  "\xF6": "o",
+  "\xF8": "o",
+  "\xD9": "U",
+  "\xDA": "U",
+  "\xDB": "U",
+  "\xDC": "U",
+  "\xF9": "u",
+  "\xFA": "u",
+  "\xFB": "u",
+  "\xFC": "u",
+  "\xDD": "Y",
+  "\xFD": "y",
+  "\xFF": "y",
+  "\xC6": "Ae",
+  "\xE6": "ae",
+  "\xDE": "Th",
+  "\xFE": "th",
+  "\xDF": "ss",
+  // Latin Extended-A block.
+  "\u0100": "A",
+  "\u0102": "A",
+  "\u0104": "A",
+  "\u0101": "a",
+  "\u0103": "a",
+  "\u0105": "a",
+  "\u0106": "C",
+  "\u0108": "C",
+  "\u010A": "C",
+  "\u010C": "C",
+  "\u0107": "c",
+  "\u0109": "c",
+  "\u010B": "c",
+  "\u010D": "c",
+  "\u010E": "D",
+  "\u0110": "D",
+  "\u010F": "d",
+  "\u0111": "d",
+  "\u0112": "E",
+  "\u0114": "E",
+  "\u0116": "E",
+  "\u0118": "E",
+  "\u011A": "E",
+  "\u0113": "e",
+  "\u0115": "e",
+  "\u0117": "e",
+  "\u0119": "e",
+  "\u011B": "e",
+  "\u011C": "G",
+  "\u011E": "G",
+  "\u0120": "G",
+  "\u0122": "G",
+  "\u011D": "g",
+  "\u011F": "g",
+  "\u0121": "g",
+  "\u0123": "g",
+  "\u0124": "H",
+  "\u0126": "H",
+  "\u0125": "h",
+  "\u0127": "h",
+  "\u0128": "I",
+  "\u012A": "I",
+  "\u012C": "I",
+  "\u012E": "I",
+  "\u0130": "I",
+  "\u0129": "i",
+  "\u012B": "i",
+  "\u012D": "i",
+  "\u012F": "i",
+  "\u0131": "i",
+  "\u0134": "J",
+  "\u0135": "j",
+  "\u0136": "K",
+  "\u0137": "k",
+  "\u0138": "k",
+  "\u0139": "L",
+  "\u013B": "L",
+  "\u013D": "L",
+  "\u013F": "L",
+  "\u0141": "L",
+  "\u013A": "l",
+  "\u013C": "l",
+  "\u013E": "l",
+  "\u0140": "l",
+  "\u0142": "l",
+  "\u0143": "N",
+  "\u0145": "N",
+  "\u0147": "N",
+  "\u014A": "N",
+  "\u0144": "n",
+  "\u0146": "n",
+  "\u0148": "n",
+  "\u014B": "n",
+  "\u014C": "O",
+  "\u014E": "O",
+  "\u0150": "O",
+  "\u014D": "o",
+  "\u014F": "o",
+  "\u0151": "o",
+  "\u0154": "R",
+  "\u0156": "R",
+  "\u0158": "R",
+  "\u0155": "r",
+  "\u0157": "r",
+  "\u0159": "r",
+  "\u015A": "S",
+  "\u015C": "S",
+  "\u015E": "S",
+  "\u0160": "S",
+  "\u015B": "s",
+  "\u015D": "s",
+  "\u015F": "s",
+  "\u0161": "s",
+  "\u0162": "T",
+  "\u0164": "T",
+  "\u0166": "T",
+  "\u0163": "t",
+  "\u0165": "t",
+  "\u0167": "t",
+  "\u0168": "U",
+  "\u016A": "U",
+  "\u016C": "U",
+  "\u016E": "U",
+  "\u0170": "U",
+  "\u0172": "U",
+  "\u0169": "u",
+  "\u016B": "u",
+  "\u016D": "u",
+  "\u016F": "u",
+  "\u0171": "u",
+  "\u0173": "u",
+  "\u0174": "W",
+  "\u0175": "w",
+  "\u0176": "Y",
+  "\u0177": "y",
+  "\u0178": "Y",
+  "\u0179": "Z",
+  "\u017B": "Z",
+  "\u017D": "Z",
+  "\u017A": "z",
+  "\u017C": "z",
+  "\u017E": "z",
+  "\u0132": "IJ",
+  "\u0133": "ij",
+  "\u0152": "Oe",
+  "\u0153": "oe",
+  "\u0149": "'n",
+  "\u017F": "s"
+};
+var deburrLetter = basePropertyOf_default(deburredLetters);
+var deburrLetter_default = deburrLetter;
+
+// node_modules/lodash-es/deburr.js
+var reLatin = /[\xc0-\xd6\xd8-\xf6\xf8-\xff\u0100-\u017f]/g;
+var rsComboMarksRange3 = "\\u0300-\\u036f";
+var reComboHalfMarksRange3 = "\\ufe20-\\ufe2f";
+var rsComboSymbolsRange3 = "\\u20d0-\\u20ff";
+var rsComboRange3 = rsComboMarksRange3 + reComboHalfMarksRange3 + rsComboSymbolsRange3;
+var rsCombo2 = "[" + rsComboRange3 + "]";
+var reComboMark = RegExp(rsCombo2, "g");
+function deburr(string) {
+  string = toString_default(string);
+  return string && string.replace(reLatin, deburrLetter_default).replace(reComboMark, "");
+}
+var deburr_default = deburr;
+
+// node_modules/lodash-es/_asciiWords.js
+var reAsciiWord = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g;
+function asciiWords(string) {
+  return string.match(reAsciiWord) || [];
+}
+var asciiWords_default = asciiWords;
+
+// node_modules/lodash-es/_hasUnicodeWord.js
+var reHasUnicodeWord = /[a-z][A-Z]|[A-Z]{2}[a-z]|[0-9][a-zA-Z]|[a-zA-Z][0-9]|[^a-zA-Z0-9 ]/;
+function hasUnicodeWord(string) {
+  return reHasUnicodeWord.test(string);
+}
+var hasUnicodeWord_default = hasUnicodeWord;
+
+// node_modules/lodash-es/_unicodeWords.js
+var rsAstralRange3 = "\\ud800-\\udfff";
+var rsComboMarksRange4 = "\\u0300-\\u036f";
+var reComboHalfMarksRange4 = "\\ufe20-\\ufe2f";
+var rsComboSymbolsRange4 = "\\u20d0-\\u20ff";
+var rsComboRange4 = rsComboMarksRange4 + reComboHalfMarksRange4 + rsComboSymbolsRange4;
+var rsDingbatRange = "\\u2700-\\u27bf";
+var rsLowerRange = "a-z\\xdf-\\xf6\\xf8-\\xff";
+var rsMathOpRange = "\\xac\\xb1\\xd7\\xf7";
+var rsNonCharRange = "\\x00-\\x2f\\x3a-\\x40\\x5b-\\x60\\x7b-\\xbf";
+var rsPunctuationRange = "\\u2000-\\u206f";
+var rsSpaceRange = " \\t\\x0b\\f\\xa0\\ufeff\\n\\r\\u2028\\u2029\\u1680\\u180e\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a\\u202f\\u205f\\u3000";
+var rsUpperRange = "A-Z\\xc0-\\xd6\\xd8-\\xde";
+var rsVarRange3 = "\\ufe0e\\ufe0f";
+var rsBreakRange = rsMathOpRange + rsNonCharRange + rsPunctuationRange + rsSpaceRange;
+var rsApos = "['\u2019]";
+var rsBreak = "[" + rsBreakRange + "]";
+var rsCombo3 = "[" + rsComboRange4 + "]";
+var rsDigits = "\\d+";
+var rsDingbat = "[" + rsDingbatRange + "]";
+var rsLower = "[" + rsLowerRange + "]";
+var rsMisc = "[^" + rsAstralRange3 + rsBreakRange + rsDigits + rsDingbatRange + rsLowerRange + rsUpperRange + "]";
+var rsFitz2 = "\\ud83c[\\udffb-\\udfff]";
+var rsModifier2 = "(?:" + rsCombo3 + "|" + rsFitz2 + ")";
+var rsNonAstral2 = "[^" + rsAstralRange3 + "]";
+var rsRegional2 = "(?:\\ud83c[\\udde6-\\uddff]){2}";
+var rsSurrPair2 = "[\\ud800-\\udbff][\\udc00-\\udfff]";
+var rsUpper = "[" + rsUpperRange + "]";
+var rsZWJ3 = "\\u200d";
+var rsMiscLower = "(?:" + rsLower + "|" + rsMisc + ")";
+var rsMiscUpper = "(?:" + rsUpper + "|" + rsMisc + ")";
+var rsOptContrLower = "(?:" + rsApos + "(?:d|ll|m|re|s|t|ve))?";
+var rsOptContrUpper = "(?:" + rsApos + "(?:D|LL|M|RE|S|T|VE))?";
+var reOptMod2 = rsModifier2 + "?";
+var rsOptVar2 = "[" + rsVarRange3 + "]?";
+var rsOptJoin2 = "(?:" + rsZWJ3 + "(?:" + [rsNonAstral2, rsRegional2, rsSurrPair2].join("|") + ")" + rsOptVar2 + reOptMod2 + ")*";
+var rsOrdLower = "\\d*(?:1st|2nd|3rd|(?![123])\\dth)(?=\\b|[A-Z_])";
+var rsOrdUpper = "\\d*(?:1ST|2ND|3RD|(?![123])\\dTH)(?=\\b|[a-z_])";
+var rsSeq2 = rsOptVar2 + reOptMod2 + rsOptJoin2;
+var rsEmoji = "(?:" + [rsDingbat, rsRegional2, rsSurrPair2].join("|") + ")" + rsSeq2;
+var reUnicodeWord = RegExp([
+  rsUpper + "?" + rsLower + "+" + rsOptContrLower + "(?=" + [rsBreak, rsUpper, "$"].join("|") + ")",
+  rsMiscUpper + "+" + rsOptContrUpper + "(?=" + [rsBreak, rsUpper + rsMiscLower, "$"].join("|") + ")",
+  rsUpper + "?" + rsMiscLower + "+" + rsOptContrLower,
+  rsUpper + "+" + rsOptContrUpper,
+  rsOrdUpper,
+  rsOrdLower,
+  rsDigits,
+  rsEmoji
+].join("|"), "g");
+function unicodeWords(string) {
+  return string.match(reUnicodeWord) || [];
+}
+var unicodeWords_default = unicodeWords;
+
+// node_modules/lodash-es/words.js
+function words(string, pattern, guard) {
+  string = toString_default(string);
+  pattern = guard ? void 0 : pattern;
+  if (pattern === void 0) {
+    return hasUnicodeWord_default(string) ? unicodeWords_default(string) : asciiWords_default(string);
+  }
+  return string.match(pattern) || [];
+}
+var words_default = words;
+
+// node_modules/lodash-es/_createCompounder.js
+var rsApos2 = "['\u2019]";
+var reApos = RegExp(rsApos2, "g");
+function createCompounder(callback) {
+  return function(string) {
+    return arrayReduce_default(words_default(deburr_default(string).replace(reApos, "")), callback, "");
+  };
+}
+var createCompounder_default = createCompounder;
+
+// node_modules/lodash-es/camelCase.js
+var camelCase = createCompounder_default(function(result, word, index) {
+  word = word.toLowerCase();
+  return result + (index ? capitalize_default(word) : word);
+});
+var camelCase_default = camelCase;
+
+// node_modules/lodash-es/_stackClear.js
+function stackClear() {
+  this.__data__ = new ListCache_default();
+  this.size = 0;
+}
+var stackClear_default = stackClear;
+
+// node_modules/lodash-es/_stackDelete.js
+function stackDelete(key) {
+  var data = this.__data__, result = data["delete"](key);
+  this.size = data.size;
+  return result;
+}
+var stackDelete_default = stackDelete;
+
+// node_modules/lodash-es/_stackGet.js
+function stackGet(key) {
+  return this.__data__.get(key);
+}
+var stackGet_default = stackGet;
+
+// node_modules/lodash-es/_stackHas.js
+function stackHas(key) {
+  return this.__data__.has(key);
+}
+var stackHas_default = stackHas;
+
+// node_modules/lodash-es/_stackSet.js
+var LARGE_ARRAY_SIZE = 200;
+function stackSet(key, value) {
+  var data = this.__data__;
+  if (data instanceof ListCache_default) {
+    var pairs = data.__data__;
+    if (!Map_default || pairs.length < LARGE_ARRAY_SIZE - 1) {
+      pairs.push([key, value]);
+      this.size = ++data.size;
+      return this;
+    }
+    data = this.__data__ = new MapCache_default(pairs);
+  }
+  data.set(key, value);
+  this.size = data.size;
+  return this;
+}
+var stackSet_default = stackSet;
+
+// node_modules/lodash-es/_Stack.js
+function Stack(entries) {
+  var data = this.__data__ = new ListCache_default(entries);
+  this.size = data.size;
+}
+Stack.prototype.clear = stackClear_default;
+Stack.prototype["delete"] = stackDelete_default;
+Stack.prototype.get = stackGet_default;
+Stack.prototype.has = stackHas_default;
+Stack.prototype.set = stackSet_default;
+var Stack_default = Stack;
+
+// node_modules/lodash-es/_cloneBuffer.js
+var freeExports3 = typeof exports == "object" && exports && !exports.nodeType && exports;
+var freeModule3 = freeExports3 && typeof module == "object" && module && !module.nodeType && module;
+var moduleExports3 = freeModule3 && freeModule3.exports === freeExports3;
+var Buffer3 = moduleExports3 ? root_default.Buffer : void 0;
+var allocUnsafe = Buffer3 ? Buffer3.allocUnsafe : void 0;
+function cloneBuffer(buffer, isDeep) {
+  if (isDeep) {
+    return buffer.slice();
+  }
+  var length = buffer.length, result = allocUnsafe ? allocUnsafe(length) : new buffer.constructor(length);
+  buffer.copy(result);
+  return result;
+}
+var cloneBuffer_default = cloneBuffer;
+
+// node_modules/lodash-es/_Uint8Array.js
+var Uint8Array2 = root_default.Uint8Array;
+var Uint8Array_default = Uint8Array2;
+
+// node_modules/lodash-es/_cloneArrayBuffer.js
+function cloneArrayBuffer(arrayBuffer) {
+  var result = new arrayBuffer.constructor(arrayBuffer.byteLength);
+  new Uint8Array_default(result).set(new Uint8Array_default(arrayBuffer));
+  return result;
+}
+var cloneArrayBuffer_default = cloneArrayBuffer;
+
+// node_modules/lodash-es/_cloneTypedArray.js
+function cloneTypedArray(typedArray, isDeep) {
+  var buffer = isDeep ? cloneArrayBuffer_default(typedArray.buffer) : typedArray.buffer;
+  return new typedArray.constructor(buffer, typedArray.byteOffset, typedArray.length);
+}
+var cloneTypedArray_default = cloneTypedArray;
+
+// node_modules/lodash-es/_initCloneObject.js
+function initCloneObject(object) {
+  return typeof object.constructor == "function" && !isPrototype_default(object) ? baseCreate_default(getPrototype_default(object)) : {};
+}
+var initCloneObject_default = initCloneObject;
+
+// node_modules/lodash-es/_createBaseFor.js
+function createBaseFor(fromRight) {
+  return function(object, iteratee, keysFunc) {
+    var index = -1, iterable = Object(object), props = keysFunc(object), length = props.length;
+    while (length--) {
+      var key = props[fromRight ? length : ++index];
+      if (iteratee(iterable[key], key, iterable) === false) {
+        break;
+      }
+    }
+    return object;
+  };
+}
+var createBaseFor_default = createBaseFor;
+
+// node_modules/lodash-es/_baseFor.js
+var baseFor = createBaseFor_default();
+var baseFor_default = baseFor;
+
+// node_modules/lodash-es/_assignMergeValue.js
+function assignMergeValue(object, key, value) {
+  if (value !== void 0 && !eq_default(object[key], value) || value === void 0 && !(key in object)) {
+    baseAssignValue_default(object, key, value);
+  }
+}
+var assignMergeValue_default = assignMergeValue;
+
+// node_modules/lodash-es/isArrayLikeObject.js
+function isArrayLikeObject(value) {
+  return isObjectLike_default(value) && isArrayLike_default(value);
+}
+var isArrayLikeObject_default = isArrayLikeObject;
+
+// node_modules/lodash-es/_safeGet.js
+function safeGet(object, key) {
+  if (key === "constructor" && typeof object[key] === "function") {
+    return;
+  }
+  if (key == "__proto__") {
+    return;
+  }
+  return object[key];
+}
+var safeGet_default = safeGet;
+
+// node_modules/lodash-es/toPlainObject.js
+function toPlainObject(value) {
+  return copyObject_default(value, keysIn_default(value));
+}
+var toPlainObject_default = toPlainObject;
+
+// node_modules/lodash-es/_baseMergeDeep.js
+function baseMergeDeep(object, source, key, srcIndex, mergeFunc, customizer, stack) {
+  var objValue = safeGet_default(object, key), srcValue = safeGet_default(source, key), stacked = stack.get(srcValue);
+  if (stacked) {
+    assignMergeValue_default(object, key, stacked);
+    return;
+  }
+  var newValue = customizer ? customizer(objValue, srcValue, key + "", object, source, stack) : void 0;
+  var isCommon = newValue === void 0;
+  if (isCommon) {
+    var isArr = isArray_default(srcValue), isBuff = !isArr && isBuffer_default(srcValue), isTyped = !isArr && !isBuff && isTypedArray_default(srcValue);
+    newValue = srcValue;
+    if (isArr || isBuff || isTyped) {
+      if (isArray_default(objValue)) {
+        newValue = objValue;
+      } else if (isArrayLikeObject_default(objValue)) {
+        newValue = copyArray_default(objValue);
+      } else if (isBuff) {
+        isCommon = false;
+        newValue = cloneBuffer_default(srcValue, true);
+      } else if (isTyped) {
+        isCommon = false;
+        newValue = cloneTypedArray_default(srcValue, true);
+      } else {
+        newValue = [];
+      }
+    } else if (isPlainObject_default(srcValue) || isArguments_default(srcValue)) {
+      newValue = objValue;
+      if (isArguments_default(objValue)) {
+        newValue = toPlainObject_default(objValue);
+      } else if (!isObject_default(objValue) || isFunction_default(objValue)) {
+        newValue = initCloneObject_default(srcValue);
+      }
+    } else {
+      isCommon = false;
+    }
+  }
+  if (isCommon) {
+    stack.set(srcValue, newValue);
+    mergeFunc(newValue, srcValue, srcIndex, customizer, stack);
+    stack["delete"](srcValue);
+  }
+  assignMergeValue_default(object, key, newValue);
+}
+var baseMergeDeep_default = baseMergeDeep;
+
+// node_modules/lodash-es/_baseMerge.js
+function baseMerge(object, source, srcIndex, customizer, stack) {
+  if (object === source) {
+    return;
+  }
+  baseFor_default(source, function(srcValue, key) {
+    stack || (stack = new Stack_default());
+    if (isObject_default(srcValue)) {
+      baseMergeDeep_default(object, source, key, srcIndex, baseMerge, customizer, stack);
+    } else {
+      var newValue = customizer ? customizer(safeGet_default(object, key), srcValue, key + "", object, source, stack) : void 0;
+      if (newValue === void 0) {
+        newValue = srcValue;
+      }
+      assignMergeValue_default(object, key, newValue);
+    }
+  }, keysIn_default);
+}
+var baseMerge_default = baseMerge;
+
+// node_modules/lodash-es/_customDefaultsMerge.js
+function customDefaultsMerge(objValue, srcValue, key, object, source, stack) {
+  if (isObject_default(objValue) && isObject_default(srcValue)) {
+    stack.set(srcValue, objValue);
+    baseMerge_default(objValue, srcValue, void 0, customDefaultsMerge, stack);
+    stack["delete"](srcValue);
+  }
+  return objValue;
+}
+var customDefaultsMerge_default = customDefaultsMerge;
+
+// node_modules/lodash-es/mergeWith.js
+var mergeWith = createAssigner_default(function(object, source, srcIndex, customizer) {
+  baseMerge_default(object, source, srcIndex, customizer);
+});
+var mergeWith_default = mergeWith;
+
+// node_modules/lodash-es/defaultsDeep.js
+var defaultsDeep = baseRest_default(function(args) {
+  args.push(void 0, customDefaultsMerge_default);
+  return apply_default(mergeWith_default, void 0, args);
+});
+var defaultsDeep_default = defaultsDeep;
+
+// node_modules/lodash-es/kebabCase.js
+var kebabCase = createCompounder_default(function(result, word, index) {
+  return result + (index ? "-" : "") + word.toLowerCase();
+});
+var kebabCase_default = kebabCase;
+
+// node_modules/lodash-es/lowerFirst.js
+var lowerFirst = createCaseFirst_default("toLowerCase");
+var lowerFirst_default = lowerFirst;
+
+// node_modules/lodash-es/snakeCase.js
+var snakeCase = createCompounder_default(function(result, word, index) {
+  return result + (index ? "_" : "") + word.toLowerCase();
+});
+var snakeCase_default = snakeCase;
+/*! Bundled license information:
+
+lodash-es/lodash.js:
+  (**
+   * @license
+   * Lodash (Custom Build) <https://lodash.com/>
+   * Build: `lodash modularize exports="es" -o ./`
+   * Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+   * Released under MIT license <https://lodash.com/license>
+   * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+   * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+   *)
+*/

--- a/test/run-rules-on-codebase/lint.mjs
+++ b/test/run-rules-on-codebase/lint.mjs
@@ -38,6 +38,7 @@ const configs = [
 			'test/integration/fixtures-local',
 			// Ignore this file self temporarily, disabling `n/file-extension-in-import` comment cause error
 			'test/run-rules-on-codebase/lint.mjs',
+			'rules/utils/lodash.js',
 		],
 	},
 	{


### PR DESCRIPTION
Hi! Thanks for the great plugin. I'm trying to reduce to install size of my default setup, and I noticed that this plugin pulls the lodash package which 5 MB, half of the install size of the plugin.

Because there is some complex logic around non-ascii for upperFirst & co, I decided to go with bundling only the require methods (expect pick where the change avoid an extra spread).

I've not measured it, but I think it could impact boot time for eslint because of the total quantity of JS for the whole loadash package.