### PR TITLE
Enable test for "## Examples" in rule docs

### DIFF
--- a/test/package.js
+++ b/test/package.js
@@ -132,7 +132,6 @@ test('Every rule has a doc with the appropriate content', t => {
 
 		// Check for examples.
 		t.true(documentContents.includes('## Examples'), `${ruleName} includes '## Examples' examples section`);
-		t.pass();
 	}
 });
 


### PR DESCRIPTION
Closes: #2530

Now that the rule docs all have examples, re-enable the test that checks for `'## Examples'` in each rule doc file.
