### PR TITLE
Fix ESLint configuration comments in docs

### DIFF
--- a/docs/rules/no-array-reduce.md
+++ b/docs/rules/no-array-reduce.md
@@ -80,13 +80,13 @@ Allow simple operations (like addition, subtraction, etc.) in a `reduce` call.
 Set it to `false` to disable reduce completely.
 
 ```js
-// eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": true}]
+/* eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": true}] */
 // ✅
 array.reduce((total, item) => total + item)
 ```
 
 ```js
-// eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": false}]
+/* eslint unicorn/no-array-reduce: ["error", {"allowSimpleOperations": false}] */
 // ❌
 array.reduce((total, item) => total + item)
 ```

--- a/docs/rules/no-array-reverse.md
+++ b/docs/rules/no-array-reverse.md
@@ -34,7 +34,7 @@ This rule allows `array.reverse()` to be used as an expression statement by defa
 Pass `allowExpressionStatement: false` to forbid `Array#reverse()` even if it's an expression statement.
 
 ```js
-// eslint unicorn/no-array-reverse: ["error", {"allowExpressionStatement": false}]
+/* eslint unicorn/no-array-reverse: ["error", {"allowExpressionStatement": false}] */
 // ❌
 array.reverse();
 ```

--- a/docs/rules/no-array-sort.md
+++ b/docs/rules/no-array-sort.md
@@ -50,7 +50,7 @@ This rule allows `array.sort()` to be used as an expression statement by default
 Pass `allowExpressionStatement: false` to forbid `Array#sort()` even if it's an expression statement.
 
 ```js
-// eslint unicorn/no-array-sort: ["error", {"allowExpressionStatement": false}]
+/* eslint unicorn/no-array-sort: ["error", {"allowExpressionStatement": false}] */
 // ❌
 array.sort();
 ```

--- a/docs/rules/no-keyword-prefix.md
+++ b/docs/rules/no-keyword-prefix.md
@@ -36,7 +36,7 @@ const fooNew = 'foo';
 If you want a custom list of disallowed prefixes you can set them with `disallowedPrefixes`:
 
 ```js
-// eslint unicorn/no-keyword-prefix: ["error", {"disallowedPrefixes": ["new", "for"]}]
+/* eslint unicorn/no-keyword-prefix: ["error", {"disallowedPrefixes": ["new", "for"]}] */
 // ✅
 const classFoo = "a";
 
@@ -51,13 +51,13 @@ The default is `["new", "class"]`.
 If you want to disable this rule for properties, set `checkProperties` to `false`:
 
 ```js
-// eslint unicorn/no-keyword-prefix: ["error", {"checkProperties": true}]
+/* eslint unicorn/no-keyword-prefix: ["error", {"checkProperties": true}] */
 // ❌
 foo.newFoo = 2;
 ```
 
 ```js
-// eslint unicorn/no-keyword-prefix: ["error", {"checkProperties": false}]
+/* eslint unicorn/no-keyword-prefix: ["error", {"checkProperties": false}] */
 // ✅
 var foo = {newFoo: 1}; // pass
 
@@ -70,13 +70,13 @@ foo.newFoo = 2; // pass
 The default behavior is to check for camel case usage. If you want to disallow the prefix entirely, set `onlyCamelCase` to `false`:
 
 ```js
-// eslint unicorn/no-keyword-prefix: ["error", {"onlyCamelCase": true}]
+/* eslint unicorn/no-keyword-prefix: ["error", {"onlyCamelCase": true}] */
 // ✅
 const new_foo = "foo";
 ```
 
 ```js
-// eslint unicorn/no-keyword-prefix: ["error", {"onlyCamelCase": false}]
+/* eslint unicorn/no-keyword-prefix: ["error", {"onlyCamelCase": false}] */
 // ❌
 const new_foo = "foo";
 ```

--- a/docs/rules/no-null.md
+++ b/docs/rules/no-null.md
@@ -49,7 +49,7 @@ Default: `false`
 Strict equality(`===`) and strict inequality(`!==`) is ignored by default.
 
 ```js
-// eslint unicorn/no-null: ["error", {"checkStrictEquality": true}]
+/* eslint unicorn/no-null: ["error", {"checkStrictEquality": true}] */
 // ❌
 if (foo === null) {}
 ```

