### PR TITLE
Add Node 20.11 `import.meta` info

### DIFF
--- a/docs/rules/prefer-module.md
+++ b/docs/rules/prefer-module.md
@@ -21,7 +21,7 @@ Prefer using the [JavaScript module](https://developer.mozilla.org/en-US/docs/We
 
 	They are [not available in JavaScript modules](https://nodejs.org/api/esm.html#esm_no_filename_or_dirname).
 
-	Starting with Node 20.11, `import.meta.dirname` and `import.meta.filename` have been introduced in ES modules, providing identical functionality to __dirname and __filename in CommonJS (CJS).
+	Starting with Node 20.11, `import.meta.dirname` and `import.meta.filename` have been introduced in ES modules, providing identical functionality to `__dirname` and `__filename` in CommonJS (CJS).
 
 	For most cases in Node 20.11 and later:
 

--- a/docs/rules/prefer-module.md
+++ b/docs/rules/prefer-module.md
@@ -21,9 +21,9 @@ Prefer using the [JavaScript module](https://developer.mozilla.org/en-US/docs/We
 
 	They are [not available in JavaScript modules](https://nodejs.org/api/esm.html#esm_no_filename_or_dirname).
 
-	Starting with Node 20.11, `import.meta.dirname` and `import.meta.filename` have been introduced in ES modules, providing identical functionality to `__dirname` and `__filename` in CommonJS (CJS).
+	Starting with Node.js 20.11, [`import.meta.dirname`](https://nodejs.org/api/esm.html#importmetadirname) and [`import.meta.filename`](https://nodejs.org/api/esm.html#importmetafilename) have been introduced in ES modules, providing identical functionality to `__dirname` and `__filename` in CommonJS (CJS).
 
-	For most cases in Node 20.11 and later:
+	For most cases in Node.js 20.11 and later:
 
 	```js
 	const __dirname = import.meta.dirname;

--- a/docs/rules/prefer-module.md
+++ b/docs/rules/prefer-module.md
@@ -21,7 +21,16 @@ Prefer using the [JavaScript module](https://developer.mozilla.org/en-US/docs/We
 
 	They are [not available in JavaScript modules](https://nodejs.org/api/esm.html#esm_no_filename_or_dirname).
 
-	Replacements:
+	Starting with Node 20.11, `import.meta.dirname` and `import.meta.filename` have been introduced in ES modules, providing identical functionality to __dirname and __filename in CommonJS (CJS).
+
+	For most cases in Node 20.11 and later:
+
+	```js
+	const __dirname = import.meta.dirname;
+	const __filename = import.meta.filename;
+	```
+
+	Replacements for older versions:
 
 	```js
 	import {fileURLToPath} from 'node:url';


### PR DESCRIPTION
Update JS Module Documentation for Node 20.11 Changes

- Added information about `import.meta.dirname` and `import.meta.filename` in ES modules, introduced in Node 20.11.