### PR TITLE
fix(prefer-includes): 🐛 don’t cross SFC tag boundary when auto-fixing…

### DIFF
--- a/rules/prefer-includes.js
+++ b/rules/prefer-includes.js
@@ -15,14 +15,9 @@ const isNegativeResult = node => ['===', '==', '<'].includes(node.operator);
 
 const getProblem = (context, node, target, argumentsNodes) => {
 	const {sourceCode} = context;
-	const tokenStore = sourceCode.parserServices.getTemplateBodyTokenStore?.() ?? sourceCode;
 
 	const memberExpressionNode = target.parent;
-	const dotToken = tokenStore.getTokenBefore(memberExpressionNode.property);
-	const targetSource = sourceCode.getText().slice(
-		sourceCode.getRange(memberExpressionNode)[0],
-		sourceCode.getRange(dotToken)[0],
-	);
+	const targetSource = sourceCode.getText(target);
 
 	// Strip default `fromIndex`
 	if (isLiteralZero(argumentsNodes[1])) {


### PR DESCRIPTION
Description:
This patch fixes a bug in the `prefer-includes` autofix logic that, in Vue Single-File Components, could accidentally replace across the `<script>` tag boundary (e.g. producing `</script.includes(value)`). The root cause was slicing the full source text via `tokenStore.getTokenBefore` + `getText().slice()`, which in SFCs can span past the script section.

- Before:

```vue
// in .vue

// before
<script>
const foo = value => [].indexOf(value) !== -1
</script>

// after --fix
<script>
const foo = value => [].indexOf(value) !== -1
</script>.includes(value)
</script.includes(value) // broken!
```

- After:

We now call sourceCode.getText(targetAstNode) directly, so the fixer only touches the ArrayExpression’s object and its .indexOf(…) call.

![image](https://github.com/user-attachments/assets/e955b707-81d4-4529-9c07-7378fb72e11c)
