### PR TITLE
Use `meta.defaultOptions` instead of manual default handling

### DIFF
--- a/rules/better-regex.js
+++ b/rules/better-regex.js
@@ -12,7 +12,7 @@ const messages = {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const {sortCharacterClasses} = context.options[0] || {};
+	const {sortCharacterClasses} = context.options[0];
 
 	const ignoreList = [];
 

--- a/rules/catch-error-name.js
+++ b/rules/catch-error-name.js
@@ -32,11 +32,7 @@ const isPromiseCatchParameter = node =>
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const options = {
-		name: 'error',
-		ignore: [],
-		...context.options[0],
-	};
+	const options = context.options[0];
 	const {name: expectedName} = options;
 	const ignore = options.ignore.map(
 		pattern => isRegExp(pattern) ? pattern : new RegExp(pattern, 'u'),
@@ -128,7 +124,7 @@ const config = {
 		},
 		fixable: 'code',
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{name: 'error', ignore: []}],
 		messages,
 	},
 };

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -192,7 +192,7 @@ function checkNode(node, scopeManager) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const {checkArrowFunctions} = {checkArrowFunctions: true, ...context.options[0]};
+	const {checkArrowFunctions} = context.options[0];
 	const {sourceCode} = context;
 	const {scopeManager} = sourceCode;
 

