### PR TITLE
Remove `ecmaVersion` and `sourceType` from flat configs

### DIFF
--- a/configs/flat-config-base.js
+++ b/configs/flat-config-base.js
@@ -1,20 +1,10 @@
 'use strict';
 const eslintrc = require('@eslint/eslintrc');
-const legacyConfigBase = require('./legacy-config-base.js');
-
-const {
-	parserOptions: {
-		ecmaVersion,
-		sourceType,
-	},
-} = legacyConfigBase;
 
 const {globals} = eslintrc.Legacy.environments.get('es2024');
 
 module.exports = {
 	languageOptions: {
-		ecmaVersion,
-		sourceType,
 		globals,
 	},
 };

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,6 @@ import * as eslintrc from '@eslint/eslintrc';
 export default [
 	{
 		languageOptions: {
-			ecmaVersion: 'latest',
-			sourceType: 'module',
 			globals: eslintrc.Legacy.environments.get('es2024'),
 		},
 		plugins: {
@@ -58,8 +56,6 @@ const eslintrc = require('@eslint/eslintrc');
 module.exports = [
 	{
 		languageOptions: {
-			ecmaVersion: 'latest',
-			sourceType: 'module',
 			globals: eslintrc.Legacy.environments.get('es2024'),
 		},
 		plugins: {

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -228,7 +228,12 @@ function getCompactConfig(config) {
 	for (const part of compat.config(config)) {
 		for (const [key, value] of Object.entries(part)) {
 			if (key === 'languageOptions') {
-				result[key] = {...result[key], ...value};
+				const languageOptions = {...result[key], ...value};
+				// ESLint uses same `ecmaVersion` and `sourceType` as we recommended in the new configuration system
+				// https://eslint.org/docs/latest/use/configure/configuration-files-new#configuration-objects
+				delete languageOptions.ecmaVersion;
+				delete languageOptions.sourceType;
+				result[key] = languageOptions;
 			} else if (key === 'plugins') {
 				result[key] = undefined;
 			} else {


### PR DESCRIPTION
According to https://eslint.org/docs/latest/use/configure/configuration-files-new#configuration-objects, in the flat config system.

ESLint already set `ecmaVersion` and use the correct `sourceType`. So we can remove them from flat configs.