### PR TITLE
Rename `isNumberLiteral` to `isNumericLiteral`

### DIFF
--- a/rules/ast/index.js
+++ b/rules/ast/index.js
@@ -1,7 +1,7 @@
 export {
 	isLiteral,
 	isStringLiteral,
-	isNumberLiteral,
+	isNumericLiteral,
 	isBigIntLiteral,
 	isNullLiteral,
 	isRegexLiteral,

--- a/rules/ast/is-negative-one.js
+++ b/rules/ast/is-negative-one.js
@@ -1,8 +1,8 @@
-import {isNumberLiteral} from './literal.js';
+import {isNumericLiteral} from './literal.js';
 
 export default function isNegativeOne(node) {
 	return node?.type === 'UnaryExpression'
 		&& node.operator === '-'
-		&& isNumberLiteral(node.argument)
+		&& isNumericLiteral(node.argument)
 		&& node.argument.value === 1;
 }

--- a/rules/ast/literal.js
+++ b/rules/ast/literal.js
@@ -12,7 +12,7 @@ export function isLiteral(node, value) {
 
 export const isStringLiteral = node => node?.type === 'Literal' && typeof node.value === 'string';
 
-export const isNumberLiteral = node => node.type === 'Literal' && typeof node.value === 'number';
+export const isNumericLiteral = node => node.type === 'Literal' && typeof node.value === 'number';
 
 export const isRegexLiteral = node => node.type === 'Literal' && Boolean(node.regex);
 

--- a/rules/consistent-existence-index-check.js
+++ b/rules/consistent-existence-index-check.js
@@ -1,12 +1,12 @@
 import toLocation from './utils/to-location.js';
-import {isMethodCall, isNegativeOne, isNumberLiteral} from './ast/index.js';
+import {isMethodCall, isNegativeOne, isNumericLiteral} from './ast/index.js';
 
 const MESSAGE_ID = 'consistent-existence-index-check';
 const messages = {
 	[MESSAGE_ID]: 'Prefer `{{replacementOperator}} {{replacementValue}}` over `{{originalOperator}} {{originalValue}}` to check {{existenceOrNonExistence}}.',
 };
 
-const isZero = node => isNumberLiteral(node) && node.value === 0;
+const isZero = node => isNumericLiteral(node) && node.value === 0;
 
 /**
 @param {parent: import('estree').BinaryExpression} binaryExpression

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -3,7 +3,7 @@ import {checkVueTemplate} from './utils/rule.js';
 import isLogicalExpression from './utils/is-logical-expression.js';
 import {isBooleanNode, getBooleanAncestor} from './utils/boolean.js';
 import {fixSpaceAroundKeyword} from './fix/index.js';
-import {isLiteral, isMemberExpression, isNumberLiteral} from './ast/index.js';
+import {isLiteral, isMemberExpression, isNumericLiteral} from './ast/index.js';
 
 const TYPE_NON_ZERO = 'non-zero';
 const TYPE_ZERO = 'zero';
@@ -90,7 +90,7 @@ function getLengthCheckNode(node) {
 }
 
 function isNodeValueNumber(node, context) {
-	if (isNumberLiteral(node)) {
+	if (isNumericLiteral(node)) {
 		return true;
 	}
 

--- a/rules/no-magic-array-flat-depth.js
+++ b/rules/no-magic-array-flat-depth.js
@@ -1,4 +1,4 @@
-import {isMethodCall, isNumberLiteral} from './ast/index.js';
+import {isMethodCall, isNumericLiteral} from './ast/index.js';
 import {getCallExpressionTokens} from './utils/index.js';
 
 const MESSAGE_ID = 'no-magic-array-flat-depth';
@@ -19,7 +19,7 @@ const create = context => ({
 
 		const [depth] = callExpression.arguments;
 
-		if (!isNumberLiteral(depth) || depth.value === 1) {
+		if (!isNumericLiteral(depth) || depth.value === 1) {
 			return;
 		}
 

--- a/rules/no-zero-fractions.js
+++ b/rules/no-zero-fractions.js
@@ -3,7 +3,7 @@ import needsSemicolon from './utils/needs-semicolon.js';
 import {isDecimalInteger} from './utils/numeric.js';
 import toLocation from './utils/to-location.js';
 import {fixSpaceAroundKeyword} from './fix/index.js';
-import {isNumberLiteral} from './ast/index.js';
+import {isNumericLiteral} from './ast/index.js';
 
 const MESSAGE_ZERO_FRACTION = 'zero-fraction';
 const MESSAGE_DANGLING_DOT = 'dangling-dot';
@@ -15,7 +15,7 @@ const messages = {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => ({
 	Literal(node) {
-		if (!isNumberLiteral(node)) {
+		if (!isNumericLiteral(node)) {
 			return;
 		}
 

--- a/rules/number-literal-case.js
+++ b/rules/number-literal-case.js
@@ -1,5 +1,5 @@
 import {checkVueTemplate} from './utils/rule.js';
-import {isNumberLiteral, isBigIntLiteral} from './ast/index.js';
+import {isNumericLiteral, isBigIntLiteral} from './ast/index.js';
 
 const MESSAGE_ID = 'number-literal-case';
 const messages = {
@@ -29,7 +29,7 @@ const create = context => ({
 		options.hexadecimalValue ??= 'uppercase';
 
 		let fixed = raw;
-		if (isNumberLiteral(node)) {
+		if (isNumericLiteral(node)) {
 			fixed = fix(raw, options);
 		} else if (isBigIntLiteral(node)) {
 			fixed = fix(raw.slice(0, -1), options) + 'n';

--- a/rules/prefer-keyboard-event-key.js
+++ b/rules/prefer-keyboard-event-key.js
@@ -1,6 +1,6 @@
 import escapeString from './utils/escape-string.js';
 import translateToKey from './shared/event-keys.js';
-import {isNumberLiteral} from './ast/index.js';
+import {isNumericLiteral} from './ast/index.js';
 
 const MESSAGE_ID = 'prefer-keyboard-event-key';
 const messages = {
@@ -80,7 +80,7 @@ const fix = node => fixer => {
 		!(
 			type === 'BinaryExpression'
 			&& (operator === '==' || operator === '===')
-			&& isNumberLiteral(right)
+			&& isNumericLiteral(right)
 		)
 	) {
 		return;

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -1,7 +1,7 @@
 import {getStaticValue} from '@eslint-community/eslint-utils';
 import {getParenthesizedText, getParenthesizedRange} from './utils/parentheses.js';
 import {replaceArgument} from './fix/index.js';
-import {isNumberLiteral, isMethodCall} from './ast/index.js';
+import {isNumericLiteral, isMethodCall} from './ast/index.js';
 
 const MESSAGE_ID_SUBSTR = 'substr';
 const MESSAGE_ID_SUBSTRING = 'substring';
@@ -11,7 +11,7 @@ const messages = {
 };
 
 const getNumericValue = node => {
-	if (isNumberLiteral(node)) {
+	if (isNumericLiteral(node)) {
 		return node.value;
 	}
 
@@ -43,7 +43,7 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 	const replaceSecondArgument = text => replaceArgument(fixer, secondArgument, text, sourceCode);
 
 	if (firstArgumentStaticResult?.value === 0) {
-		if (isNumberLiteral(secondArgument) || isLengthProperty(secondArgument)) {
+		if (isNumericLiteral(secondArgument) || isLengthProperty(secondArgument)) {
 			return;
 		}
 
@@ -57,7 +57,7 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 		return;
 	}
 
-	if (argumentNodes.every(node => isNumberLiteral(node))) {
+	if (argumentNodes.every(node => isNumericLiteral(node))) {
 		yield replaceSecondArgument(firstArgument.value + secondArgument.value);
 		return;
 	}

--- a/rules/shared/negative-index.js
+++ b/rules/shared/negative-index.js
@@ -1,6 +1,6 @@
 import isSameReference from '../utils/is-same-reference.js';
 import {getParenthesizedRange} from '../utils/parentheses.js';
-import {isNumberLiteral} from '../ast/index.js';
+import {isNumericLiteral} from '../ast/index.js';
 
 const isLengthMemberExpression = node =>
 	node.type === 'MemberExpression'
@@ -10,7 +10,7 @@ const isLengthMemberExpression = node =>
 	&& node.property.name === 'length';
 
 const isLiteralPositiveNumber = node =>
-	isNumberLiteral(node)
+	isNumericLiteral(node)
 	&& node.value > 0;
 
 export function getNegativeIndexLengthNode(node, objectNode) {

--- a/rules/utils/is-number.js
+++ b/rules/utils/is-number.js
@@ -1,5 +1,5 @@
 import {getStaticValue} from '@eslint-community/eslint-utils';
-import {isNumberLiteral} from '../ast/index.js';
+import {isNumericLiteral} from '../ast/index.js';
 
 const isStaticProperties = (node, object, properties) =>
 	node.type === 'MemberExpression'
@@ -117,7 +117,7 @@ const mathOperators = new Set(['-', '*', '/', '%', '**', '<<', '>>', '|', '^', '
 // eslint-disable-next-line complexity
 export default function isNumber(node, scope) {
 	if (
-		isNumberLiteral(node)
+		isNumericLiteral(node)
 		|| isMathProperty(node)
 		|| isMathMethodCall(node)
 		|| isNumberCall(node)

--- a/rules/utils/numeric.js
+++ b/rules/utils/numeric.js
@@ -1,4 +1,4 @@
-import {isNumberLiteral, isBigIntLiteral} from '../ast/index.js';
+import {isNumericLiteral, isBigIntLiteral} from '../ast/index.js';
 
 // Determine whether this node is a decimal integer literal.
 // Copied from https://github.com/eslint/eslint/blob/cc4871369645c3409dc56ded7a555af8a9f63d51/lib/rules/utils/ast-utils.js#L1237
@@ -6,11 +6,11 @@ const DECIMAL_INTEGER_PATTERN = /^(?:0|0[0-7]*[89]\d*|[1-9](?:_?\d)*)$/u;
 
 export const isDecimalInteger = text => DECIMAL_INTEGER_PATTERN.test(text);
 
-export const isDecimalIntegerNode = node => isNumberLiteral(node) && isDecimalInteger(node.raw);
+export const isDecimalIntegerNode = node => isNumericLiteral(node) && isDecimalInteger(node.raw);
 
-export const isNumeric = node => isNumberLiteral(node) || isBigIntLiteral(node);
+export const isNumeric = node => isNumericLiteral(node) || isBigIntLiteral(node);
 
-export const isLegacyOctal = node => isNumberLiteral(node) && /^0\d+$/.test(node.raw);
+export const isLegacyOctal = node => isNumericLiteral(node) && /^0\d+$/.test(node.raw);
 
 export function getPrefix(text) {
 	let prefix = '';


### PR DESCRIPTION
It's more common to call it `NumericLiteral` instead of `NumberLiteral`.

[`NumericLiteral` in babel](https://github.com/babel/babel/blob/7f57d3a2e97b7e2800fb82cff9284a3591377971/packages/babel-parser/src/types.ts#L251)

[`NumericLiteral` in oxc](https://github.com/oxc-project/oxc/blob/dc9645f98f7d009919e1220db26a345de922babd/npm/oxc-types/types.d.ts#L838)

ESLint also use more [`NumericLiteral`](https://github.com/search?q=repo%3Aeslint%2Feslint+NumericLiteral&type=code) than [`NumberLiteral`](https://github.com/search?q=repo%3Aeslint%2Feslint+NumberLiteral&type=code)