### PR TITLE
`prevent-abbreviations`: Add `ProcessEnv` to `defaultAllowList`

### DIFF
--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -254,6 +254,9 @@ export const defaultAllowList = {
 	getStaticProps: true,
 	// The name iOS is a standard name for an OS
 	iOS: true,
+	// Node.js global environment interface
+	// https://nodejs.org/api/process.html#processenv
+	ProcessEnv: true,
 	// React PropTypes
 	// https://reactjs.org/docs/typechecking-with-proptypes.html
 	propTypes: true,


### PR DESCRIPTION
Hello!

I currently have a problem when using the `prevent-abbreviations` rule when typing `process.env`:

```
// environment.d.ts
declare global {
  namespace NodeJS {
    interface ProcessEnv {
      GITHUB_ACTIONS: string;
    }
  }
}

export {}
```

Error:

```
The variable `ProcessEnv` should be named `ProcessEnvironment`.
```

This is the only and natural way to describe types for `process.env`.