### PR TITLE
refactor: replace deprecated `Linter.FlatConfig` with `Linter.Config`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,15 +2,15 @@ import type {ESLint, Linter} from 'eslint';
 
 declare const eslintPluginUnicorn: ESLint.Plugin & {
 	configs: {
-		recommended: Linter.FlatConfig;
-		unopinionated: Linter.FlatConfig;
-		all: Linter.FlatConfig;
+		recommended: Linter.Config;
+		unopinionated: Linter.Config;
+		all: Linter.Config;
 
 		/** @deprecated Use `all` instead. The `flat/` prefix is no longer needed. */
-		'flat/all': Linter.FlatConfig;
+		'flat/all': Linter.Config;
 
 		/** @deprecated Use `recommended` instead. The `flat/` prefix is no longer needed. */
-		'flat/recommended': Linter.FlatConfig;
+		'flat/recommended': Linter.Config;
 	};
 };
 


### PR DESCRIPTION
<!--
If you're adding a new rule, please follow [these steps](../docs/new-rule.md).
-->

Migrate the deprecated ESLint API to the currently recommended API

ref: https://github.com/eslint/eslint/blob/e86b813eb660f1a5adc8e143a70d9b683cd12362/lib/types/index.d.ts#L1053-L1054