### PR TITLE
fix(`no-array-for-each`): ignore forEach for Effect library

### DIFF
--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -384,6 +384,8 @@ const ignoredObjects = [
 	'R',
 	// https://www.npmjs.com/package/p-iteration
 	'pIteration',
+	// https://www.npmjs.com/package/effect
+	'Effect',
 ];
 
 /** @param {import('eslint').Rule.RuleContext} context */

--- a/test/no-array-for-each.js
+++ b/test/no-array-for-each.js
@@ -17,6 +17,8 @@ test.snapshot({
 				// My other code...
 			});
 		`,
+		// #2758
+		'Effect.forEach([1,2,3], (n) => Effect.succeed(n))',
 	],
 	invalid: [
 		'foo.forEach?.(element => bar(element))',


### PR DESCRIPTION
fixes #2758, added Effect library to ignore objects for no-array-for-each rule
