### PR TITLE
Update deprecated docs

### DIFF
--- a/docs/deleted-and-deprecated-rules.md
+++ b/docs/deleted-and-deprecated-rules.md
@@ -1,73 +1,79 @@
 # Deprecated/Removed Rules
 
-## import-index
+## Deprecated rules
 
-This rule was removed. JavaScript modules (ESM) do not support importing a directory.
-
-## no-array-instanceof
+### no-instanceof-array
 
 Replaced by [`no-instanceof-builtins`](rules/no-instanceof-builtins.md) which covers more cases.
 
-## no-fn-reference-in-iterator
+[a](#import-index)
+
+## Deleted rules
+
+### ~import-index~
+
+This rule is outdated. JavaScript modules (ESM) do not support importing a directory.
+
+### ~no-array-instanceof~
+
+Replaced by [`no-instanceof-builtins`](rules/no-instanceof-builtins.md) which covers more cases.
+
+### ~no-fn-reference-in-iterator~
 
 This rule was renamed to [`no-array-callback-reference`](rules/no-array-callback-reference.md) to avoid using the abbreviation `fn` in the name.
 
-## no-instanceof-array
-
-Replaced by [`no-instanceof-builtins`](rules/no-instanceof-builtins.md) which covers more cases.
-
-## no-reduce
+### ~no-reduce~
 
 This rule was renamed to [`no-array-reduce`](rules/no-array-reduce.md) to be more specific.
 
-## no-unsafe-regex
+### ~no-unsafe-regex~
 
 Removed due to bugs.
 
-## prefer-dataset
+### ~prefer-dataset~
 
 This rule was renamed to [`prefer-dom-node-dataset`](rules/prefer-dom-node-dataset.md) to be more specific.
 
-## prefer-event-key
+### ~prefer-event-key~
 
 This rule was renamed to [`prefer-keyboard-event-key`](rules/prefer-keyboard-event-key.md) to be more specific.
 
-## prefer-exponentiation-operator
+### ~prefer-exponentiation-operator~
 
 This rule was deprecated in favor of the built-in ESLint [`prefer-exponentiation-operator`](https://eslint.org/docs/rules/prefer-exponentiation-operator) rule.
 
-## prefer-flat-map
+### ~prefer-flat-map~
 
 This rule was renamed to [`prefer-array-flat-map`](rules/prefer-array-flat-map.md) to be more specific.
 
-## prefer-node-append
+### ~prefer-node-append~
 
 This rule was renamed to [`prefer-dom-node-append`](rules/prefer-dom-node-append.md) to be less ambiguous.
 
-## prefer-node-remove
+### ~prefer-node-remove~
 
 This rule was renamed to [`prefer-dom-node-remove`](rules/prefer-dom-node-remove.md) to be less ambiguous.
 
-## prefer-object-has-own
+### ~prefer-object-has-own~
 
 This rule was deprecated in favor of the built-in ESLint [`prefer-object-has-own`](https://eslint.org/docs/rules/prefer-object-has-own) rule.
 
-## prefer-replace-all
+### ~prefer-replace-all~
 
 This rule was renamed to [`prefer-string-replace-all`](rules/prefer-string-replace-all.md) to be more specific.
 
-## prefer-starts-ends-with
+### ~prefer-starts-ends-with~
 
 This rule was renamed to [`prefer-string-starts-ends-with`](rules/prefer-string-starts-ends-with.md) to be more specific.
 
-## prefer-text-content
+### ~prefer-text-content~
 
 This rule was renamed to [`prefer-dom-node-text-content`](rules/prefer-dom-node-text-content.md) to be more specific.
 
-## prefer-trim-start-end
+### ~prefer-trim-start-end~
 
 This rule was renamed to [`prefer-string-trim-start-end`](rules/prefer-string-trim-start-end.md) to be more specific.
 
-## regex-shorthand
+### ~regex-shorthand~
 
 This rule was renamed to [`better-regex`](rules/better-regex.md) as it does more than just preferring the shorthand.

--- a/docs/deleted-and-deprecated-rules.md
+++ b/docs/deleted-and-deprecated-rules.md
@@ -6,8 +6,6 @@
 
 Replaced by [`no-instanceof-builtins`](rules/no-instanceof-builtins.md) which covers more cases.
 
-[a](#import-index)
-
 ## Deleted rules
 
 ### ~import-index~

--- a/docs/deprecated-rules.md
+++ b/docs/deprecated-rules.md
@@ -2,7 +2,7 @@
 
 ## import-index
 
-This rule is outdated. JavaScript modules (ESM) do not support importing a directory.
+This rule was removed. JavaScript modules (ESM) do not support importing a directory.
 
 ## no-array-instanceof
 

--- a/readme.md
+++ b/readme.md
@@ -186,9 +186,9 @@ export default [
 
 <!-- end auto-generated rules list -->
 
-### Deleted and deprecated Rules
+### Deleted and deprecated rules
 
-See [docs/deleted-and-deprecated-rules.md](docs/deleted-and-deprecated-rules.md)
+See [the list](docs/deleted-and-deprecated-rules.md).
 
 ## Preset configs
 

--- a/readme.md
+++ b/readme.md
@@ -186,9 +186,9 @@ export default [
 
 <!-- end auto-generated rules list -->
 
-### Deprecated Rules
+### Deleted and deprecated Rules
 
-See [docs/deprecated-rules.md](docs/deprecated-rules.md)
+See [docs/deleted-and-deprecated-rules.md](docs/deleted-and-deprecated-rules.md)
 
 ## Preset configs
 

--- a/test/package.js
+++ b/test/package.js
@@ -106,17 +106,16 @@ test('Every rule has valid meta.type', t => {
 	}
 });
 
-test('Every deprecated rules listed in docs/deprecated-rules.md', async t => {
-	const content = await fsAsync.readFile('docs/deprecated-rules.md', 'utf8');
-	const rulesInMarkdown = new Set(content.match(/(?<=^## ).*?$/gm));
-
+test('Every deprecated rules listed in docs/deleted-and-deprecated-rules.md', async t => {
+	const content = await fsAsync.readFile('docs/deleted-and-deprecated-rules.md', 'utf8');
 	for (const name of deprecatedRules) {
 		const rule = eslintPluginUnicorn.rules[name];
 		t.is(typeof rule.create, 'function', `${name} create is not function`);
 		t.deepEqual(rule.create(), {}, `${name} create should return empty object`);
 		t.is(typeof rule.meta.deprecated.message, 'string', `${name} meta.deprecated.message should be string`);
 		t.true(Array.isArray(rule.meta.deprecated.replacedBy), `${name} meta.deprecated.replacedBy should be array`);
-		t.true(rulesInMarkdown.has(name));
+		t.true(content.includes(`\n### ${name}\n`));
+		t.false(content.includes(`\n### ~${name}~\n`));
 	}
 });
 


### PR DESCRIPTION
The `import-index` rule has been removed between `56.0.0` and `57.0.0`: this PR clearly marks it as **removed** in the docs, and not simply _deprecated_.

I think the release where it was removed should also mention it.

Fixes #2585 