### PR TITLE
Unpin and update eslint-doc-generator to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"enquirer": "^2.4.1",
 		"eslint": "^9.10.0",
 		"eslint-ava-rule-tester": "^5.0.1",
-		"eslint-doc-generator": "1.7.0",
+		"eslint-doc-generator": "^2.0.1",
 		"eslint-plugin-eslint-plugin": "^6.2.0",
 		"eslint-plugin-internal-rules": "file:./scripts/internal-rules/",
 		"eslint-remote-tester": "^4.0.1",


### PR DESCRIPTION
* https://github.com/bmish/eslint-doc-generator/releases/tag/v2.0.1
* https://github.com/bmish/eslint-doc-generator/releases/tag/v2.0.0

The latest update should fix the issue mentioned here by respecting the newline character choice in `.editorconfig`:

              This breaks on Windows if markdown files are using `\n`.

_Originally posted by @fisker in https://github.com/bmish/eslint-doc-generator/issues/524#issuecomment-2101847616_

That means we can unpin the version (reverting https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2344).

Let me know if there's still any problem with it.