--- a/docs/rules/no-typeof-undefined.md
+++ b/docs/rules/no-typeof-undefined.md
@@ -47,7 +47,7 @@ The rule ignores variables not defined in the file by default.
 Set it to `true` to check all variables.
 
 ```js
-// eslint unicorn/no-typeof-undefined: ["error", {"checkGlobalVariables": true}]
+/* eslint unicorn/no-typeof-undefined: ["error", {"checkGlobalVariables": true}] */
 
 // ❌
 if (typeof undefinedVariable === 'undefined') {}

--- a/docs/rules/no-useless-undefined.md
+++ b/docs/rules/no-useless-undefined.md
@@ -104,13 +104,13 @@ Disallow the use of `undefined` at the end of function call arguments. Pass `che
 
 ```js
 // ❌
-// eslint unicorn/no-useless-undefined: ["error", {"checkArguments": true}]
+/* eslint unicorn/no-useless-undefined: ["error", {"checkArguments": true}] */
 foo(bar, baz, undefined);
 ```
 
 ```js
 // ✅
-// eslint unicorn/no-useless-undefined: ["error", {"checkArguments": false}]
+/* eslint unicorn/no-useless-undefined: ["error", {"checkArguments": false}] */
 foo(bar, baz, undefined);
 ```
 
@@ -122,13 +122,13 @@ Default: `true`
 Disallow the use of `undefined` as arrow function body. Pass `checkArrowFunctionBody: false` to disable checking them.
 
 ```js
-// eslint unicorn/no-useless-undefined: ["error", {"checkArrowFunctionBody": true}]
+/* eslint unicorn/no-useless-undefined: ["error", {"checkArrowFunctionBody": true}] */
 // ❌
 const foo = () => undefined;
 ```
 
 ```js
-// eslint unicorn/no-useless-undefined: ["error", {"checkArrowFunctionBody": false}]
+/* eslint unicorn/no-useless-undefined: ["error", {"checkArrowFunctionBody": false}] */
 // ✅
 const foo = () => undefined;
 ```

--- a/docs/rules/numeric-separators-style.md
+++ b/docs/rules/numeric-separators-style.md
@@ -79,7 +79,7 @@ You can set it at top-level, or override for each specific number type.
 Example:
 
 ```js
-// eslint unicorn/numeric-separators-style: ["error", {"onlyIfContainsSeparator": true, "binary": {"onlyIfContainsSeparator": false}]
+/* eslint unicorn/numeric-separators-style: ["error", {"onlyIfContainsSeparator": true, "binary": {"onlyIfContainsSeparator": false}] */
 const number = 100000; // Pass, this number does not contain separators
 const binary = 0b101010001; // Fail, `binary` type don't require separators
 const hexadecimal = 0xD_EED_BEE_F; // Fail, it contain separators and it's incorrectly grouped
@@ -112,7 +112,7 @@ Numbers are split into 3 distinct parts:
 ### Examples
 
 ```js
-// eslint unicorn/numeric-separators-style: ["error", {"number": {"minimumDigits": 0, "groupLength": 3}}]
+/* eslint unicorn/numeric-separators-style: ["error", {"number": {"minimumDigits": 0, "groupLength": 3}}] */
 
 // ❌
 const foo = 12345;
@@ -125,7 +125,7 @@ const foo = 123.1_000_001;
 ```
 
 ```js
-// eslint unicorn/numeric-separators-style: ["error", {"binary": {"minimumDigits": 0, "groupLength": 4}}]
+/* eslint unicorn/numeric-separators-style: ["error", {"binary": {"minimumDigits": 0, "groupLength": 4}}] */
 
 // ❌
 const foo = 0b101010;
@@ -135,13 +135,13 @@ const foo = 0b1010_10001;
 ```
 
 ```js
-// eslint unicorn/numeric-separators-style: ["error", {"hexadecimal": {"minimumDigits": 0, "groupLength": 2}}]
+/* eslint unicorn/numeric-separators-style: ["error", {"hexadecimal": {"minimumDigits": 0, "groupLength": 2}}] */
 // ❌
 const foo = 0xA_B_CD_EF;
 ```
 
 ```js
-// eslint unicorn/numeric-separators-style: ["error", {"number": {"minimumDigits": 0, "groupLength": 3}}]
+/* eslint unicorn/numeric-separators-style: ["error", {"number": {"minimumDigits": 0, "groupLength": 3}}] */
 
 // ✅
 const foo = 100;
@@ -154,14 +154,14 @@ const foo = 1_000_000;
 ```
 
 ```js
-// eslint unicorn/numeric-separators-style: ["error", {"number": {"minimumDigits": 5, "groupLength": 3}}]
+/* eslint unicorn/numeric-separators-style: ["error", {"number": {"minimumDigits": 5, "groupLength": 3}}] */
 
 // ✅
 const foo = 1000;
 ```
 
 ```js
