### PR TITLE
Update style for rule fail/pass examples (1/5)

### DIFF
--- a/docs/rules/better-regex.md
+++ b/docs/rules/better-regex.md
@@ -9,28 +9,62 @@
 
 Note: This rule uses [`regexp-tree`](https://github.com/DmitrySoshnikov/regexp-tree) and [`clean-regexp`](https://github.com/samverschueren/clean-regexp) under the hood.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const regex = /[0-9]/;
-const regex = /[^0-9]/;
-const regex = /[a-zA-Z0-9_]/;
-const regex = /[a-z0-9_]/i;
-const regex = /[^a-zA-Z0-9_]/;
-const regex = /[^a-z0-9_]/i;
-const regex = /[0-9]\.[a-zA-Z0-9_]\-[^0-9]/i;
+
+// ✅
+const regex = /\d/;
 ```
 
-## Pass
+```js
+// ❌
+const regex = /[^0-9]/;
+
+// ✅
+const regex = /\D/;
+```
 
 ```js
-const regex = /\d/;
-const regex = /\D/;
+// ❌
+const regex = /[a-zA-Z0-9_]/;
+
+// ✅
 const regex = /\w/;
+```
+
+```js
+// ❌
+const regex = /[a-z0-9_]/i;
+
+// ✅
 const regex = /\w/i;
+```
+
+```js
+// ❌
+const regex = /[^a-zA-Z0-9_]/;
+
+// ✅
 const regex = /\W/;
+```
+
+```js
+// ❌
+const regex = /[^a-z0-9_]/i;
+
+// ✅
 const regex = /\W/i;
-const regex = /\d\.\w\-\D/i;
+```
+
+```js
+// ❌
+const regex = /[0-9]\.[a-zA-Z0-9_]\-[^0-9]/i;
+
+// ✅
+const regex = /\d\.\w-\D/i;
 ```
 
 ## Options

--- a/docs/rules/catch-error-name.md
+++ b/docs/rules/catch-error-name.md
@@ -21,54 +21,52 @@ The following names are ignored:
 - Descriptive names, for example, `fsError` or `authError`.
 - Names matching [`options.ignore`](#ignore).
 
-## Fail
+## Examples
 
 ```js
+// ❌
 try {} catch (badName) {}
-```
 
-```js
-// `_` is not allowed if it's used
-try {} catch (_) {
-	console.log(_);
-}
-```
-
-```js
-promise.catch(badName => {});
-```
-
-```js
-promise.then(undefined, badName => {});
-```
-
-## Pass
-
-```js
+// ✅
 try {} catch (error) {}
 ```
 
 ```js
+// ❌
+promise.catch(badName => {});
+
+// ✅
 promise.catch(error => {});
 ```
 
 ```js
+// ❌
+promise.then(undefined, badName => {});
+
+// ✅
 promise.then(undefined, error => {});
 ```
 
 ```js
-// `_` is allowed when it's not used
+// ❌
+try {} catch (_) {
+	console.log(_);
+}
+
+// ✅
 try {} catch (_) {
 	console.log(foo);
 }
 ```
 
 ```js
+// ✅
 // Descriptive name is allowed
 try {} catch (fsError) {}
 ```
 
 ```js
+// ✅
 // `error_` is allowed because of shadowed variables
 try {} catch (error_) {
 	const error = new Error('🦄');

--- a/docs/rules/consistent-assert.md
+++ b/docs/rules/consistent-assert.md
@@ -18,7 +18,7 @@ assert.strictEqual(actual, expected);
 assert.deepStrictEqual(actual, expected);
 
 // ❌
-assert(divide(10, 2) === 5); // Inconsistent with other API styles
+assert(divide(10, 2) === 5);
 
 // ✅
 assert.ok(divide(10, 2) === 5);
@@ -31,7 +31,7 @@ assert.strictEqual(actual, expected);
 assert.deepStrictEqual(actual, expected);
 
 // ❌
-assert(divide(10, 2) === 5); // Inconsistent with other API styles
+assert(divide(10, 2) === 5);
 
 // ✅
 assert.ok(divide(10, 2) === 5);
@@ -44,7 +44,7 @@ assert.strictEqual(actual, expected);
 assert.deepStrictEqual(actual, expected);
 
 // ❌
-assert(divide(10, 2) === 5); // Inconsistent with other API styles
+assert(divide(10, 2) === 5);
 
 // ✅
 assert.ok(divide(10, 2) === 5);

--- a/docs/rules/consistent-destructuring.md
+++ b/docs/rules/consistent-destructuring.md
@@ -11,49 +11,57 @@ Enforces the use of already destructured objects and their variables over access
 
 This rule is partly fixable. It does not fix nested destructuring.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const {a} = foo;
 console.log(a, foo.b);
+
+// ✅
+const {a, b} = foo;
+console.log(a, b);
+
+// ✅
+console.log(foo.a, foo.b);
 ```
 
 ```js
+// ❌
 const {a} = foo;
 console.log(foo.a);
-```
 
-```js
-const {
-	a: {
-		b
-	}
-} = foo;
-console.log(foo.a.c);
-```
-
-```js
-const {bar} = foo;
-const {a} = foo.bar;
-```
-
-## Pass
-
-```js
+// ✅
 const {a} = foo;
 console.log(a);
 ```
 
 ```js
-console.log(foo.a, foo.b);
+// ❌
+const {
+	a: {b},
+} = foo;
+console.log(foo.a.c);
 ```
 
 ```js
+// ❌
+const {bar} = foo;
+const {a} = foo.bar;
+
+// ✅
+const {bar} = foo;
+const {a} = bar;
+```
+
+```js
+// ✅
 const {a} = foo;
 console.log(a, foo.b());
 ```
 
 ```js
+// ✅
 const {a} = foo.bar;
 console.log(foo.bar);
 ```

--- a/docs/rules/consistent-empty-array-spread.md
+++ b/docs/rules/consistent-empty-array-spread.md
@@ -9,32 +9,28 @@
 
 When spreading a ternary in an array, we can use both `[]` and `''` as fallbacks, but it's better to have consistent types in both branches.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const array = [
 	a,
 	...(foo ? [b, c] : ''),
 ];
-```
 
-```js
+// ❌
 const array = [
 	a,
 	...(foo ? 'bc' : []),
 ];
-```
 
-## Pass
-
-```js
+// ✅
 const array = [
 	a,
 	...(foo ? [b, c] : []),
 ];
-```
 
-```js
+// ✅
 const array = [
 	a,
 	...(foo ? 'bc' : ''),

--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -7,9 +7,10 @@
 
 A function definition should be placed as close to the top-level scope as possible without breaking its captured values. This improves readability, [directly improves performance](https://stackoverflow.com/a/81329/207247) and allows JavaScript engines to [better optimize performance](https://ponyfoo.com/articles/javascript-performance-pitfalls-v8#optimization-limit).
 
-## Fail
+## Examples
 
 ```js
+// ❌
 export function doFoo(foo) {
 	// Does not capture anything from the scope, can be moved to the outer scope
 	function doBar(bar) {
@@ -19,16 +20,7 @@ export function doFoo(foo) {
 	return doBar;
 }
 
-function doFoo(foo) {
-	const doBar = bar => {
-		return bar === 'bar';
-	};
-}
-```
-
-## Pass
-
-```js
+// ✅
 function doBar(bar) {
 	return bar === 'bar';
 }
@@ -36,7 +28,26 @@ function doBar(bar) {
 export function doFoo(foo) {
 	return doBar;
 }
+```
 
+```js
+// ❌
+function doFoo(foo) {
+	const doBar = bar => {
+		return bar === 'bar';
+	};
+}
+
+// ✅
+const doBar = bar => {
+	return bar === 'bar';
+};
+
+function doFoo(foo) {}
+```
+
+```js
+// ✅
 export function doFoo(foo) {
 	function doBar(bar) {
 		return bar === 'bar' && foo.doBar(bar);

--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -9,87 +9,86 @@
 
 Enforces the only valid way of `Error` subclassing. It works with any super class that ends in `Error`.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 class CustomError extends Error {
 	constructor(message) {
 		super(message);
+		// The `this.message` assignment is useless as it's already set via the `super()` call.
 		this.message = message;
 		this.name = 'CustomError';
 	}
 }
-```
 
-The `this.message` assignment is useless as it's already set via the `super()` call.
-
-```js
+// ❌
 class CustomError extends Error {
 	constructor(message) {
 		super();
+		// Pass the error message to `super()` instead of setting `this.message`.
 		this.message = message;
+		this.name = 'CustomError';
+	}
+}
+
+// ❌
+class CustomError extends Error {
+	constructor(message) {
+		super(message);
+		// No `name` property set. The name property is needed so the
+		// error shows up as `[CustomError: foo]` and not `[Error: foo]`.
+	}
+}
+
+// ❌
+class CustomError extends Error {
+	constructor(message) {
+		super(message);
+		// Use a string literal to set the `name` property as it will not change after minifying.
+		this.name = this.constructor.name;
+	}
+}
+
+// ❌
+class CustomError extends Error {
+	constructor(message) {
+		super(message);
+		// The `name` property should be set to the class name.
+		this.name = 'MyError';
+	}
+}
+
+// ✅
+class CustomError extends Error {
+	constructor(message) {
+		super(message);
 		this.name = 'CustomError';
 	}
 }
 ```
 
-Pass the error message to `super()` instead of setting `this.message`.
-
 ```js
-class CustomError extends Error {
-	constructor(message) {
-		super(message);
-	}
-}
-```
-
-No `name` property set. The name property is needed so the error shows up as `[CustomError: foo]` and not `[Error: foo]`.
-
-```js
-class CustomError extends Error {
-	constructor(message) {
-		super(message);
-		this.name = this.constructor.name;
-	}
-}
-```
-
-Use a string literal to set the `name` property as it will not change after minifying.
-
-```js
-class CustomError extends Error {
-	constructor(message) {
-		super(message);
-		this.name = 'MyError';
-	}
-}
-```
-
-The `name` property should be set to the class name.
-
-```js
+// ❌
+// The class name should be capitalized and end with `Error`.
 class foo extends Error {
 	constructor(message) {
 		super(message);
 		this.name = 'foo';
 	}
 }
-```
 
-The class name is invalid. It should be capitalized and end with `Error`. In this case it should be `FooError`.
-
-## Pass
-
-```js
-class CustomError extends Error {
+// ✅
+class FooError extends Error {
 	constructor(message) {
 		super(message);
-		this.name = 'CustomError';
+		this.name = 'FooError';
 	}
 }
 ```
 
 ```js
+// ✅
 class CustomError extends Error {
 	constructor() {
 		super('My custom error');
@@ -99,6 +98,7 @@ class CustomError extends Error {
 ```
 
 ```js
+// ✅
 class CustomError extends TypeError {
 	constructor() {
 		super();

--- a/docs/rules/empty-brace-spaces.md
+++ b/docs/rules/empty-brace-spaces.md
@@ -7,26 +7,24 @@
 <!-- end auto-generated rule header -->
 <!-- Do not manually modify this header. Run: `npm run fix:eslint-docs` -->
 
-## Fail
+## Examples
 
 ```js
+// ❌
 class Unicorn {
 }
-```
 
-```js
-try {
-	foo();
-} catch { }
-```
-
-## Pass
-
-```js
+// ✅
 class Unicorn {}
 ```
 
 ```js
+// ❌
+try {
+	foo();
+} catch { }
+
+// ✅
 try {
 	foo();
 } catch {}

--- a/docs/rules/expiring-todo-comments.md
+++ b/docs/rules/expiring-todo-comments.md
@@ -183,9 +183,10 @@ Imagine you maintain a `main` branch at a version such as 10 and always keep wor
   `TODO [...]: message` or `TODO [...] message`.
 - If no proper argument is found, you'll be notified that the TODO is useless (See [`eslint/no-warning-comments`](#disallow-warning-comments-no-warning-comments)).
 
-## Fail
+## Examples
 
 ```js
+// ❌
 // TODO [2000-01-01]: I'll fix this next week.
 // TODO [2000-01-01, 2001-01-01]: Multiple dates won't work.
 
@@ -204,9 +205,8 @@ Imagine you maintain a `main` branch at a version such as 10 and always keep wor
 // TODO: Add unicorns.
 ```
 
-## Pass
-
 ```js
+// ✅
 // TODO [2200-12-25]: Too long... Can you feel it?
 // FIXME [2200-12-25]: Too long... Can you feel it?
 

--- a/docs/rules/explicit-length-check.md
+++ b/docs/rules/explicit-length-check.md
@@ -15,56 +15,50 @@ This rule is fixable, unless it's [unsafe to fix](#unsafe-to-fix-case).
 
 Enforce comparison with `=== 0` when checking for zero length.
 
-### Fail
+### Examples
 
 ```js
+// ❌
 const isEmpty = !foo.length;
-```
 
-```js
+// ❌
 const isEmpty = foo.length == 0;
-```
 
-```js
+// ❌
 const isEmpty = foo.length < 1;
-```
 
-```js
+// ❌
 const isEmpty = 0 === foo.length;
-```
 
-```js
+// ❌
 const isEmpty = 0 == foo.length;
-```
 
-```js
+// ❌
 const isEmpty = 1 > foo.length;
-```
 
-```js
+// ❌
 // Negative style is disallowed too
 const isEmpty = !(foo.length > 0);
-```
 
-```js
-const isEmptySet = !foo.size;
-```
-
-```vue
-<template>
-	<div v-if="foo.length">Vue</div>
-</template>
-```
-
-### Pass
-
-```js
+// ✅
 const isEmpty = foo.length === 0;
 ```
 
+```js
+// ❌
+const isEmptySet = !foo.size;
+
+// ✅
+const isEmptySet = foo.size === 0;
+```
+
 ```vue
 <template>
-	<div v-if="foo.length > 0">Vue</div>
+	<!-- ❌ -->
+	<div v-if="!foo.length">Vue</div>
+
+	<!-- ✅ -->
+	<div v-if="foo.length === 0">Vue</div>
 </template>
 ```
 
@@ -72,73 +66,79 @@ const isEmpty = foo.length === 0;
 
 Enforce comparison with `> 0` when checking for non-zero length.
 
-### Fail
+### Examples
 
 ```js
+// ❌
 const isNotEmpty = foo.length !== 0;
-```
 
-```js
+// ❌
 const isNotEmpty = foo.length != 0;
-```
 
-```js
+// ❌
 const isNotEmpty = foo.length >= 1;
-```
 
-```js
+// ❌
 const isNotEmpty = 0 !== foo.length;
-```
 
-```js
+// ❌
 const isNotEmpty = 0 != foo.length;
-```
 
-```js
+// ❌
 const isNotEmpty = 0 < foo.length;
-```
 
-```js
+// ❌
 const isNotEmpty = 1 <= foo.length;
-```
 
-```js
+// ❌
 const isNotEmpty = Boolean(foo.length);
-```
 
-```js
+// ❌
 // Negative style is disallowed too
 const isNotEmpty = !(foo.length === 0);
-```
 
-```js
-if (foo.length || bar.length) {}
-```
-
-```js
-const unicorn = foo.length ? 1 : 2;
-```
-
-```js
-while (foo.length) {}
-```
-
-```js
-do {} while (foo.length);
-```
-
-```js
-for (; foo.length; ) {};
-```
-
-### Pass
-
-```js
+// ✅
 const isNotEmpty = foo.length > 0;
 ```
 
 ```js
+// ❌
+if (foo.length || bar.length) {}
+
+// ✅
 if (foo.length > 0 || bar.length > 0) {}
+```
+
+```js
+// ❌
+const unicorn = foo.length ? 1 : 2;
+
+// ✅
+const unicorn = foo.length > 0 ? 1 : 2;
+```
+
+```js
+// ❌
+while (foo.length) {}
+
+// ✅
+while (foo.length > 0) {}
+```
+
+```js
+// ❌
+do {} while (foo.length);
+
+// ✅
+do {} while (foo.length > 0);
+```
+
+```js
+// ❌
+for (; foo.length; ) {};
+
+// ✅
+for (; foo.length > 0; ) {};
 ```
 
 ### Options

--- a/docs/rules/import-style.md
+++ b/docs/rules/import-style.md
@@ -14,21 +14,24 @@ This rule defines 4 import styles:
 - `namespace` - `import * as path from 'path'` or `const path = require('path')`
 - `named` - `import {inspect} from 'util'` or `const {inspect} = require('util')`
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const util = require('node:util');
 
-import util from 'node:util';
-
-import * as util from 'node:util';
+// ✅
+const {promisify} = require('node:util');
 ```
 
-## Pass
-
 ```js
-const {promisify} = require('node:util');
+// ❌
+import util from 'node:util';
 
+// ❌
+import * as util from 'node:util';
+
+// ✅
 import {promisify} from 'node:util';
 ```
 

--- a/docs/rules/new-for-builtins.md
+++ b/docs/rules/new-for-builtins.md
@@ -53,33 +53,31 @@ Disallows the use of `new` for following builtins.
 
 This rule is fixable, except `new String()`, `new Number()`, and `new Boolean()`, [they return wrapped object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#String_primitives_and_String_objects).
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const list = Array(10);
-```
 
-```js
-const now = Date();
-```
-
-```js
-const map = Map([
-	['foo', 'bar']
-]);
-```
-
-## Pass
-
-```js
+// ✅
 const list = new Array(10);
 ```
 
 ```js
+// ❌
+const now = Date();
+
+// ✅
 const now = new Date();
 ```
 
 ```js
+// ❌
+const map = Map([
+	['foo', 'bar']
+]);
+
+// ✅
 const map = new Map([
 	['foo', 'bar']
 ]);

--- a/docs/rules/no-abusive-eslint-disable.md
+++ b/docs/rules/no-abusive-eslint-disable.md
@@ -36,26 +36,32 @@ console.log(message); // `message` is not defined, but it won't be reported
 
 This rule enforces specifying the rules to disable. If you want to disable ESLint on a file altogether, you should ignore it through [`.eslintignore`](https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories) for ESLint or through the [`ignores` property](https://github.com/xojs/xo#ignores) in `package.json` for `XO`.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 /* eslint-disable */
 console.log(message);
 
-console.log(message); // eslint-disable-line
-
-// eslint-disable-next-line
+// ✅
+/* eslint-disable no-console */
 console.log(message);
 ```
 
-## Pass
+```js
+// ❌
+console.log(message); // eslint-disable-line
+
+// ✅
+console.log(message); // eslint-disable-line no-console
+```
 
 ```js
-/* eslint-disable no-console */
+// ❌
+// eslint-disable-next-line
 console.log(message);
 
-console.log(message); // eslint-disable-line no-console
-
+// ✅
 // eslint-disable-next-line no-console
 console.log(message);
 ```

--- a/docs/rules/no-anonymous-default-export.md
+++ b/docs/rules/no-anonymous-default-export.md
@@ -9,56 +9,54 @@
 
 Naming default exports improves codebase searchability by ensuring consistent identifier use for a module's default export, both where it's declared and where it's imported.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 export default class {}
-```
 
-```js
-export default function () {}
-```
-
-```js
-export default () => {};
-```
-
-```js
-module.exports = class {};
-```
-
-```js
-module.exports = function () {};
-```
-
-```js
-module.exports = () => {};
-```
-
-## Pass
-
-```js
+// ✅
 export default class Foo {}
 ```
 
 ```js
+// ❌
+export default function () {}
+
+// ✅
 export default function foo () {}
 ```
 
 ```js
+// ❌
+export default () => {};
+
+// ✅
 const foo = () => {};
 export default foo;
 ```
 
 ```js
+// ❌
+module.exports = class {};
+
+// ✅
 module.exports = class Foo {};
 ```
 
 ```js
+// ❌
+module.exports = function () {};
+
+// ✅
 module.exports = function foo () {};
 ```
 
 ```js
+// ❌
+module.exports = () => {};
+
+// ✅
 const foo = () => {};
 module.exports = foo;
 ```

--- a/docs/rules/no-array-callback-reference.md
+++ b/docs/rules/no-array-callback-reference.md
@@ -52,97 +52,81 @@ import unicorn from 'unicorn';
 //=> [2, 3, 4]
 ```
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const foo = array.map(callback);
-```
 
-```js
-array.forEach(callback);
-```
-
-```js
-const foo = array.every(callback);
-```
-
-```js
-const foo = array.filter(callback);
-```
-
-```js
-const foo = array.find(callback);
-```
-
-```js
-const index = array.findIndex(callback);
-```
-
-```js
-const foo = array.some(callback);
-```
-
-```js
-const foo = array.reduce(callback, 0);
-```
-
-```js
-const foo = array.reduceRight(callback, []);
-```
-
-```js
-const foo = array.flatMap(callback);
-```
-
-```js
-array.forEach(someFunction({foo: 'bar'}));
-```
-
-```js
-array.forEach(callback, thisArgument);
-```
-
-## Pass
-
-```js
+// ✅
 const foo = array.map(element => callback(element));
 ```
 
 ```js
+// ✅
 const foo = array.map(Boolean);
 ```
 
 ```js
+// ❌
+array.forEach(callback);
+
+// ✅
 array.forEach(element => {
 	callback(element);
 });
 ```
 
 ```js
+// ❌
+const foo = array.every(callback);
+
+// ✅
 const foo = array.every(element => callback(element));
 ```
 
 ```js
+// ❌
+const foo = array.filter(callback);
+
+// ✅
 const foo = array.filter(element => callback(element));
 ```
 
 ```js
+// ✅
 const foo = array.filter(Boolean);
 ```
 
 ```js
+// ❌
+const foo = array.find(callback);
+
+// ✅
 const foo = array.find(element => callback(element));
 ```
 
 ```js
+// ❌
+const index = array.findIndex(callback);
+
+// ✅
 const index = array.findIndex(element => callback(element));
 ```
 
 ```js
+// ❌
+const foo = array.some(callback);
+
+// ✅
 const foo = array.some(element => callback(element));
 ```
 
 ```js
+// ❌
+const foo = array.reduce(callback, 0);
+
+// ✅
 const foo = array.reduce(
 	(accumulator, element) => accumulator + callback(element),
 	0
@@ -150,6 +134,10 @@ const foo = array.reduce(
 ```
 
 ```js
+// ❌
+const foo = array.reduceRight(callback, []);
+
+// ✅
 const foo = array.reduceRight(
 	(accumulator, element) => [
 		...accumulator,
@@ -160,10 +148,18 @@ const foo = array.reduceRight(
 ```
 
 ```js
+// ❌
+const foo = array.flatMap(callback);
+
+// ✅
 const foo = array.flatMap(element => callback(element));
 ```
 
 ```js
+// ❌
+array.forEach(someFunction({foo: 'bar'}));
+
+// ✅
 const callback = someFunction({foo: 'bar'});
 
 array.forEach(element => {
@@ -172,12 +168,17 @@ array.forEach(element => {
 ```
 
 ```js
+// ❌
+array.forEach(callback, thisArgument);
+
+// ✅
 array.forEach(function (element) {
 	callback(element, this);
 }, thisArgument);
 ```
 
 ```js
+// ✅
 function readFile(filename) {
 	return fs.readFile(filename, 'utf8');
 }

--- a/docs/rules/no-array-for-each.md
+++ b/docs/rules/no-array-for-each.md
@@ -16,47 +16,53 @@ Benefits of [`for…of` statement](https://developer.mozilla.org/en-US/docs/Web/
 
 Additionally, using `for…of` has great benefits if you are using TypeScript, because it does not cause a function boundary to be crossed. This means that type-narrowing earlier on in the current scope will work properly while inside of the loop (without having to re-type-narrow). Furthermore, any mutated variables inside of the loop will picked up on for the purposes of determining if a variable is being used.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 array.forEach(element => {
 	bar(element);
 });
-```
 
-```js
-array?.forEach(element => {
-	bar(element);
-});
-```
-
-```js
-array.forEach((element, index) => {
-	bar(element, index);
-});
-```
-
-```js
-array.forEach((element, index, array) => {
-	bar(element, index, array);
-});
-```
-
-## Pass
-
-```js
+// ✅
 for (const element of array) {
 	bar(element);
 }
 ```
 
 ```js
+// ❌
+array?.forEach(element => {
+	bar(element);
+});
+
+// ✅
+if (array) {
+	for (const element of array) {
+		bar(element);
+	}
+}
+```
+
+```js
+// ❌
+array.forEach((element, index) => {
+	bar(element, index);
+});
+
+// ✅
 for (const [index, element] of array.entries()) {
 	bar(element, index);
 }
 ```
 
 ```js
+// ❌
+array.forEach((element, index, array) => {
+	bar(element, index, array);
+});
+
+// ✅
 for (const [index, element] of array.entries()) {
 	bar(element, index, array);
 }

--- a/docs/rules/no-array-method-this-argument.md
+++ b/docs/rules/no-array-method-this-argument.md
@@ -28,31 +28,28 @@ This rule checks following array methods accepts `thisArg`:
 
 This rule is fixable when the callback is an arrow function and the `thisArg` argument has no side effect.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const foo = bar.find(element => isUnicorn(element), baz);
-```
 
-```js
-const foo = bar.map(function (element) => {
-	return this.unicorn(element);
-}, baz);
-```
-
-## Pass
-
-```js
+// ✅
 const foo = bar.find(element => isUnicorn(element));
 ```
 
 ```js
+// ❌
+const foo = bar.map(function (element) {
+	return this.unicorn(element);
+}, baz);
+
+// ✅
 const foo = bar.map(function (element) => {
 	return baz.unicorn(element);
 });
-```
 
-```js
+// ✅
 const foo = bar.map(function (element) => {
 	return this.unicorn(element);
 }.bind(baz));

--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -13,44 +13,22 @@ Use `eslint-disable` comment if you really need to use it or disable the rule en
 
 This rule is not fixable.
 
-## Fail
+## Examples
 
 ```js
-array.reduce(reducer, initialValue);
-```
+// ❌
+array.reduce(reducer);
 
-```js
-array.reduceRight(reducer, initialValue);
-```
-
-```js
+// ✅
+// eslint-disable-next-line unicorn/no-array-reduce
 array.reduce(reducer);
 ```
 
 ```js
-[].reduce.call(array, reducer);
-```
-
-```js
-[].reduce.apply(array, [reducer, initialValue]);
-```
-
-```js
-Array.prototype.reduce.call(array, reducer);
-```
-
-## Pass
-
-```js
-// eslint-disable-next-line unicorn/no-array-reduce
+// ❌
 array.reduce(reducer, initialValue);
-```
 
-```js
-array.reduce((total, value) => total + value);
-```
-
-```js
+// ✅
 let result = initialValue;
 
 for (const element of array) {
@@ -59,11 +37,35 @@ for (const element of array) {
 ```
 
 ```js
+// ✅
+array.reduce((total, value) => total + value);
+```
+
+```js
+// ❌
+array.reduceRight(reducer, initialValue);
+
+// ✅
 let result = initialValue;
 
 for (const element of array.toReversed()) { // Equivalent to .reduceRight()
 	result += element;
 }
+```
+
+```js
+// ❌
+[].reduce.call(array, reducer);
+```
+
+```js
+// ❌
+[].reduce.apply(array, [reducer, initialValue]);
+```
+
+```js
+// ❌
+Array.prototype.reduce.call(array, reducer);
 ```
 
 ## Options
@@ -79,10 +81,12 @@ Set it to `false` to disable reduce completely.
 
 ```js
 // eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": true}]
-array.reduce((total, item) => total + item) // Passes
+// ✅
+array.reduce((total, item) => total + item)
 ```
 
 ```js
 // eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": false}]
-array.reduce((total, item) => total + item) // Fails
+// ❌
+array.reduce((total, item) => total + item)
 ```

--- a/docs/rules/no-array-reverse.md
+++ b/docs/rules/no-array-reverse.md
@@ -33,10 +33,9 @@ Default: `true`
 This rule allows `array.reverse()` to be used as an expression statement by default.\
 Pass `allowExpressionStatement: false` to forbid `Array#reverse()` even if it's an expression statement.
 
-#### Fail
-
 ```js
 // eslint unicorn/no-array-reverse: ["error", {"allowExpressionStatement": false}]
+// ❌
 array.reverse();
 ```
 

--- a/docs/rules/no-array-sort.md
+++ b/docs/rules/no-array-sort.md
@@ -18,7 +18,15 @@ Prefer using [`Array#toSorted()`](https://developer.mozilla.org/en-US/docs/Web/J
 const sorted = [...array].sort();
 
 // ✅
-const sorted = [...array].toSorted();
+const sorted = array.toSorted();
+```
+
+```js
+// ❌
+const sorted = [...iterable].sort();
+
+// ✅
+const sorted = [...iterable].toSorted();
 ```
 
 ```js
@@ -26,7 +34,7 @@ const sorted = [...array].toSorted();
 const sorted = [...array].sort((a, b) => a - b);
 
 // ✅
-const sorted = [...array].toSorted((a, b) => a - b);
+const sorted = array.toSorted((a, b) => a - b);
 ```
 
 ## Options
@@ -41,10 +49,9 @@ Default: `true`
 This rule allows `array.sort()` to be used as an expression statement by default.\
 Pass `allowExpressionStatement: false` to forbid `Array#sort()` even if it's an expression statement.
 
-#### Fail
-
 ```js
 // eslint unicorn/no-array-sort: ["error", {"allowExpressionStatement": false}]
+// ❌
 array.sort();
 ```
 

--- a/docs/rules/no-await-expression-member.md
+++ b/docs/rules/no-await-expression-member.md
@@ -11,39 +11,37 @@ When accessing a member from an await expression, the await expression has to be
 
 This rule is fixable for simple member access.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 const foo = (await import('./foo.js')).default;
-```
 
-```js
-const secondElement = (await getArray())[1];
-```
-
-```js
-const property = (await getObject()).property;
-```
-
-```js
-const data = await (await fetch('/foo')).json();
-```
-
-## Pass
-
-```js
+// ✅
 const {default: foo} = await import('./foo.js');
 ```
 
 ```js
+// ❌
+const secondElement = (await getArray())[1];
+
+// ✅
 const [, secondElement] = await getArray();
 ```
 
 ```js
+// ❌
+const property = (await getObject()).property;
+
+// ✅
 const {property} = await getObject();
 ```
 
 ```js
+// ❌
+const data = await (await fetch('/foo')).json();
+
+// ✅
 const response = await fetch('/foo');
 const data = await response.json();
 ```

--- a/docs/rules/no-await-in-promise-methods.md
+++ b/docs/rules/no-await-in-promise-methods.md
@@ -9,26 +9,36 @@
 
 Using `await` on promises passed as arguments to `Promise.all()`, `Promise.allSettled()`, `Promise.any()`, or `Promise.race()` is likely a mistake.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 Promise.all([await promise, anotherPromise]);
 
-Promise.allSettled([await promise, anotherPromise]);
-
-Promise.any([await promise, anotherPromise]);
-
-Promise.race([await promise, anotherPromise]);
+// ✅
+Promise.all([promise, anotherPromise]);
 ```
 
-## Pass
+```js
+// ❌
+Promise.allSettled([await promise, anotherPromise]);
+
+// ✅
+Promise.allSettled([promise, anotherPromise]);
+```
 
 ```js
-Promise.all([promise, anotherPromise]);
+// ❌
+Promise.any([await promise, anotherPromise]);
 
-Promise.allSettled([promise, anotherPromise]);
-
+// ✅
 Promise.any([promise, anotherPromise]);
+```
 
+```js
+// ❌
+Promise.race([await promise, anotherPromise]);
+
+// ✅
 Promise.race([promise, anotherPromise]);
 ```

--- a/docs/rules/no-console-spaces.md
+++ b/docs/rules/no-console-spaces.md
@@ -9,35 +9,72 @@
 
 The [`console.log()` method](https://developer.mozilla.org/en-US/docs/Web/API/Console/log) and similar methods joins the parameters with a space, so adding a leading/trailing space to a parameter, results in two spaces being added.
 
-## Fail
+## Examples
 
 ```js
+// ❌
 console.log('abc ', 'def');
+
+// ❌
 console.log('abc', ' def');
 
+// ❌
 console.log("abc ", " def");
+
+// ❌
 console.log(`abc `, ` def`);
 
-console.debug('abc ', 'def');
-console.info('abc ', 'def');
-console.warn('abc ', 'def');
-console.error('abc ', 'def');
+// ✅
+console.log('abc', 'def');
 ```
 
-## Pass
+```js
+// ❌
+console.debug('abc ', 'def');
+
+// ✅
+console.debug('abc', 'def');
+```
 
 ```js
-console.log('abc');
-console.log('abc', 'def');
+// ❌
+console.info('abc ', 'def');
 
+// ✅
+console.info('abc', 'def');
+```
+
+```js
+// ❌
+console.warn('abc ', 'def');
+
+// ✅
+console.warn('abc', 'def');
+```
+
+```js
+// ❌
+console.error('abc ', 'def');
+
+// ✅
+console.error('abc', 'def');
+```
+
+```js
+// ✅
 console.log('abc ');
+
+// ✅
 console.log(' abc');
+```
 
+```js
+// ✅
 console.log('abc  ', 'def');
-console.log('abc\t', 'def');
-console.log('abc\n', 'def');
 
-console.log(`
-	abc
-`);
+// ✅
+console.log('abc\t', 'def');
+
+// ✅
+console.log('abc\n', 'def');
 ```

--- a/docs/rules/no-document-cookie.md
+++ b/docs/rules/no-document-cookie.md
@@ -7,24 +7,18 @@
 
 It's not recommended to use [`document.cookie`](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie) directly as it's easy to get the string wrong. Instead, you should use the [Cookie Store API](https://developer.mozilla.org/en-US/docs/Web/API/Cookie_Store_API) or a [cookie library](https://www.npmjs.com/search?q=cookie).
 
-## Fail
+## Examples
 
 ```js
+// ❌
 document.cookie =
 	'foo=bar' +
 	'; Path=/' +
 	'; Domain=example.com' +
 	'; expires=Fri, 31 Dec 9999 23:59:59 GMT' +
 	'; Secure';
-```
 
-```js
-document.cookie += '; foo=bar';
-```
-
-## Pass
-
-```js
+// ✅
 await cookieStore.set({
 	name: 'foo',
 	value: 'bar',
@@ -34,11 +28,19 @@ await cookieStore.set({
 ```
 
 ```js
-const array = document.cookie.split('; ');
-```
+// ❌
+document.cookie += '; foo=bar';
 
-```js
+// ✅
+await cookieStore.set('foo', 'bar');
+
+// ✅
 import Cookies from 'js-cookie';
 
 Cookies.set('foo', 'bar');
+```
+
+```js
+// ✅
+const array = document.cookie.split('; ');
 ```

--- a/docs/rules/no-empty-file.md
+++ b/docs/rules/no-empty-file.md
@@ -16,7 +16,9 @@ Disallow any files only containing the following:
 - Empty block statements
 - Hashbang
 
-## Fail
+## Examples
+
+These files fail:
 
 ```js
 
@@ -47,7 +49,7 @@ Disallow any files only containing the following:
 #!/usr/bin/env node
 ```
 
-## Pass
+These files pass:
 
 ```js
 const x = 0;


### PR DESCRIPTION
Ref: #2530

This PR updates the style for rule fail/pass examples in 25 files, following the example in #2529 and in other docs files.

As requested in https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2530#issuecomment-2610704892, this PR addresses a subset of the total files that need to be changed.

In this PR, I didn't update docs/rules/no-empty-file.md to use the style of `// ❌` and `// ✅` comments because I believe this would interfere with the demonstration of what "empty file" means.

All related PRs:

- #2753 (current)
- #2754
- #2755
- #2756
- #2757