### PR TITLE
`prefer-global-this` Add navigation to `windowSpecificAPIs`

### DIFF
--- a/rules/prefer-global-this.js
+++ b/rules/prefer-global-this.js
@@ -62,6 +62,7 @@ const windowSpecificAPIs = new Set([
 	'open',
 	'originAgentCluster',
 	'postMessage',
+	'navigation',
 
 	// Events commonly associated with "window"
 	...[...windowSpecificEvents].map(event => `on${event}`),


### PR DESCRIPTION
Adds `navigation` to the `windowSpecificAPIs` array which stops the rule throwing when using [@types/dom-navigation](https://www.npmjs.com/package/@types/dom-navigation/v/1.0.1).

* https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api
* https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API 
