### PR TITLE
`prevent-abbreviations` - non-ASCII characters ignored in filenames

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -116,7 +116,7 @@ const getNameReplacements = (name, options, limit = 3) => {
 	}
 
 	// Split words
-	const words = name.split(/(?=[^a-z])|(?<=[^A-Za-z])/).filter(Boolean);
+	const words = name.split(/(?=\P{Lowercase_Letter})|(?<=\P{Letter})/u).filter(Boolean);
 
 	let hasReplacements = false;
 	const combinations = words.map(word => {

--- a/test/prevent-abbreviations.mjs
+++ b/test/prevent-abbreviations.mjs
@@ -1931,6 +1931,10 @@ test({
 			code: 'foo();',
 			filename: 'err/http-error.js',
 		},
+		{
+			code: 'foo();',
+			filename: 'Мiръ.html',
+		},
 		// `ignore` option
 		{
 			code: outdent`


### PR DESCRIPTION
<!--
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
-->
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2292