### PR TITLE
`expiring-todo-comments`: Fix compatibility with ESLint 9.15

### DIFF
--- a/.github/workflows/title-formatter.yml
+++ b/.github/workflows/title-formatter.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Auto-format rule names in titles
-        uses: fregante/title-replacer-action@v1
+        uses: fregante/title-replacer-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pattern-path: docs/rules
           replacement: '`$0`'
-          trim-punctuation: true
+          trim-wrappers: true

--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
 					],
 					"eslint-plugin/require-meta-docs-url": "off",
 					"eslint-plugin/require-meta-has-suggestions": "off",
-					"eslint-plugin/require-meta-schema": "off"
+					"eslint-plugin/require-meta-schema": "off",
+					"eslint-plugin/require-meta-schema-description": "off"
 				}
 			}
 		]

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -276,7 +276,7 @@ const DEFAULT_OPTIONS = {
 	ignore: [],
 	ignoreDatesOnPullRequests: true,
 	allowWarningComments: true,
-}
+};
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
@@ -588,7 +588,7 @@ module.exports = {
 			recommended: true,
 		},
 		schema,
-		defaultOptions: [{ ...DEFAULT_OPTIONS }],
+		defaultOptions: [{...DEFAULT_OPTIONS}],
 		messages,
 	},
 };

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -271,13 +271,17 @@ function semverComparisonForOperator(operator) {
 	}[operator];
 }
 
+const DEFAULT_OPTIONS = {
+	terms: ['todo', 'fixme', 'xxx'],
+	ignore: [],
+	ignoreDatesOnPullRequests: true,
+	allowWarningComments: true,
+}
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = {
-		terms: ['todo', 'fixme', 'xxx'],
-		ignore: [],
-		ignoreDatesOnPullRequests: true,
-		allowWarningComments: true,
+		...DEFAULT_OPTIONS,
 		date: new Date().toISOString().slice(0, 10),
 		...context.options[0],
 	};
@@ -564,7 +568,7 @@ const schema = [
 			},
 			allowWarningComments: {
 				type: 'boolean',
-				default: false,
+				default: true,
 			},
 			date: {
 				type: 'string',
@@ -584,6 +588,7 @@ module.exports = {
 			recommended: true,
 		},
 		schema,
+		defaultOptions: [{ ...DEFAULT_OPTIONS }],
 		messages,
 	},
 };

--- a/test/integration/projects.mjs
+++ b/test/integration/projects.mjs
@@ -223,6 +223,7 @@ export default [
 			// Invalid syntax
 			'src/vs/platform/files/test/node/fixtures/**',
 			'src/vs/workbench/services/search/test/node/fixtures/examples/**',
+			'extensions/vscode-colorize-perf-tests/test/**',
 		],
 	},
 ].flatMap((projectOrProjects, index) =>

--- a/test/package.mjs
+++ b/test/package.mjs
@@ -168,6 +168,7 @@ function getCompactConfig(config) {
 					// `Intl` was added to ESLint https://github.com/eslint/eslint/pull/18318
 					// But `@eslint/eslintrc` choose not to update `globals` https://github.com/eslint/eslintrc/pull/164
 					Intl: false,
+					Iterator: false,
 				};
 				result[key] = languageOptions;
 			} else if (key === 'plugins') {


### PR DESCRIPTION
Close #2496.

I added the default options to `expiring-todo-comments` rule to avoid error when running this config with `eslint@9.15`.

I also added `Iterator` to `languageOptions.globals` otherwise the recommended config test will fail.

I tested that the patch works also with `eslint@9.14` but let me know if want that I try to test  multiple version of `ESLint` in `CI` workflow

---

> [!WARNING]
> I cloned and checkout `main` branch then I installed the dependencies using  `npm i`.
> After that I ran `npm run lint` I got
> ```text
> 27 warnings
> 56 errors
> ```
> is this expected or I have missed some step during setup?



