### PR TITLE
`no-array-for-each`: Add `ignoreNamedIdentifier` option

### DIFF
--- a/docs/rules/no-array-for-each.md
+++ b/docs/rules/no-array-for-each.md
@@ -61,3 +61,17 @@ for (const [index, element] of array.entries()) {
 	bar(element, index, array);
 }
 ```
+
+## Options
+
+### ignoreNamedIdentifier
+
+Type: `boolean`\
+Default: `false`
+
+Ignores the rule when the callback is function identifier.
+
+```js
+// Pass
+array.forEach(bar);
+```

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -385,6 +385,7 @@ const create = context => {
 	const allIdentifiers = [];
 	const functionInfo = new Map();
 	const {sourceCode} = context;
+	const {ignoreNamedIdentifier} = context.options[0] || {};
 
 	context.on(functionTypes, node => {
 		functionStack.push(node);
@@ -420,6 +421,13 @@ const create = context => {
 				method: 'forEach',
 			})
 			|| isNodeMatches(node.callee.object, ignoredObjects)
+			|| (
+				isMethodCall(node, {
+					method: 'forEach',
+				})
+				&& ignoreNamedIdentifier
+				&& node.arguments[0].type === 'Identifier'
+			)
 		) {
 			return;
 		}
@@ -468,6 +476,19 @@ const create = context => {
 	});
 };
 
+const schema = [
+	{
+		type: 'object',
+		additionalProperties: false,
+		properties: {
+			ignoreNamedIdentifier: {
+				type: 'boolean',
+				default: false,
+			},
+		},
+	},
+];
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
@@ -479,6 +500,7 @@ module.exports = {
 		},
 		fixable: 'code',
 		hasSuggestions: true,
+		schema,
 		messages,
 	},
 };

--- a/test/no-array-for-each.mjs
+++ b/test/no-array-for-each.mjs
@@ -680,3 +680,30 @@ test({
 		},
 	],
 });
+
+test({
+	valid: [
+		{
+			code: `foo.forEach(bar)`,
+			options: [
+				{
+					ignoreNamedIdentifier: true,
+				},
+			],
+		},
+	],
+	invalid: [
+		{
+			code: `foo.forEach(element => bar(element))`,
+			options: [
+				{
+					ignoreNamedIdentifier: true,
+				},
+			],
+			output: outdent`
+				for (const element of foo) bar(element)
+			`,
+			errors: 1,
+		},
+	],
+})


### PR DESCRIPTION
The `no-array-for-each` rule is good for making code easier to understand and shorter. However, in some cases I find it easier to use `forEach` when I have a function that is applied via `forEach` in multiple places.

This PR adds the ability to ignore the rule if only the function name is passed in the arguments to `forEach`.

Example:
https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/rules/sort-classes.ts#L341-L374

```ts
if ('elements' in nodeValue) {
  nodeValue.elements
    .filter(currentNode => currentNode !== null)
    .forEach(traverseNode)
}

if ('argument' in nodeValue && nodeValue.argument) {
  traverseNode(nodeValue.argument)
}

if ('arguments' in nodeValue) {
  nodeValue.arguments.forEach(traverseNode)
}

if ('declarations' in nodeValue) {
  nodeValue.declarations.forEach(traverseNode)
}

if ('properties' in nodeValue) {
  nodeValue.properties.forEach(traverseNode)
}

if ('expressions' in nodeValue) {
  nodeValue.expressions.forEach(traverseNode)
}
```