### PR TITLE
`no-useless-undefined`: ignore React state setters

### DIFF
--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -60,6 +60,7 @@ const shouldIgnore = node => {
 
 		// `React.createContext(undefined)`
 		|| name === 'createContext'
+		// `setState(undefined)`
 		|| /^set[A-Z]/.test(name)
 
 		// https://vuejs.org/api/reactivity-core.html#ref

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -60,6 +60,7 @@ const shouldIgnore = node => {
 
 		// `React.createContext(undefined)`
 		|| name === 'createContext'
+		|| /^set[A-Z]/.test(name)
 
 		// https://vuejs.org/api/reactivity-core.html#ref
 		|| name === 'ref';

--- a/test/no-useless-undefined.mjs
+++ b/test/no-useless-undefined.mjs
@@ -53,6 +53,10 @@ test({
 		'array.unshift(undefined);',
 		'createContext(undefined);',
 		'React.createContext(undefined);',
+		'setState(undefined)',
+		'setState?.(undefined)',
+		'props.setState(undefined)',
+		'props.setState?.(undefined)',
 		'array.includes(undefined)',
 		'set.has(undefined)',
 


### PR DESCRIPTION
Similar to the exclusion already defined for `React.createContext()`, autofixing `setState(undefined)` to `setState()` works at runtime, but causes a TypeScript error.

Fixes [1377](https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1377)