### PR TITLE
Fix: use explicit versions of eslint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 		"yaml": "^2.5.1"
 	},
 	"peerDependencies": {
-		"eslint": ">=8.56.0"
+		"eslint": "^8.56.0 || ^9.0.0"
 	},
 	"ava": {
 		"files": [


### PR DESCRIPTION
`>=8.56.0` allows version 9 and future versions of `eslint` (10, 11 etc) and it doesn't advise with warnings of the package managers.