### PR TITLE
`prefer-prototype-methods`: Fix argument of `isMethodCall`

### DIFF
--- a/rules/prefer-prototype-methods.js
+++ b/rules/prefer-prototype-methods.js
@@ -30,7 +30,7 @@ function create(context) {
 				// `[].foo.{apply,bind,call}(…)`
 				// `({}).foo.{apply,bind,call}(…)`
 				isMethodCall(callExpression, {
-					names: ['apply', 'bind', 'call'],
+					methods: ['apply', 'bind', 'call'],
 					optionalCall: false,
 					optionalMember: false,
 				})

--- a/test/prefer-prototype-methods.mjs
+++ b/test/prefer-prototype-methods.mjs
@@ -33,6 +33,9 @@ test.snapshot({
 		'foo.bar.bind(bar)',
 		'foo[{}].call(bar)',
 		'Object.hasOwn(bar)',
+		'const foo = [].push.notApply(bar, elements);',
+		'const push = [].push.notBind(foo)',
+		'[].forEach.notCall(foo, () => {})',
 	],
 	invalid: [
 		'const foo = [].push.apply(bar, elements);',


### PR DESCRIPTION
<!--
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
-->

This PR fixes the option used by the `isMethodCall` function in the `prefer-prototype-methods` rule.