### PR TITLE
`prevent-abbreviations`: Add `util` and `utils` to abbreviations

### DIFF
--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -214,6 +214,12 @@ module.exports.defaultReplacements = {
 	tmp: {
 		temporary: true,
 	},
+	util: {
+		utility: true,
+	},
+	utils: {
+		utilities: true,
+	},
 	val: {
 		value: true,
 	},


### PR DESCRIPTION
In fact, the word `utils` does not exist in the English language. It is an abbreviation of the word `utilities`.