### PR TITLE
Remove useless "recommended" properties

### DIFF
--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -46,7 +46,6 @@ const arrayFlatMap = {
 	},
 	getArrayNode: node => node.callee.object,
 	description: 'Array#flatMap()',
-	recommended: true,
 };
 
 // `array.reduce((a, b) => a.concat(b), [])`
@@ -100,7 +99,6 @@ const arrayReduce = {
 	},
 	getArrayNode: node => node.callee.object,
 	description: 'Array#reduce()',
-	recommended: true,
 };
 
 // `[].concat(maybeArray)`
@@ -121,7 +119,6 @@ const emptyArrayConcat = {
 		return argumentNode.type === 'SpreadElement' ? argumentNode.argument : argumentNode;
 	},
 	description: '[].concat()',
-	recommended: true,
 	shouldSwitchToArray: node => node.arguments[0].type !== 'SpreadElement',
 };
 
@@ -157,7 +154,6 @@ const arrayPrototypeConcat = {
 		return argumentNode.type === 'SpreadElement' ? argumentNode.argument : argumentNode;
 	},
 	description: 'Array.prototype.concat()',
-	recommended: true,
 	shouldSwitchToArray: node => node.arguments[1].type !== 'SpreadElement' && node.callee.property.name === 'call',
 };
 

--- a/rules/prefer-modern-math-apis.js
+++ b/rules/prefer-modern-math-apis.js
@@ -154,7 +154,6 @@ const create = context => {
 				data: {
 					replacement: `Math.${replacementMethod}(…)`,
 					description: 'Math.sqrt(…)',
-					recommended: true,
 				},
 				* fix(fixer) {
 					const {sourceCode} = context;

--- a/rules/prefer-structured-clone.js
+++ b/rules/prefer-structured-clone.js
@@ -61,7 +61,6 @@ const create = context => {
 			messageId: MESSAGE_ID_ERROR,
 			data: {
 				description: 'JSON.parse(JSON.stringify(…))',
-				recommended: true,
 			},
 			suggest: [
 				{


### PR DESCRIPTION
This removes the `recommended` property from rules with no apparent use, this just seems like an oversight from a Find and Replace to add the property after all `description` properties, however without ensuring that only those within the `docs` object are affected.

`recommended` itself is not used within these files, and it doesn't seem like they're used externally.