### PR TITLE
`no-array-callback-reference`: fix optional chaining expressions ignored

### DIFF
--- a/rules/no-array-callback-reference.js
+++ b/rules/no-array-callback-reference.js
@@ -234,7 +234,6 @@ const create = context => ({
 				minimumArguments: 1,
 				maximumArguments: 2,
 				optionalCall: false,
-				optionalMember: false,
 				computed: false,
 			})
 			|| callExpression.callee.property.type !== 'Identifier'

--- a/test/no-array-callback-reference.js
+++ b/test/no-array-callback-reference.js
@@ -57,6 +57,10 @@ test({
 		...simpleMethods.map(method => `foo.${method}(element => fn(element))`),
 		...reduceLikeMethods.map(method => `foo.${method}((accumulator, element) => fn(element))`),
 
+		// Optional chaining
+		...simpleMethods.map(method => `foo?.${method}(element => fn(element))`),
+		...reduceLikeMethods.map(method => `foo?.${method}((accumulator, element) => fn(element))`),
+
 		// `this.{map, filter, …}`
 		...simpleMethods.map(method => `this.${method}(fn)`),
 		...reduceLikeMethods.map(method => `this.${method}(fn)`),
@@ -157,6 +161,18 @@ test({
 					`foo.${method}((element) => fn(element))`,
 					`foo.${method}((element, index) => fn(element, index))`,
 					`foo.${method}((element, index, array) => fn(element, index, array))`,
+				],
+			}),
+		),
+		...simpleMethodsExceptForEach.map(
+			method => invalidTestCase({
+				code: `foo?.${method}(fn)`,
+				method,
+				name: 'fn',
+				suggestions: [
+					`foo?.${method}((element) => fn(element))`,
+					`foo?.${method}((element, index) => fn(element, index))`,
+					`foo?.${method}((element, index, array) => fn(element, index, array))`,
 				],
 			}),
 		),


### PR DESCRIPTION
This PR fixes an inconsistency where unsafe syntax is allowed if the optional-chaining operator is used:

```js
x.map(String.fromCharCode); // flagged
x?.map(String.fromCharCode); // not flagged 🤔
```

Now both cases are flagged by the rule.

Closes #2294

