### PR TITLE
Update package.json - added homapage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"license": "MIT",
 	"repository": "sindresorhus/eslint-plugin-unicorn",
 	"funding": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1",
+	"homepage": "https://github.com/sindresorhus/eslint-plugin-unicorn",
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",


### PR DESCRIPTION
Added missing homepage url.

with this property we could see url in VSCode :

![obraz](https://github.com/user-attachments/assets/eb02db7f-a6a6-48b3-b2e7-90ef517efe27)
