### PR TITLE
`no-unnecessary-polyfills`: Fix browserslist field name

### DIFF
--- a/docs/rules/no-unnecessary-polyfills.md
+++ b/docs/rules/no-unnecessary-polyfills.md
@@ -53,9 +53,9 @@ Type: `object`
 
 Type: `string | string[] | object`
 
-Specify the target versions, which could be a Browserlist query or a targets object. See the [core-js-compat `targets` option](https://github.com/zloirock/core-js/tree/HEAD/packages/core-js-compat#targets-option) for more info.
+Specify the target versions, which could be a Browserslist query or a targets object. See the [core-js-compat `targets` option](https://github.com/zloirock/core-js/tree/HEAD/packages/core-js-compat#targets-option) for more info.
 
-If the option is not specified, the target versions are defined using the [`browserlist`](https://browsersl.ist) field in package.json, or as a last resort, the `engines` field in package.json.
+If the option is not specified, the target versions are defined using the [`browserslist`](https://browsersl.ist) field in package.json, or as a last resort, the `engines` field in package.json.
 
 ```js
 "unicorn/no-unnecessary-polyfills": [

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -68,8 +68,8 @@ function getTargets(options, dirname) {
 		return;
 	}
 
-	const {browserlist, engines} = packageResult.packageJson;
-	return browserlist ?? engines;
+	const {browserslist, engines} = packageResult.packageJson;
+	return browserslist ?? engines;
 }
 
 function create(context) {


### PR DESCRIPTION
BrowsersList uses the `browserslist` field in package.json, not `browserlist`.

Docs:
https://browsersl.ist/#q=%22browserslist%22%3A+%5B%0A++%22defaults+and+fully+supports+es6-module%22%2C%0A++%22maintained+node+versions%22%0A%5D