### PR TITLE
`prefer-single-call`: Fix crash on `CallExpression` followed by `FunctionDeclaration`

### DIFF
--- a/rules/prefer-single-call.js
+++ b/rules/prefer-single-call.js
@@ -67,7 +67,7 @@ const cases = [
 	},
 ].map(problematicalCase => ({
 	...problematicalCase,
-	test: callExpression => isExpressionStatement(callExpression) && problematicalCase.test(callExpression),
+	test: callExpression => problematicalCase.test(callExpression) && isExpressionStatement(callExpression),
 }));
 
 function create(context) {

--- a/test/prefer-single-call.js
+++ b/test/prefer-single-call.js
@@ -86,6 +86,10 @@ test.snapshot({
 			],
 		},
 		'for (const _ of []) foo.push(bar);',
+		outdent`
+			function bar() {}
+			foo.push(bindEvents);
+		`,
 	],
 	invalid: [
 		outdent`


### PR DESCRIPTION
Fixes #2637
