### PR TITLE
`explicit-length-check`: Ignore `||` with string fallback value

### DIFF
--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -102,6 +102,19 @@ function isNodeValueNumber(node, context) {
 	return staticValue && typeof staticValue.value === 'number';
 }
 
+function isNodeValueString(node, context) {
+	if (node.type === 'Literal' && typeof node.value === 'string') {
+		return true;
+	}
+
+	if (node.type === 'TemplateLiteral') {
+		return true;
+	}
+
+	const staticValue = getStaticValue(node, context.sourceCode.getScope(node));
+	return staticValue && typeof staticValue.value === 'string';
+}
+
 function create(context) {
 	const options = {
 		'non-zero': 'greater-than',
@@ -186,7 +199,7 @@ function create(context) {
 				isLogicalExpression(lengthNode.parent)
 				&& !(
 					lengthNode.parent.operator === '||'
-					&& isNodeValueNumber(lengthNode.parent.right, context)
+					&& (isNodeValueNumber(lengthNode.parent.right, context) || isNodeValueString(lengthNode.parent.right, context))
 				)
 			) {
 				isZeroLengthCheck = isNegative;

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -101,9 +101,13 @@ test({
 		'const foo = { length: 1.5 }; if (foo.length) {}', // Array lengths must be integers
 		'const foo = { length: NaN }; if (foo.length) {}', // Array lengths cannot be NaN
 		'const foo = { length: Infinity }; if (foo.length) {}', // Array lengths cannot be Infinity
-		// Logical OR
+		// Logical OR with number or string fallback
 		'const x = foo.length || 2',
 		'const A_NUMBER = 2; const x = foo.length || A_NUMBER',
+		'const x = foo.length || "bar"',
+		'const x = foo.length || `bar`',
+		'const A_STRING = "bar"; const x = foo.length || A_STRING',
+		'const size = props.size || "mini"',
 	],
 	invalid: [
 		suggestionCase({
@@ -119,9 +123,9 @@ test({
 			desc: 'Replace `.length` with `.length > 0`.',
 		}),
 		suggestionCase({
-			code: 'const NON_NUMBER = "2"; const x = foo.length || NON_NUMBER',
+			code: 'const NON_NUMBER = true; const x = foo.length || NON_NUMBER',
 			messageId: TYPE_NON_ZERO,
-			output: 'const NON_NUMBER = "2"; const x = foo.length > 0 || NON_NUMBER',
+			output: 'const NON_NUMBER = true; const x = foo.length > 0 || NON_NUMBER',
 			desc: 'Replace `.length` with `.length > 0`.',
 		}),
 		suggestionCase({


### PR DESCRIPTION
Fixes #2846