-// eslint unicorn/numeric-separators-style: ["error", {"octal": {"minimumDigits": 0, "groupLength": 4}}]
+/* eslint unicorn/numeric-separators-style: ["error", {"octal": {"minimumDigits": 0, "groupLength": 4}}] */
 
 // ✅
 const foo = 0o7777;

--- a/docs/rules/prefer-array-find.md
+++ b/docs/rules/prefer-array-find.md
@@ -50,7 +50,7 @@ Default: `true`
 Pass `checkFromLast: false` to disable check cases searching from last.
 
 ```js
-// eslint unicorn/prefer-array-find: ["error", {"checkFromLast": false}]
+/* eslint unicorn/prefer-array-find: ["error", {"checkFromLast": false}] */
 
 // ✅
 const item = array.filter(x => isUnicorn(x)).at(-1);

--- a/docs/rules/prefer-array-flat.md
+++ b/docs/rules/prefer-array-flat.md
@@ -86,7 +86,7 @@ Example:
 ```
 
 ```js
-// eslint unicorn/prefer-array-flat: ["error", {"functions": ["utils.flat"]}]
+/* eslint unicorn/prefer-array-flat: ["error", {"functions": ["utils.flat"]}] */
 // ❌
 const foo = utils.flat(bar);
 ```

--- a/docs/rules/prefer-at.md
+++ b/docs/rules/prefer-at.md
@@ -88,7 +88,7 @@ Example:
 ```
 
 ```js
-// eslint unicorn/prefer-at: ["error", {"checkAllIndexAccess": true}]
+/* eslint unicorn/prefer-at: ["error", {"checkAllIndexAccess": true}] */
 const foo = bar[10]; // Fails, will fix to `bar.at(10)`
 const foo = bar[unknownProperty]; // Passes
 const foo = string.charAt(unknownIndex); // Fails
@@ -119,7 +119,7 @@ Example:
 ```
 
 ```js
-// eslint unicorn/prefer-at: ["error", {"getLastElementFunctions": ["utils.lastElement"]}]
+/* eslint unicorn/prefer-at: ["error", {"getLastElementFunctions": ["utils.lastElement"]}] */
 // ❌
 const foo = utils.lastElement(bar);
 ```

--- a/docs/rules/prefer-export-from.md
+++ b/docs/rules/prefer-export-from.md
@@ -74,7 +74,7 @@ Default: `false`
 When `true`, if an import is used in other places than just a re-export, all variables in the import declaration will be ignored.
 
 ```js
-// eslint unicorn/prefer-export-from: ["error", {"ignoreUsedVariables": false}]
+/* eslint unicorn/prefer-export-from: ["error", {"ignoreUsedVariables": false}] */
 // ❌
 import {named1, named2} from './foo.js';
 
@@ -84,7 +84,7 @@ export {named1, named2};
 ```
 
 ```js
-// eslint unicorn/prefer-export-from: ["error", {"ignoreUsedVariables": true}]
+/* eslint unicorn/prefer-export-from: ["error", {"ignoreUsedVariables": true}] */
 // ✅
 import {named1, named2} from './foo.js';
 

--- a/docs/rules/prefer-number-properties.md
+++ b/docs/rules/prefer-number-properties.md
@@ -102,7 +102,7 @@ Default: `false`
 Pass `checkInfinity: true` to enable check on `Infinity`.
 
 ```js
-// eslint unicorn/prefer-number-properties: ["error", {"checkInfinity": true}]
+/* eslint unicorn/prefer-number-properties: ["error", {"checkInfinity": true}] */
 
 // ❌
 const foo = Infinity;
@@ -127,7 +127,7 @@ Default: `true`
 Pass `checkNaN: false` to disable check on `NaN`.
 
 ```js
-// eslint unicorn/prefer-number-properties: ["error", {"checkNaN": false}]
+/* eslint unicorn/prefer-number-properties: ["error", {"checkNaN": false}] */
 
 // ✅
 const foo = NaN;

--- a/docs/rules/prefer-object-from-entries.md
+++ b/docs/rules/prefer-object-from-entries.md
@@ -68,7 +68,7 @@ Example:
 ```
 
 ```js
