### PR TITLE
Meta: Fix title formatter

### DIFF
--- a/.github/workflows/title-formatter.yml
+++ b/.github/workflows/title-formatter.yml
@@ -14,10 +14,12 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout: docs/rules
       - name: Auto-format rule names in titles
-        uses: fregante/title-replacer-action@v2
+        uses: fregante/keyword-formatter-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pattern-path: docs/rules
-          replacement: '`$0`'
-          trim-wrappers: true
+          keywords-path: docs/rules
+          prefix: unicorn/
+


### PR DESCRIPTION
I rewrote the formatter action to reduce the scope and fix some issues:

- `unicorn/prefer-ternary` is now supported
- ```pre-formatted `something prefer-ternary` ``` is now ignored, as long as the keyword is touching a backtick.

Later followups:

- Restore https://github.com/fregante/keyword-formatter-action/issues/3
- Also fix https://github.com/fregante/keyword-formatter-action/issues/2
