### PR TITLE
`prefer-string-raw`: Ignore strings in Enums

### DIFF
--- a/rules/prefer-string-raw.js
+++ b/rules/prefer-string-raw.js
@@ -47,6 +47,7 @@ const create = context => {
 			)
 			|| (node.parent.type === 'Property' && !node.parent.computed && node.parent.key === node)
 			|| (node.parent.type === 'JSXAttribute' && node.parent.value === node)
+			|| (node.parent.type === 'TSEnumMember' && (node.parent.initializer === node || node.parent.id === node))
 		) {
 			return;
 		}

--- a/test/prefer-string-raw.mjs
+++ b/test/prefer-string-raw.mjs
@@ -38,3 +38,19 @@ test.snapshot({
 		String.raw`const foo = "foo \\x46";`,
 	],
 });
+
+test.typescript({
+	valid: [
+		outdent`
+			enum Files {
+				Foo = "C:\\\\path\\\\to\\\\foo.js",
+			}
+		`,
+		outdent`
+			enum Foo {
+				"\\\\a\\\\b" = "baz",
+			}
+		`,
+	],
+	invalid: [],
+});


### PR DESCRIPTION
[TS playground](https://www.typescriptlang.org/play/?#code/JAimDsFcFsAIDECWAbUBnWBvAsAKBCPAPZGwC8sARAMIBcAOvQA4CGALgBaNtGMBmJAHQArNJQA0eAsABCLAE7lYAZTbzE4AOaD5LAO4ADOs3Zce9AEYKRaA5PwgAvkA)