### PR TITLE
Automatically format rule names in PR and issue titles

### DIFF
--- a/.github/workflows/title-formatter.yml
+++ b/.github/workflows/title-formatter.yml
@@ -20,3 +20,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           pattern-path: docs/rules
           replacement: '`$0`'
+          trim-punctuation: true

--- a/.github/workflows/title-formatter.yml
+++ b/.github/workflows/title-formatter.yml
@@ -1,0 +1,22 @@
+name: Titles formatter
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+  issues:
+    types: [opened, edited]
+
+jobs:
+  Rule:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Auto-format rule names in titles
+        uses: fregante/title-replacer-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pattern-path: docs/rules
+          replacement: '`$0`'

--- a/.github/workflows/title-formatter.yml
+++ b/.github/workflows/title-formatter.yml
@@ -1,4 +1,4 @@
-name: Titles formatter
+name: Title formatter
 
 on:
   pull_request_target:


### PR DESCRIPTION
Proposal.

Judging by these two commits/events, both @sindresorhus and @fisker prefer formatting `rule-names` with backticks:

- https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2398#event-13645018947
- https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2260#pullrequestreview-1826904539

And I do too, as I regularly format the titles of issues on this repo.

So I think why not automate at least some of these replacements? It's a low maintenance, low risk kind of automation. Worth a try?

What the [`title-replacer-action`](https://github.com/marketplace/actions/title-replacer) does:

1. it collects the rule names from the docs folder
2. it looks for the rule names in the titles of PRs and issues
3. it wraps each match with backticks and updates the title, if necessary