### PR TITLE
`no-useless-undefined`: udpate docs to mention conflict with `getter-return` ESLint rule

### DIFF
--- a/docs/rules/no-useless-undefined.md
+++ b/docs/rules/no-useless-undefined.md
@@ -139,14 +139,22 @@ const foo = () => undefined;
 const foo = () => undefined;
 ```
 
-## Conflict with ESLint `array-callback-return` rule
+## Conflict with ESLint `array-callback-return` and `getter-return` rules
 
-We recommend setting the ESLint [`array-callback-return`](https://eslint.org/docs/rules/array-callback-return#top) rule option [`allowImplicit`](https://eslint.org/docs/rules/array-callback-return#options) to `true`:
+We recommend setting `allowImplicit` options to `true` for these ESLint rules:
+- [`array-callback-return`](https://eslint.org/docs/rules/array-callback-return#options)
+- [`getter-return`](https://eslint.org/docs/rules/getter-return#options)
 
 ```json
 {
 	"rules": {
 		"array-callback-return": [
+			"error",
+			{
+				"allowImplicit": true
+			}
+		],
+		"getter-return": [
 			"error",
 			{
 				"allowImplicit": true

--- a/docs/rules/no-useless-undefined.md
+++ b/docs/rules/no-useless-undefined.md
@@ -141,7 +141,7 @@ const foo = () => undefined;
 
 ## Conflict with ESLint `array-callback-return` and `getter-return` rules
 
-We recommend setting `allowImplicit` options to `true` for these ESLint rules:
+We recommend setting `allowImplicit` option to `true` for these ESLint rules:
 - [`array-callback-return`](https://eslint.org/docs/rules/array-callback-return#options)
 - [`getter-return`](https://eslint.org/docs/rules/getter-return#options)
 

--- a/docs/rules/no-useless-undefined.md
+++ b/docs/rules/no-useless-undefined.md
@@ -142,6 +142,7 @@ const foo = () => undefined;
 ## Conflict with ESLint `array-callback-return` and `getter-return` rules
 
 We recommend setting `allowImplicit` option to `true` for these ESLint rules:
+
 - [`array-callback-return`](https://eslint.org/docs/rules/array-callback-return#options)
 - [`getter-return`](https://eslint.org/docs/rules/getter-return#options)
 


### PR DESCRIPTION


<!--
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
-->
