### PR TITLE
`no-unnecessary-polyfills`: Fix false positive for graduated `esnext` features

### DIFF
--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -81,7 +81,13 @@ function create(context) {
 		return;
 	}
 
-	const checkFeatures = features => !features.every(feature => unavailableFeatures.includes(feature));
+	// When core-js graduates a feature from `esnext` to `es`, the entries list both (e.g. `['es.regexp.escape', 'esnext.regexp.escape']`),
+	// but `coreJsCompat` only includes the `es` version in its unavailable list, making the `esnext` version appear "available".
+	// To avoid false positives, treat `esnext.*` features as unavailable when their `es.*` counterpart is already in the list.
+	const checkFeatures = features => !features.every(feature =>
+		unavailableFeatures.includes(feature)
+		|| (feature.startsWith('esnext.') && features.includes(feature.replace('esnext.', 'es.'))),
+	);
 
 	context.on('Literal', node => {
 		if (

--- a/test/no-unnecessary-polyfills.js
+++ b/test/no-unnecessary-polyfills.js
@@ -8,6 +8,15 @@ test({
 			code: 'require("object-assign")',
 			options: [{targets: {node: '0.1.0'}}],
 		},
+		// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2584
+		{
+			code: 'import regexpEscape from "regexp.escape"',
+			options: [{targets: {node: '18'}}],
+		},
+		{
+			code: 'require("core-js/full/regexp/escape")',
+			options: [{targets: {node: '18'}}],
+		},
 		{
 			code: 'require("this-is-not-a-polyfill")',
 			options: [{targets: {node: '0.1.0'}}],
@@ -172,6 +181,17 @@ test({
 			code: 'require("typed-array-float64-array-polyfill")',
 			options: [{targets: 'node 17'}],
 			errors: [{message: 'Use built-in instead.'}],
+		},
+		// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2584
+		{
+			code: 'import regexpEscape from "regexp.escape"',
+			options: [{targets: {node: '24'}}],
+			errors: [{message: 'Use built-in instead.'}],
+		},
+		{
+			code: 'require("core-js/full/regexp/escape")',
+			options: [{targets: {node: '24'}}],
+			errors: [{message: 'All polyfilled features imported from `core-js/full/regexp/escape` are available as built-ins. Use the built-ins instead.'}],
 		},
 	],
 });


### PR DESCRIPTION
Fixes #2584