### PR TITLE
Add regex global flag to replaceAll in docs

### DIFF
--- a/docs/rules/prefer-string-replace-all.md
+++ b/docs/rules/prefer-string-replace-all.md
@@ -46,7 +46,7 @@ string.replaceAll('string', '');
 ```
 
 ```js
-string.replaceAll(/\s/, '');
+string.replaceAll(/\s/g, '');
 ```
 
 ```js


### PR DESCRIPTION
I've realised a mistake in one of the passing examples. When using `String#replaceAll()` with a `RegExp`, the regex global flag (`g`) must be used, as was mentioned in the [issue](https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1948#issuecomment-1321301671) which originally prompted this passing case to be added to the documentation. Without the global flag, a `TypeError` is thrown at runtime.