### PR TITLE
`prevent-abbreviations`: Preserve `iOS`

### DIFF
--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -252,6 +252,8 @@ export const defaultAllowList = {
 	getInitialProps: true,
 	getServerSideProps: true,
 	getStaticProps: true,
+	// The name iOS is a standard name for an OS
+	iOS: true,
 	// React PropTypes
 	// https://reactjs.org/docs/typechecking-with-proptypes.html
 	propTypes: true,

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -129,6 +129,7 @@ const tests = {
 		'const i18n = new I18n({ locales: ["en", "fr"] })',
 		'const i18nData = {}',
 		'const l10n = new L10n()',
+		'const iOS = true',
 		outdent`
 			(class {
 				error() {}


### PR DESCRIPTION
Fixes #1970