### PR TITLE
`consistent-assert`: explicitly check specifier node type

### DIFF
--- a/rules/consistent-assert.js
+++ b/rules/consistent-assert.js
@@ -22,12 +22,14 @@ const isAssertFunction = (specifier, moduleName) =>
 	// `import {default as assert} from 'node:assert/strict';`
 	|| (
 		specifier.type === 'ImportSpecifier'
+		&& specifier.imported.type === 'Identifier'
 		&& specifier.imported.name === 'default'
 	)
 	// `import {strict as assert} from 'node:assert';`
 	|| (
 		moduleName === 'assert'
 		&& specifier.type === 'ImportSpecifier'
+		&& specifier.imported.type === 'Identifier'
 		&& specifier.imported.name === 'strict'
 	);
 

--- a/test/consistent-assert.js
+++ b/test/consistent-assert.js
@@ -51,6 +51,11 @@ test.snapshot({
 			import assert from 'node:assert/strict';
 			console.log(assert)
 		`,
+		// We are not checking this
+		outdent`
+			import {'strict' as assert} from 'assert';
+			assert(foo)
+		`,
 		...[
 			'import type assert from "node:assert/strict";',
 			'import {type strict as assert} from "node:assert/strict";',


### PR DESCRIPTION
Does not change the logic, but makes it explicit that we only check `Identifier`s. (It can be a string literal)