### PR TITLE
`escape-case`: Ignore `String.raw`

### DIFF
--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -47,7 +47,7 @@ const create = context => {
 		const templateLiteral = node.parent;
 		if (
 			templateLiteral.parent.type === 'TaggedTemplateExpression'
-			&& templateLiteral.parent.quasi == templateLiteral
+			&& templateLiteral.parent.quasi === templateLiteral
 		) {
 			const {tag} = templateLiteral.parent;
 			if (isNodeMatches(tag, ['String.raw'])) {
@@ -59,7 +59,7 @@ const create = context => {
 			node,
 			original: node.value.raw,
 			fix: (fixer, fixed) => replaceTemplateElement(fixer, node, fixed),
-		})
+		});
 	});
 };
 

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -48,11 +48,9 @@ const create = context => {
 		if (
 			templateLiteral.parent.type === 'TaggedTemplateExpression'
 			&& templateLiteral.parent.quasi === templateLiteral
+			&& isNodeMatches(templateLiteral.parent.tag, ['String.raw'])
 		) {
-			const {tag} = templateLiteral.parent;
-			if (isNodeMatches(tag, ['String.raw'])) {
-				return;
-			}
+			return;
 		}
 
 		return getProblem({

--- a/test/escape-case.mjs
+++ b/test/escape-case.mjs
@@ -41,6 +41,7 @@ test({
 		'const foo = `foo\\\\\\\\xbar`;',
 		'const foo = `foo\\\\\\\\ubarbaz`;',
 		'const foo = `\\ca`;',
+		'const foo = String.raw`\\xA9`;',
 
 		// Literal regex
 		'const foo = /foo\\xA9/',
@@ -189,6 +190,17 @@ test({
 			code: 'const foo = `foo \\\\\\ud834`;',
 			errors,
 			output: 'const foo = `foo \\\\\\uD834`;',
+		},
+		// TODO: This is not safe, it will be broken if `tagged` uses `arguments[0].raw`
+		{
+			code: 'const foo = tagged`\\xa9`;',
+			errors,
+			output: 'const foo = tagged`\\xA9`;',
+		},
+		{
+			code: 'const foo = `\\xa9```;',
+			errors,
+			output: 'const foo = `\\xA9```;',
 		},
 
 		// Mixed cases

--- a/test/escape-case.mjs
+++ b/test/escape-case.mjs
@@ -41,7 +41,7 @@ test({
 		'const foo = `foo\\\\\\\\xbar`;',
 		'const foo = `foo\\\\\\\\ubarbaz`;',
 		'const foo = `\\ca`;',
-		'const foo = String.raw`\\xA9`;',
+		'const foo = String.raw`\\uAaAa`;',
 
 		// Literal regex
 		'const foo = /foo\\xA9/',
@@ -192,15 +192,16 @@ test({
 			output: 'const foo = `foo \\\\\\uD834`;',
 		},
 		// TODO: This is not safe, it will be broken if `tagged` uses `arguments[0].raw`
+		// #2341
 		{
-			code: 'const foo = tagged`\\xa9`;',
+			code: 'const foo = tagged`\\uAaAa`;',
 			errors,
-			output: 'const foo = tagged`\\xA9`;',
+			output: 'const foo = tagged`\\uAAAA`;',
 		},
 		{
-			code: 'const foo = `\\xa9```;',
+			code: 'const foo = `\\uAaAa```;',
 			errors,
-			output: 'const foo = `\\xA9```;',
+			output: 'const foo = `\\uAAAA```;',
 		},
 
 		// Mixed cases


### PR DESCRIPTION
Part of #2341, `String.raw` is known as broken, this PR fixes it, but we should collect more libs uses `TemplateObject.raw` and make functions configurable.