### PR TITLE
Improve type inference for configs in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const allRules = Object.fromEntries(
 	]),
 );
 
-const createLegacyConfig = (rules) => ({
+const createLegacyConfig = rules => ({
 	...legacyConfigBase,
 	plugins: ['unicorn'],
 	rules: {...externalRules, ...rules},
@@ -58,7 +58,7 @@ const createFlatConfig = (rules, flatConfigName) => ({
 	name: flatConfigName,
 	plugins: {unicorn},
 	rules: {...externalRules, ...rules},
-})
+});
 
 const unicorn = {
 	meta: {

--- a/index.js
+++ b/index.js
@@ -47,14 +47,18 @@ const allRules = Object.fromEntries(
 	]),
 );
 
-const createConfig = (rules, flatConfigName = false) => ({
-	...(
-		flatConfigName
-			? {...flatConfigBase, name: flatConfigName, plugins: {unicorn}}
-			: {...legacyConfigBase, plugins: ['unicorn']}
-	),
+const createLegacyConfig = (rules) => ({
+	...legacyConfigBase,
+	plugins: ['unicorn'],
 	rules: {...externalRules, ...rules},
 });
+
+const createFlatConfig = (rules, flatConfigName) => ({
+	...flatConfigBase,
+	name: flatConfigName,
+	plugins: {unicorn},
+	rules: {...externalRules, ...rules},
+})
 
 const unicorn = {
 	meta: {
@@ -68,10 +72,10 @@ const unicorn = {
 };
 
 const configs = {
-	recommended: createConfig(recommendedRules),
-	all: createConfig(allRules),
-	'flat/recommended': createConfig(recommendedRules, 'unicorn/flat/recommended'),
-	'flat/all': createConfig(allRules, 'unicorn/flat/all'),
+	recommended: createLegacyConfig(recommendedRules),
+	all: createLegacyConfig(allRules),
+	'flat/recommended': createFlatConfig(recommendedRules, 'unicorn/flat/recommended'),
+	'flat/all': createFlatConfig(allRules, 'unicorn/flat/all'),
 };
 
 module.exports = {...unicorn, configs};


### PR DESCRIPTION
Currently, using a unicorn config in a type-checked eslint.config.js gives me this:

![image](https://github.com/sindresorhus/eslint-plugin-unicorn/assets/60049320/7fa553c7-669e-4e47-a8be-b084758f8024)

This happens because `createConfig`'s return type has `name` inferred as `boolean` and `plugins` as the union of `typeof {unicorn}` and `typeof ['unicorn']`.

I separated `createConfig` into two versions so TypeScript will infer more specific types for each configuration, fixing the above error.