### PR TITLE
`no-array-reverse`: better examples in doc

### DIFF
--- a/docs/rules/no-array-reverse.md
+++ b/docs/rules/no-array-reverse.md
@@ -15,10 +15,10 @@ Prefer using [`Array#toReversed()`](https://developer.mozilla.org/en-US/docs/Web
 
 ```js
 // ❌
-const reversed = [...array].reverse();
+const reversed = array.reverse();
 
 // ✅
-const reversed = [...array].toReversed();
+const reversed = array.toReversed();
 ```
 
 ## Options


### PR DESCRIPTION
This is a bad example of incorrect code, because it will create a new array and does not modify the original one.