### PR TITLE
Fix coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
+          disable_search: true
           files: coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
   run-rules-on-codebase:


### PR DESCRIPTION
CI log:

[info - 2025-02-18 05:44:44,827 -- Found 134 coverage files to report](https://github.com/sindresorhus/eslint-plugin-unicorn/actions/runs/13384049161/job/37377470702#step:9:45)

This is actually a long-standing issue I reported to codecov before, but they didn't give me the solution, I found this way a few weeks ago when working in Prettier https://github.com/prettier/prettier/pull/17082

