### PR TITLE
fix: export the same object in configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import createDeprecatedRules from './rules/utils/create-deprecated-rules.js';
 import flatConfigBase from './configs/flat-config-base.js';
 import * as rawRules from './rules/index.js';
-import { toEslintRules } from './rules/rule/index.js';
+import {toEslintRules} from './rules/rule/index.js';
 import packageJson from './package.json' with {type: 'json'};
 
 const rules = toEslintRules(rawRules);


### PR DESCRIPTION
fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2854

This pull request simplifies the export structure in `index.js` by attaching the `configs` object directly to the `unicorn` object and exporting `unicorn` as the default export, instead of creating a separate `allConfigs` object.

Export structure simplification:

* Modified `index.js` to attach the `configs` object directly to the `unicorn` object and export `unicorn` as the default export, removing the intermediate `allConfigs` object.