### PR TITLE
`prevent-abbreviations`:  `db` is also the abbreviation for `decibel`

### DIFF
--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -39,6 +39,7 @@ module.exports.defaultReplacements = {
 	},
 	db: {
 		database: true,
+		decibel: true,
 	},
 	def: {
 		defer: true,


### PR DESCRIPTION
db is also the abbreviation for decibel

<!--
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
-->