-// eslint unicorn/prefer-object-from-entries: ["error", {"functions": ["utils.fromPairs"]}]
+/* eslint unicorn/prefer-object-from-entries: ["error", {"functions": ["utils.fromPairs"]}] */
 // ❌
 const object = utils.fromPairs(pairs);
 ```

--- a/docs/rules/prefer-single-call.md
+++ b/docs/rules/prefer-single-call.md
@@ -70,7 +70,7 @@ Example:
 ```
 
 ```js
-// eslint unicorn/prefer-single-call: ["error", {"ignore": ["readable"]}]
+/* eslint unicorn/prefer-single-call: ["error", {"ignore": ["readable"]}] */
 import {Readable} from 'node:stream';
 
 const readable = new Readable();

--- a/docs/rules/prefer-structured-clone.md
+++ b/docs/rules/prefer-structured-clone.md
@@ -51,7 +51,7 @@ Example:
 ```
 
 ```js
-// eslint unicorn/prefer-structured-clone: ["error", {"functions": ["utils.clone"]}]
+/* eslint unicorn/prefer-structured-clone: ["error", {"functions": ["utils.clone"]}] */
 // ❌
 const clone = utils.clone(foo);
 ```

--- a/docs/rules/prefer-switch.md
+++ b/docs/rules/prefer-switch.md
@@ -71,7 +71,7 @@ The `default` branch doesn't count. Multiple comparisons on the same `if` block 
 Examples:
 
 ```js
-// eslint unicorn/prefer-switch: ["error", {"minimumCases": 4}]
+/* eslint unicorn/prefer-switch: ["error", {"minimumCases": 4}] */
 
 // ✅
 if (foo === 1) {}
@@ -91,7 +91,7 @@ else if (foo === 4) {}
 ```
 
 ```js
-// eslint unicorn/prefer-switch: ["error", {"minimumCases": 2}]
+/* eslint unicorn/prefer-switch: ["error", {"minimumCases": 2}] */
 
 // ❌
 if (foo === 1) {}

--- a/docs/rules/prefer-ternary.md
+++ b/docs/rules/prefer-ternary.md
@@ -138,7 +138,7 @@ Default: `'always'`
   - Only check if the content of the `if` and/or `else` block is less than one line long.
 
 ```js
-// eslint unicorn/prefer-ternary: ["error", "only-single-line"]
+/* eslint unicorn/prefer-ternary: ["error", "only-single-line"] */
 // ✅
 if (test) {
 	foo = [

--- a/docs/rules/relative-url-style.md
+++ b/docs/rules/relative-url-style.md
@@ -30,7 +30,7 @@ Default: `'never'`
   - Always add a `./` prefix to the relative URL when possible.
 
 ```js
-// eslint unicorn/relative-url-style: ["error", "always"]
+/* eslint unicorn/relative-url-style: ["error", "always"] */
 
 // ❌
 const url = new URL('foo', base);

--- a/docs/rules/string-content.md
+++ b/docs/rules/string-content.md
@@ -23,7 +23,7 @@ This rule ignores the following tagged template literals as they're known to con
 ## Examples
 
 ```js
-/*eslint unicorn/string-content: ["error", { "patterns": { "'": "’" } }]*/
+/* eslint unicorn/string-content: ["error", { "patterns": { "'": "’" } }] */
 
 // ❌
 const foo = 'Someone\'s coming!';

--- a/docs/rules/switch-case-braces.md
+++ b/docs/rules/switch-case-braces.md
@@ -63,7 +63,7 @@ Default: `'always'`
 The following cases are considered valid:
 
 ```js
-// eslint unicorn/switch-case-braces: ["error", "avoid"]
+/* eslint unicorn/switch-case-braces: ["error", "avoid"] */
 switch (foo) {
 	case 1:
 		doSomething();
@@ -72,7 +72,7 @@ switch (foo) {
 ```
 
 ```js
-// eslint unicorn/switch-case-braces: ["error", "avoid"]
+/* eslint unicorn/switch-case-braces: ["error", "avoid"] */
 switch (foo) {
 	case 1: {
 		const bar = 2;
@@ -85,7 +85,7 @@ switch (foo) {
 The following case is considered invalid:
 
 ```js
-// eslint unicorn/switch-case-braces: ["error", "avoid"]
+/* eslint unicorn/switch-case-braces: ["error", "avoid"] */
 switch (foo) {
 	case 1: {
 		doSomething();


### PR DESCRIPTION
Configuration comments allow you to configure ESLint inside of a file. They use the following format:

```js
/* eslint eqeqeq: "off", curly: "error" */
```

The docs use configuration comments in example code blocks for custom rule options. Most of these comments start with `//`. These comments would be ignored by ESLint if used in an actual file. This PR changes all configuration comments to use the correct format (with `/*` and `*/`).

More info: https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments