### PR TITLE
`string-content`: fix jsx autofix for newlines, etc.

### DIFF
--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -105,10 +105,13 @@ const create = context => {
 
 		const fixed = string.replace(regex, suggest);
 		const fix = type === 'Literal'
-			? fixer => fixer.replaceText(
-				node,
-				escapeString(fixed, raw[0]),
-			)
+			? fixer => {
+				const [quote] = raw;
+				return fixer.replaceText(
+					node,
+					node.parent.type == 'JSXAttribute' ? quote + fixed + quote : escapeString(fixed, quote),
+				);
+			}
 			: fixer => replaceTemplateElement(
 				fixer,
 				node,

--- a/test/string-content.mjs
+++ b/test/string-content.mjs
@@ -45,6 +45,13 @@ const createSuggestionError = (match, suggest, output) => [
 ];
 
 test({
+	testerOptions: {
+		parserOptions: {
+			ecmaFeatures: {
+				jsx: true
+			}
+		}
+	},
 	valid: [
 		'const foo = "";',
 		...[
@@ -279,5 +286,19 @@ test({
 			errors: createError('no', 'yes'),
 		},
 		/* eslint-enable no-template-curly-in-string */
+		{
+			code: outdent`
+				const foo = <div className='
+					no
+				' />
+			`,
+			output: outdent`
+				const foo = <div className='
+					yes
+				' />
+			`,
+			options:[{patterns: noToYesPattern}],
+			errors: createError('no', 'yes')
+		}
 	],
 });


### PR DESCRIPTION
When applying `string-content`'s autofix in a non-curly-braced JSX literal (i.e. a `Literal` that is a direct child of a `JSXAttribute`), special characters are wrongly replaced with escape sequences — for example, literal newlines are replaced with `\n`s.

We can fix this by not applying the `escapeString` function in this case. This is safe to do because these types of literals cannot contain any escape sequences.