### PR TITLE
Improve the style for showing fail/pass examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/rule_change.yml
+++ b/.github/ISSUE_TEMPLATE/rule_change.yml
@@ -35,13 +35,13 @@ body:
         ```js
         // ❌
         function foo() {
-          var replace = 'me';
-          return replace;
+        	var replace = 'me';
+        	return replace;
         }
 
         // ✅
         function foo() {
-          return 'me';
+        	return 'me';
         }
         ```
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/rule_change.yml
+++ b/.github/ISSUE_TEMPLATE/rule_change.yml
@@ -21,33 +21,27 @@ body:
     validations:
       required: true
     attributes:
-      label: Fail
-      description: Specify examples of code that should be detected.
+      label: Examples
+      description: Provide examples of code to detect and the acceptable alternatives.
       value: |
         ```js
+        // ❌
         var replace = 'me';
-        ```
 
-        ```js
-        function foo() {
-        	var replace = 'me';
-        	return replace;
-        }
-        ```
-  - type: textarea
-    validations:
-      required: true
-    attributes:
-      label: Pass
-      description: Specify examples of code that would be accepted in its place.
-      value: |
-        ```js
+        // ✅
         const replace = 'me';
         ```
 
         ```js
+        // ❌
         function foo() {
-        	return 'me';
+          var replace = 'me';
+          return replace;
+        }
+
+        // ✅
+        function foo() {
+          return 'me';
         }
         ```
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/rule_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/rule_proposal.yml
@@ -20,31 +20,25 @@ body:
     validations:
       required: true
     attributes:
-      label: Fail
-      description: Specify examples of code that should be detected
+      label: Examples
+      description: Provide examples of code to detect and the acceptable alternatives.
       value: |
         ```js
+        // ❌
         var replace = 'me';
-        ```
 
-        ```js
-        function foo() {
-          var replace = 'me';
-          return replace;
-        }
-        ```
-  - type: textarea
-    validations:
-      required: true
-    attributes:
-      label: Pass
-      description: Specify examples of code that would be accepted in its place
-      value: |
-        ```js
+        // ✅
         const replace = 'me';
         ```
 
         ```js
+        // ❌
+        function foo() {
+          var replace = 'me';
+          return replace;
+        }
+
+        // ✅
         function foo() {
           return 'me';
         }

--- a/.github/ISSUE_TEMPLATE/rule_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/rule_proposal.yml
@@ -34,13 +34,13 @@ body:
         ```js
         // ❌
         function foo() {
-          var replace = 'me';
-          return replace;
+        	var replace = 'me';
+        	return replace;
         }
 
         // ✅
         function foo() {
-          return 'me';
+        	return 'me';
         }
         ```
   - type: input

--- a/scripts/template/documentation.md.jst
+++ b/scripts/template/documentation.md.jst
@@ -3,14 +3,25 @@
 
 <!-- Remove this comment, add more detailed description. -->
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const foo = 'unicorn';
+
+// ✅
+const foo = '🦄';
 ```
 
-## Pass
-
 ```js
-const foo = '🦄';
+// ❌
+function foo() {
+	var replace = 'me';
+	return replace;
+}
+
+// ✅
+function foo() {
+	return 'me';
+}
 ```


### PR DESCRIPTION
We are already using the style in https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-existence-index-check.md?plain=1#L16-L36, but we haven't yet formalized it.