### PR TITLE
Add `allowIndexParameter` option to `no-array-for-each`

### DIFF
--- a/docs/rules/no-array-for-each.md
+++ b/docs/rules/no-array-for-each.md
@@ -61,3 +61,21 @@ for (const [index, element] of array.entries()) {
 	bar(element, index, array);
 }
 ```
+
+## Options
+
+### allowIndexParameter
+
+Type: `boolean`\
+Default: `false`
+
+You can set the `allowIndexParameter` option like this:
+
+```js
+"unicorn/no-array-for-each": [
+	"error",
+	{
+		"allowIndexParameter": true
+	}
+]
+```

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -386,6 +386,11 @@ const create = context => {
 	const functionInfo = new Map();
 	const {sourceCode} = context;
 
+	const {allowIndexParameter} = {
+		allowIndexParameter: false,
+		...context.options[0],
+	};
+
 	context.on(functionTypes, node => {
 		functionStack.push(node);
 		functionInfo.set(node, {
@@ -423,6 +428,8 @@ const create = context => {
 		) {
 			return;
 		}
+
+		if (allowIndexParameter && node.arguments[0].params.length > 1) return
 
 		callExpressions.push({
 			node,
@@ -468,6 +475,19 @@ const create = context => {
 	});
 };
 
+const schema = [
+	{
+		type: 'object',
+		additionalProperties: false,
+		properties: {
+			allowIndexParameter: {
+				type: 'boolean',
+				default: false,
+			},
+		},
+	},
+];
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	create,
@@ -479,6 +499,7 @@ module.exports = {
 		},
 		fixable: 'code',
 		hasSuggestions: true,
+		schema,
 		messages,
 	},
 };

--- a/test/no-array-for-each.mjs
+++ b/test/no-array-for-each.mjs
@@ -531,7 +531,10 @@ test.snapshot({
 });
 
 test({
-	valid: [],
+	valid: [{
+		code: "foo.forEach((element, index) => {})",
+		options: [{ allowIndexParameter: true }],
+	}],
 	invalid: [
 		{
 			code: outdent`


### PR DESCRIPTION
When using unicorn in [roblox-ts](https://roblox-ts.com/), the `no-array-for-each` suggests that it should convert a for loop to `for (const [index, value] of foo.entries()) {`. Yet, `array.entries()` does not exist.

`array.entries()` also was introduced in ES6 I believe, so adding this paramater would support ES5 code (although very rare these days!) and other runtimes that do not support `array.entries()` yet still want to use unicorn (e.g. [assemblyscript](https://www.assemblyscript.org/)).