### PR TITLE
`prefer-add-event-listener`: Use `Reflect.apply` instead of `Map#get` to prepare for landing `prefer-map-has`

### DIFF
--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -44,7 +44,7 @@ const shouldFixBeforeUnload = (assignedExpression, nodeReturnsSomething) => {
 		return false;
 	}
 
-	return !nodeReturnsSomething.get(assignedExpression);
+	return !Reflect.apply(nodeReturnsSomething.get, nodeReturnsSomething, [assignedExpression]);
 };
 
 const isClearing = node => isUndefined(node) || isNullLiteral(node);


### PR DESCRIPTION
Context: https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2414#issuecomment-2260353582