### PR TITLE
`no-typeof-undefined`: fix typo in an example

### DIFF
--- a/docs/rules/no-typeof-undefined.md
+++ b/docs/rules/no-typeof-undefined.md
@@ -29,7 +29,7 @@ if (typeof foo.bar !== 'undefined') {}
 
 ```js
 function foo(bar) {
-	if (foo === undefined) {}
+	if (bar === undefined) {}
 }
 ```
 


### PR DESCRIPTION
This PR fixes a small typo, I assume we should check the value of an argument, not function itself