### PR TITLE
docs: `require('fs')` should fail `prefer-node-protocol`

### DIFF
--- a/docs/rules/prefer-node-protocol.md
+++ b/docs/rules/prefer-node-protocol.md
@@ -30,6 +30,10 @@ import fs from 'fs/promises';
 ```
 
 ```js
+const fs = require('fs');
+```
+
+```js
 const fs = require('fs/promises');
 ```
 
@@ -45,10 +49,6 @@ export {strict as default} from 'node:assert';
 
 ```js
 import fs from 'node:fs/promises';
-```
-
-```js
-const fs = require('fs');
 ```
 
 ```js


### PR DESCRIPTION
I was a bit confused by the docs and am not sure they're correct. @fisker do you think you accidentally forgot to mark this example as invalid as part of https://github.com/sindresorhus/eslint-plugin-unicorn/pull/1827?