### PR TITLE
`template-indent`: Support member expression paths in `tags` and `functions`

### DIFF
--- a/docs/rules/template-indent.md
+++ b/docs/rules/template-indent.md
@@ -69,7 +69,7 @@ Under the hood, [strip-indent](https://npmjs.com/package/strip-indent) is used t
 
 ## Options
 
-The rule accepts lists of `tags`, `functions`, `selectors` and `comments` to match template literals. `tags` are tagged template literal identifiers or member expression paths, functions are names of utility functions like `stripIndent`, selectors can be any [ESLint selector](https://eslint.org/docs/developer-guide/selectors), and comments are `/* block-commented */` strings.
+The rule accepts lists of `tags`, `functions`, `selectors` and `comments` to match template literals. `tags` are tagged template literal identifiers or member expression paths, functions are names or member expression paths of utility functions like `stripIndent`, selectors can be any [ESLint selector](https://eslint.org/docs/developer-guide/selectors), and comments are `/* block-commented */` strings.
 
 Default configuration:
 

--- a/docs/rules/template-indent.md
+++ b/docs/rules/template-indent.md
@@ -69,7 +69,7 @@ Under the hood, [strip-indent](https://npmjs.com/package/strip-indent) is used t
 
 ## Options
 
-The rule accepts lists of `tags`, `functions`, `selectors` and `comments` to match template literals. `tags` are tagged template literal identifiers, functions are names of utility functions like `stripIndent`, selectors can be any [ESLint selector](https://eslint.org/docs/developer-guide/selectors), and comments are `/* block-commented */` strings.
+The rule accepts lists of `tags`, `functions`, `selectors` and `comments` to match template literals. `tags` are tagged template literal identifiers or member expression paths, functions are names of utility functions like `stripIndent`, selectors can be any [ESLint selector](https://eslint.org/docs/developer-guide/selectors), and comments are `/* block-commented */` strings.
 
 Default configuration:
 

--- a/rules/ast/index.js
+++ b/rules/ast/index.js
@@ -33,6 +33,7 @@ module.exports = {
 	isNewExpression,
 	isReferenceIdentifier: require('./is-reference-identifier.js'),
 	isStaticRequire: require('./is-static-require.js'),
+	isTaggedTemplateLiteral: require('./is-tagged-template-literal.js'),
 	isUndefined: require('./is-undefined.js'),
 
 	functionTypes: require('./function-types.js'),

--- a/rules/ast/is-tagged-template-literal.js
+++ b/rules/ast/is-tagged-template-literal.js
@@ -3,7 +3,7 @@
 const {isNodeMatches} = require('../utils/is-node-matches.js');
 
 /**
-Check if node is tagged template literal.
+Check if the given node is a tagged template literal.
 
 @param {Node} node - The AST node to check.
 @param {string[]} tags - The object name or key paths.

--- a/rules/ast/is-tagged-template-literal.js
+++ b/rules/ast/is-tagged-template-literal.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {isNodeMatches} = require('../utils/is-node-matches.js')
+const {isNodeMatches} = require('../utils/is-node-matches.js');
 
 /**
 Check if node is tagged template literal.
@@ -15,7 +15,7 @@ function isTaggedTemplateLiteral(node, tags) {
 		|| node.parent.type !== 'TaggedTemplateExpression'
 		|| node.parent.quasi !== node
 	) {
-		return false
+		return false;
 	}
 
 	if (tags) {

--- a/rules/ast/is-tagged-template-literal.js
+++ b/rules/ast/is-tagged-template-literal.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const {isNodeMatches} = require('../utils/is-node-matches.js')
+
+/**
+Check if node is tagged template literal.
+
+@param {Node} node - The AST node to check.
+@param {string[]} tags - The object name or key paths.
+@returns {boolean}
+*/
+function isTaggedTemplateLiteral(node, tags) {
+	if (
+		node.type !== 'TemplateLiteral'
+		|| node.parent.type !== 'TaggedTemplateExpression'
+		|| node.parent.quasi !== node
+	) {
+		return false
+	}
+
+	if (tags) {
+		return isNodeMatches(node.parent.tag, tags);
+	}
+
+	return true;
+}
+
+module.exports = isTaggedTemplateLiteral;

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -1,7 +1,10 @@
 'use strict';
 const {replaceTemplateElement} = require('./fix/index.js');
-const {isRegexLiteral, isStringLiteral} = require('./ast/index.js');
-const {isNodeMatches} = require('./utils/index.js');
+const {
+	isRegexLiteral,
+	isStringLiteral,
+	isTaggedTemplateLiteral,
+} = require('./ast/index.js');
 
 const MESSAGE_ID = 'escape-case';
 const messages = {
@@ -44,13 +47,8 @@ const create = context => {
 	});
 
 	context.on('TemplateElement', node => {
-		const templateLiteral = node.parent;
-		if (
-			templateLiteral.parent.type === 'TaggedTemplateExpression'
-			&& templateLiteral.parent.quasi === templateLiteral
-			&& isNodeMatches(templateLiteral.parent.tag, ['String.raw'])
-		) {
-			return;
+		if (isTaggedTemplateLiteral(node.parent, ['String.raw'])) {
+			return
 		}
 
 		return getProblem({

--- a/rules/escape-case.js
+++ b/rules/escape-case.js
@@ -48,7 +48,7 @@ const create = context => {
 
 	context.on('TemplateElement', node => {
 		if (isTaggedTemplateLiteral(node.parent, ['String.raw'])) {
-			return
+			return;
 		}
 
 		return getProblem({

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -1,7 +1,10 @@
 'use strict';
 const {replaceTemplateElement} = require('./fix/index.js');
-const {isStringLiteral, isRegexLiteral} = require('./ast/index.js');
-const {isNodeMatches} = require('./utils/index.js');
+const {
+	isStringLiteral,
+	isRegexLiteral,
+	isTaggedTemplateLiteral,
+} = require('./ast/index.js');
 
 const MESSAGE_ID = 'no-hex-escape';
 const messages = {
@@ -31,13 +34,8 @@ const create = context => ({
 		}
 	},
 	TemplateElement(node) {
-		const templateLiteral = node.parent;
-		if (
-			templateLiteral.parent.type === 'TaggedTemplateExpression'
-			&& templateLiteral.parent.quasi === templateLiteral
-			&& isNodeMatches(templateLiteral.parent.tag, ['String.raw'])
-		) {
-			return;
+		if (isTaggedTemplateLiteral(node.parent, ['String.raw'])) {
+			return
 		}
 
 		return checkEscape(context, node, node.value.raw);

--- a/rules/no-hex-escape.js
+++ b/rules/no-hex-escape.js
@@ -35,7 +35,7 @@ const create = context => ({
 	},
 	TemplateElement(node) {
 		if (isTaggedTemplateLiteral(node.parent, ['String.raw'])) {
-			return
+			return;
 		}
 
 		return checkEscape(context, node, node.value.raw);

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -3,7 +3,11 @@ const stripIndent = require('strip-indent');
 const indentString = require('indent-string');
 const esquery = require('esquery');
 const {replaceTemplateElement} = require('./fix/index.js');
-const {isMethodCall, isCallExpression} = require('./ast/index.js');
+const {
+	isMethodCall,
+	isCallExpression,
+	isTaggedTemplateLiteral,
+} = require('./ast/index.js');
 
 const MESSAGE_ID_IMPROPERLY_INDENTED_TEMPLATE = 'template-indent';
 const messages = {
@@ -114,10 +118,7 @@ const create = context => {
 
 		if (
 			options.tags.length > 0
-			&& node.parent.type === 'TaggedTemplateExpression'
-			&& node.parent.quasi === node
-			&& node.parent.tag.type === 'Identifier'
-			&& options.tags.includes(node.parent.tag.name)
+			&& isTaggedTemplateLiteral(node, options.tags)
 		) {
 			return true;
 		}

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -8,6 +8,7 @@ const {
 	isCallExpression,
 	isTaggedTemplateLiteral,
 } = require('./ast/index.js');
+const {isNodeMatches} = require('./utils/index.js')
 
 const MESSAGE_ID_IMPROPERLY_INDENTED_TEMPLATE = 'template-indent';
 const messages = {
@@ -127,8 +128,7 @@ const create = context => {
 			options.functions.length > 0
 			&& node.parent.type === 'CallExpression'
 			&& node.parent.arguments.includes(node)
-			&& node.parent.callee.type === 'Identifier'
-			&& options.functions.includes(node.parent.callee.name)
+			&& isNodeMatches(node.parent.callee, options.functions)
 		) {
 			return true;
 		}

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -8,7 +8,7 @@ const {
 	isCallExpression,
 	isTaggedTemplateLiteral,
 } = require('./ast/index.js');
-const {isNodeMatches} = require('./utils/index.js')
+const {isNodeMatches} = require('./utils/index.js');
 
 const MESSAGE_ID_IMPROPERLY_INDENTED_TEMPLATE = 'template-indent';
 const messages = {

--- a/test/template-indent.mjs
+++ b/test/template-indent.mjs
@@ -87,6 +87,26 @@ test({
 		},
 		{
 			options: [{
+				tags: ['utils.dedent'],
+			}],
+			code: fixInput(`
+				foo = utils.dedent\`
+				••••••••one
+				••••••••two
+				••••••••••three
+				••••••••\`
+			`),
+			errors,
+			output: fixInput(`
+				foo = utils.dedent\`
+				••one
+				••two
+				••••three
+				\`
+			`),
+		},
+		{
+			options: [{
 				tags: ['customIndentableTag'],
 				selectors: [':not(TaggedTemplateExpression) > TemplateLiteral'],
 			}],

--- a/test/template-indent.mjs
+++ b/test/template-indent.mjs
@@ -432,15 +432,15 @@ test({
 		},
 		{
 			options: [{
-				functions: ['customDedentFunction'],
+				functions: ['customDedentFunction1', 'utils.customDedentFunction2'],
 			}],
 			code: fixInput(`
-				foo = customDedentFunction(\`
+				foo = customDedentFunction1(\`
 				••••••••one
 				••••••••two
 				••••••••••three
 				••••••••\`)
-				foo = customDedentFunction('some-other-arg', \`
+				foo = utils.customDedentFunction2('some-other-arg', \`
 				••••••••one
 				••••••••two
 				••••••••••three
@@ -448,12 +448,12 @@ test({
 			`),
 			errors: [...errors, ...errors],
 			output: fixInput(`
-				foo = customDedentFunction(\`
+				foo = customDedentFunction1(\`
 				••one
 				••two
 				••••three
 				\`)
-				foo = customDedentFunction('some-other-arg', \`
+				foo = utils.customDedentFunction2('some-other-arg', \`
 				••one
 				••two
 				••••three


### PR DESCRIPTION
- Add utility `isTaggedTemplateLiteral`
- Support member expression paths in `template-indent` tags
- Support member expression paths in `template-indent` functions