### PR TITLE
`prefer-module`: allow `module` as TSIndexSignature names or TSTypeAliasDeclaration ids

### DIFF
--- a/rules/ast/is-reference-identifier.js
+++ b/rules/ast/is-reference-identifier.js
@@ -120,6 +120,11 @@ function isNotReference(node) {
 			return parent.parameters.includes(node);
 		}
 
+		// `type Identifier = Foo`
+		case 'TSTypeAliasDeclaration': {
+			return parent.id === node;
+		}
+
 		case 'TSPropertySignature': {
 			return parent.key === node;
 		}

--- a/rules/ast/is-reference-identifier.js
+++ b/rules/ast/is-reference-identifier.js
@@ -115,6 +115,7 @@ function isNotReference(node) {
 			return parent.id === node;
 		}
 
+		// `type Foo = { [Identifier: string]: string }`
 		case 'TSIndexSignature': {
 			return parent.parameters.includes(node);
 		}

--- a/rules/ast/is-reference-identifier.js
+++ b/rules/ast/is-reference-identifier.js
@@ -115,6 +115,10 @@ function isNotReference(node) {
 			return parent.id === node;
 		}
 
+		case 'TSIndexSignature': {
+			return parent.parameters.includes(node);
+		}
+
 		case 'TSPropertySignature': {
 			return parent.key === node;
 		}

--- a/rules/utils/is-shadowed.js
+++ b/rules/utils/is-shadowed.js
@@ -25,7 +25,7 @@ function isShadowed(scope, node) {
 	const reference = findReference(scope, node);
 
 	return (
-		reference?.resolved
+		Boolean(reference?.resolved)
 		&& reference.resolved.defs.length > 0
 	);
 }

--- a/test/prefer-module.mjs
+++ b/test/prefer-module.mjs
@@ -266,6 +266,13 @@ test.snapshot({
 	],
 });
 
+test.typescript({
+	valid: [
+		'type ModuleRegistry = { [module: string]: string };',
+	],
+	invalid: [],
+});
+
 // `.cjs` file
 test.snapshot({
 	valid: [

--- a/test/prefer-module.mjs
+++ b/test/prefer-module.mjs
@@ -269,6 +269,9 @@ test.snapshot({
 test.typescript({
 	valid: [
 		'type ModuleRegistry = { [module: string]: string };',
+		'const module = 1; type ModuleRegistry = { [module: string]: string };',
+		'type module = number[]; type ModuleRegistry = { [module: string]: string };',
+		'type ModuleRegistry = { [exports: string]: string };',
 	],
 	invalid: [],
 });

--- a/test/prefer-module.mjs
+++ b/test/prefer-module.mjs
@@ -268,6 +268,7 @@ test.snapshot({
 
 test.typescript({
 	valid: [
+		'type module = number[];',
 		'type ModuleRegistry = { [module: string]: string };',
 		'const module = 1; type ModuleRegistry = { [module: string]: string };',
 		'type module = number[]; type ModuleRegistry = { [module: string]: string };',


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2208

- https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2208

I tried adding a test for that, but was unable to do that (maybe because it requires ts support):

````txt
  message: `␊
    > 1 | type ModuleRegistry = { [module: string]: string };␊
        |      ^ Parsing error: Unexpected token ModuleRegistry`,                                                                                                            
  }                                                                                                                                                                          

  » |      ^ Parsing error: Unexpected token ModuleRegistry
  » verify (file:///test/utils/snapshot-rule-tester.mjs:138:9)
  » file:///test/utils/snapshot-rule-tester.mjs:169:23
````

So I used https://github.com/faker-js/faker/pull/2510/files#diff-7170563e0d86e93e8997b4acb856e5e494809a0ef41b9f4386f26e14bc961908R19 to test that.