### PR TITLE
`no-useless-undefined`: Ignore `Set#delete(undefined)`

### DIFF
--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -53,6 +53,8 @@ const shouldIgnore = node => {
 		|| name === 'add'
 		// `set.has(undefined)`
 		|| name === 'has'
+		// `set.delete(undefined)`
+		|| name === 'delete'
 
 		// `map.set(foo, undefined)`
 		|| name === 'set'

--- a/test/no-useless-undefined.js
+++ b/test/no-useless-undefined.js
@@ -61,6 +61,7 @@ test({
 		'props.setState?.(undefined)',
 		'array.includes(undefined)',
 		'set.has(undefined)',
+		'set.delete(undefined)',
 
 		// `Function#bind()`
 		'foo.bind(bar, undefined)',


### PR DESCRIPTION
Fixes #2737