### PR TITLE
Fix: missing ESLint v9 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 		"yaml": "^2.5.1"
 	},
 	"peerDependencies": {
-		"eslint": ">=8.56.0"
+		"eslint": ">=8.56.0 || ^9.0.0"
 	},
 	"ava": {
 		"files": [


### PR DESCRIPTION
Continue of #2250