--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -270,7 +270,6 @@ const DEFAULT_OPTIONS = {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = {
-		...DEFAULT_OPTIONS,
 		date: new Date().toISOString().slice(0, 10),
 		...context.options[0],
 	};

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -103,10 +103,7 @@ function isNodeValueNumber(node, context) {
 }
 
 function create(context) {
-	const options = {
-		'non-zero': 'greater-than',
-		...context.options[0],
-	};
+	const options = context.options[0];
 	const nonZeroStyle = nonZeroStyles.get(options['non-zero']);
 	const {sourceCode} = context;
 
@@ -230,6 +227,7 @@ const config = {
 		},
 		fixable: 'code',
 		schema,
+		defaultOptions: [{'non-zero': 'greater-than'}],
 		messages,
 		hasSuggestions: true,
 	},

--- a/rules/isolated-functions.js
+++ b/rules/isolated-functions.js
@@ -18,10 +18,7 @@ const defaultOptions = {
 const create = context => {
 	const {sourceCode} = context;
 	/** @type {typeof defaultOptions} */
-	const options = {
-		...defaultOptions,
-		...context.options[0],
-	};
+	const options = {...context.options[0]};
 
 	options.comments = options.comments.map(comment => comment.toLowerCase());
 

--- a/rules/no-array-reduce.js
+++ b/rules/no-array-reduce.js
@@ -87,7 +87,7 @@ const schema = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const {allowSimpleOperations} = {allowSimpleOperations: true, ...context.options[0]};
+	const {allowSimpleOperations} = context.options[0];
 
 	context.on('CallExpression', function * (callExpression) {
 		for (const {test, getMethodNode, isSimpleOperation} of cases) {

--- a/rules/no-null.js
+++ b/rules/no-null.js
@@ -14,10 +14,7 @@ const isStrictEqual = node => node.type === 'BinaryExpression' && ['===', '!==']
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const {checkStrictEquality} = {
-		checkStrictEquality: false,
-		...context.options[0],
-	};
+	const {checkStrictEquality} = context.options[0];
 
 	context.on('Literal', node => {
 		if (

--- a/rules/no-typeof-undefined.js
+++ b/rules/no-typeof-undefined.js
@@ -19,12 +19,7 @@ const messages = {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const {
-		checkGlobalVariables,
-	} = {
-		checkGlobalVariables: false,
-		...context.options[0],
-	};
+	const {checkGlobalVariables} = context.options[0];
 
 	context.on('BinaryExpression', binaryExpression => {
 		if (!(

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -106,11 +106,7 @@ const create = context => {
 		};
 	};
 
-	const options = {
-		checkArguments: true,
-		checkArrowFunctionBody: true,
-		...context.options[0],
-	};
+	const options = context.options[0];
 
 	const removeNodeAndLeadingSpace = (node, fixer) =>
 		replaceNodeOrTokenAndSpacesBefore(node, '', fixer, context);
@@ -267,7 +263,7 @@ const config = {
 		},
 		fixable: 'code',
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{checkArguments: true, checkArrowFunctionBody: true}],
 		messages,
 	},
 };

--- a/rules/numeric-separators-style.js
+++ b/rules/numeric-separators-style.js
@@ -68,32 +68,13 @@ const create = context => {
 		octal,
 		hexadecimal,
 		number,
-	} = {
-		onlyIfContainsSeparator: false,
-		...context.options[0],
-	};
+	} = context.options[0];
 
 	const options = {
-		'0b': {
-			onlyIfContainsSeparator,
-			...defaultOptions.binary,
-			...binary,
-		},
-		'0o': {
-			onlyIfContainsSeparator,
-			...defaultOptions.octal,
-			...octal,
-		},
-		'0x': {
-			onlyIfContainsSeparator,
-			...defaultOptions.hexadecimal,
-			...hexadecimal,
-		},
-		'': {
-			onlyIfContainsSeparator,
-			...defaultOptions.number,
-			...number,
-		},
+		'0b': {onlyIfContainsSeparator, ...binary},
+		'0o': {onlyIfContainsSeparator, ...octal},
+		'0x': {onlyIfContainsSeparator, ...hexadecimal},
+		'': {onlyIfContainsSeparator, ...number},
 	};
 
 	context.on('Literal', node => {

--- a/rules/prefer-add-event-listener.js
+++ b/rules/prefer-add-event-listener.js
@@ -51,8 +51,8 @@ const isClearing = node => isUndefined(node) || isNullLiteral(node);
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const options = context.options[0] || {};
-	const excludedPackages = new Set(options.excludedPackages || ['koa', 'sax']);
+	const options = context.options[0];
+	const excludedPackages = new Set(options.excludedPackages);
 	let isDisabled;
 
 	const nodeReturnsSomething = new WeakMap();
@@ -182,7 +182,7 @@ const config = {
 		},
 		fixable: 'code',
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{excludedPackages: ['koa', 'sax']}],
 		messages,
 	},
 };

--- a/rules/prefer-array-find.js
+++ b/rules/prefer-array-find.js
@@ -176,12 +176,7 @@ const isDestructuringFirstElement = node => {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {sourceCode} = context;
-	const {
-		checkFromLast,
-	} = {
-		checkFromLast: true,
-		...context.options[0],
-	};
+	const {checkFromLast} = context.options[0];
 
 	// Zero index access
 	// `array.filter()[0]`

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -190,10 +190,7 @@ function fix(node, array, context, shouldSwitchToArray, optional) {
 }
 
 function create(context) {
-	const {functions: configFunctions} = {
-		functions: [],
-		...context.options[0],
-	};
+	const {functions: configFunctions} = context.options[0];
 	const functions = [...configFunctions, ...lodashFlattenFunctions];
 
 	const cases = [
@@ -269,7 +266,7 @@ const config = {
 		},
 		fixable: 'code',
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{functions: []}],
 		messages,
 	},
 };

--- a/rules/prefer-at.js
+++ b/rules/prefer-at.js
@@ -136,11 +136,7 @@ function create(context) {
 	const {
 		getLastElementFunctions,
 		checkAllIndexAccess,
-	} = {
-		getLastElementFunctions: [],
-		checkAllIndexAccess: false,
-		...context.options[0],
-	};
+	} = context.options[0];
 	const getLastFunctions = [...getLastElementFunctions, ...lodashLastFunctions];
 	const {sourceCode} = context;
 

--- a/rules/prefer-export-from.js
+++ b/rules/prefer-export-from.js
@@ -266,7 +266,7 @@ const schema = [
 /** @param {import('eslint').Rule.RuleContext} context */
 function create(context) {
 	const {sourceCode} = context;
-	const {ignoreUsedVariables} = {ignoreUsedVariables: false, ...context.options[0]};
+	const {ignoreUsedVariables} = context.options[0];
 	const importDeclarations = new Set();
 	const exportDeclarations = [];
 

--- a/rules/prefer-number-properties.js
+++ b/rules/prefer-number-properties.js
@@ -76,11 +76,7 @@ const create = context => {
 	const {
 		checkInfinity,
 		checkNaN,
-	} = {
-		checkInfinity: false,
-		checkNaN: true,
-		...context.options[0],
-	};
+	} = context.options[0];
 
 	const objects = Object.keys(globalObjects).filter(name => {
 		if (!checkInfinity && name === 'Infinity') {

--- a/rules/prefer-object-from-entries.js
+++ b/rules/prefer-object-from-entries.js
@@ -169,10 +169,7 @@ function fixReduceAssignOrSpread({context, callExpression, property}) {
 /** @param {import('eslint').Rule.RuleContext} context */
 function create(context) {
 	const {sourceCode} = context;
-	const {functions: configFunctions} = {
-		functions: [],
-		...context.options[0],
-	};
+	const {functions: configFunctions} = context.options[0];
 	const functions = [...configFunctions, ...lodashFromPairsFunctions];
 
 	context.on('CallExpression', function * (callExpression) {
@@ -246,7 +243,7 @@ const config = {
 		},
 		fixable: 'code',
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{functions: []}],
 		messages,
 	},
 };

--- a/rules/prefer-single-call.js
+++ b/rules/prefer-single-call.js
@@ -63,12 +63,7 @@ const cases = [
 ];
 
 function create(context) {
-	const {
-		ignore: ignoredCalleeInOptions,
-	} = {
-		ignore: [],
-		...context.options[0],
-	};
+	const {ignore: ignoredCalleeInOptions} = context.options[0];
 	const {sourceCode} = context;
 
 	context.on('CallExpression', function * (secondCall) {
@@ -178,7 +173,7 @@ const config = {
 		fixable: 'code',
 		hasSuggestions: true,
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{ignore: []}],
 		messages,
 	},
 };

--- a/rules/prefer-structured-clone.js
+++ b/rules/prefer-structured-clone.js
@@ -16,10 +16,7 @@ const lodashCloneDeepFunctions = [
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const {functions: configFunctions} = {
-		functions: [],
-		...context.options[0],
-	};
+	const {functions: configFunctions} = context.options[0];
 	const functions = [...configFunctions, ...lodashCloneDeepFunctions];
 
 	// `JSON.parse(JSON.stringify(…))`
@@ -141,7 +138,7 @@ const config = {
 		},
 		hasSuggestions: true,
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{functions: []}],
 		messages,
 	},
 };

--- a/rules/prefer-switch.js
+++ b/rules/prefer-switch.js
@@ -257,10 +257,8 @@ function fix({discriminant, ifStatements}, context, options) {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = {
-		minimumCases: 3,
-		emptyDefaultCase: 'no-default-comment',
-		insertBreakInDefaultCase: false,
 		...context.options[0],
+		insertBreakInDefaultCase: false,
 	};
 	const {sourceCode} = context;
 	const ifStatements = new Set();

--- a/rules/relative-url-style.js
+++ b/rules/relative-url-style.js
@@ -84,7 +84,7 @@ function removeDotSlash(node, sourceCode) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const style = context.options[0] || 'never';
+	const style = context.options[0];
 
 	// TemplateLiteral are not always safe to remove `./`, but if it's starts with `./` we'll report
 	if (style === 'never') {

--- a/rules/string-content.js
+++ b/rules/string-content.js
@@ -62,10 +62,7 @@ function getReplacements(patterns) {
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
-	const {patterns} = {
-		patterns: {},
-		...context.options[0],
-	};
+	const {patterns} = context.options[0];
 	const replacements = getReplacements(patterns);
 
 	if (replacements.length === 0) {
@@ -184,7 +181,7 @@ const config = {
 		fixable: 'code',
 		hasSuggestions: true,
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{patterns: {}}],
 		messages,
 	},
 };

--- a/rules/template-indent.js
+++ b/rules/template-indent.js
@@ -13,13 +13,7 @@ const messages = {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {sourceCode} = context;
-	const options = {
-		tags: ['outdent', 'dedent', 'gql', 'sql', 'html', 'styled'],
-		functions: ['dedent', 'stripIndent'],
-		selectors: [],
-		comments: ['HTML', 'indent'],
-		...context.options[0],
-	};
+	const options = {...context.options[0]};
 
 	options.comments = options.comments.map(comment => comment.toLowerCase());
 	const checked = new WeakSet();
@@ -186,7 +180,12 @@ const config = {
 		},
 		fixable: 'code',
 		schema,
-		defaultOptions: [{}],
+		defaultOptions: [{
+			tags: ['outdent', 'dedent', 'gql', 'sql', 'html', 'styled'],
+			functions: ['dedent', 'stripIndent'],
+			selectors: [],
+			comments: ['HTML', 'indent'],
+		}],
 		messages,
 	},
 };


### PR DESCRIPTION
Moves default option values into `meta.defaultOptions` nd remove redundant manual spreading/fallback patterns in `create()` functions. ESLint (>=9.15.0) recursively merges user options on top of `meta.defaultOptions`, making manual default handling unnecessary.