### PR TITLE
`no-array-reduce` - enable reporting of optional chaining and calling of `.reduce()`

### DIFF
--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -16,7 +16,6 @@ const cases = [
 				methods: ['reduce', 'reduceRight'],
 				minimumArguments: 1,
 				maximumArguments: 2,
-				optionalCall: false,
 			})
 			&& !isNodeValueNotFunction(callExpression.arguments[0]),
 		getMethodNode: callExpression => callExpression.callee.property,
@@ -46,7 +45,6 @@ const cases = [
 		test: callExpression =>
 			isMethodCall(callExpression, {
 				method: 'call',
-				optionalCall: false,
 			})
 			&& isArrayPrototypeProperty(callExpression.callee.object, {
 				properties: ['reduce', 'reduceRight'],
@@ -62,7 +60,6 @@ const cases = [
 		test: callExpression =>
 			isMethodCall(callExpression, {
 				method: 'apply',
-				optionalCall: false,
 			})
 			&& isArrayPrototypeProperty(callExpression.callee.object, {
 				properties: ['reduce', 'reduceRight'],

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -16,6 +16,7 @@ const cases = [
 				methods: ['reduce', 'reduceRight'],
 				minimumArguments: 1,
 				maximumArguments: 2,
+				optionalCall: false,
 			})
 			&& !isNodeValueNotFunction(callExpression.arguments[0]),
 		getMethodNode: callExpression => callExpression.callee.property,

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -45,6 +45,8 @@ const cases = [
 		test: callExpression =>
 			isMethodCall(callExpression, {
 				method: 'call',
+				optionalCall: false,
+				optionalMember: false,
 			})
 			&& isArrayPrototypeProperty(callExpression.callee.object, {
 				properties: ['reduce', 'reduceRight'],
@@ -60,6 +62,8 @@ const cases = [
 		test: callExpression =>
 			isMethodCall(callExpression, {
 				method: 'apply',
+				optionalCall: false,
+				optionalMember: false,
 			})
 			&& isArrayPrototypeProperty(callExpression.callee.object, {
 				properties: ['reduce', 'reduceRight'],

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -17,7 +17,6 @@ const cases = [
 				minimumArguments: 1,
 				maximumArguments: 2,
 				optionalCall: false,
-				optionalMember: false,
 			})
 			&& !isNodeValueNotFunction(callExpression.arguments[0]),
 		getMethodNode: callExpression => callExpression.callee.property,
@@ -48,7 +47,6 @@ const cases = [
 			isMethodCall(callExpression, {
 				method: 'call',
 				optionalCall: false,
-				optionalMember: false,
 			})
 			&& isArrayPrototypeProperty(callExpression.callee.object, {
 				properties: ['reduce', 'reduceRight'],
@@ -65,7 +63,6 @@ const cases = [
 			isMethodCall(callExpression, {
 				method: 'apply',
 				optionalCall: false,
-				optionalMember: false,
 			})
 			&& isArrayPrototypeProperty(callExpression.callee.object, {
 				properties: ['reduce', 'reduceRight'],

--- a/test/no-array-reduce.js
+++ b/test/no-array-reduce.js
@@ -81,6 +81,9 @@ test({
 		// More or less argument(s)
 		// We are not checking arguments length
 
+		// Ignore optional call to avoid false positive on non-array objects
+		'array.reduce?.((str, item) => str += item, "")',
+
 		// `reduce-like`
 		'array.reducex(foo)',
 		'array.xreduce(foo)',
@@ -109,7 +112,6 @@ test({
 	invalid: [
 		'array.reduce((str, item) => str += item, "")',
 		'array?.reduce((str, item) => str += item, "")',
-		'array.reduce?.((str, item) => str += item, "")',
 		outdent`
 			array.reduce((obj, item) => {
 				obj[item] = null;

--- a/test/no-array-reduce.js
+++ b/test/no-array-reduce.js
@@ -12,6 +12,7 @@ test({
 		'a[b.reduce]()',
 		'a(b.reduce)',
 		'a.reduce()',
+		'a?.reduce()',
 		'a.reduce(1, 2, 3)',
 		'a.reduce(b, c, d)',
 		'[][reduce].call()',
@@ -106,6 +107,7 @@ test({
 	].flatMap(testCase => [testCase, testCase.replace('reduce', 'reduceRight')]),
 	invalid: [
 		'array.reduce((str, item) => str += item, "")',
+		'array?.reduce((str, item) => str += item, "")',
 		outdent`
 			array.reduce((obj, item) => {
 				obj[item] = null;

--- a/test/no-array-reduce.js
+++ b/test/no-array-reduce.js
@@ -13,6 +13,7 @@ test({
 		'a(b.reduce)',
 		'a.reduce()',
 		'a?.reduce()',
+		'a.reduce?.()',
 		'a.reduce(1, 2, 3)',
 		'a.reduce(b, c, d)',
 		'[][reduce].call()',
@@ -108,6 +109,7 @@ test({
 	invalid: [
 		'array.reduce((str, item) => str += item, "")',
 		'array?.reduce((str, item) => str += item, "")',
+		'array.reduce?.((str, item) => str += item, "")',
 		outdent`
 			array.reduce((obj, item) => {
 				obj[item] = null;


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2720

This PR enables checking for optionally chainged `.reduce()` calls for `no-array-reduce` rule.

<!--
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
-->
