### PR TITLE
Update `engines.node` to match real compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=18.18"
+		"node": "^18.20.0 || ^20.10.0 || >=21.0.0"
 	},
 	"scripts": {
 		"bundle-lodash": "echo export {defaultsDeep, camelCase, kebabCase, snakeCase, upperFirst, lowerFirst} from 'lodash-es'; | npx esbuild --bundle --outfile=rules/utils/lodash.js --format=esm",


### PR DESCRIPTION
Addresses https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2561#issuecomment-2676673692

Particularly, the current config suggests that v57 is compatible with Node 19, but it's not.

It doesn't address the warnings issue, which can indeed be resolved by bumping Node (I'm not seeing the warning on v20.18.3)