### PR TITLE
Fix `import-style` crash on `export {x}` without `from` clause

### DIFF
--- a/rules/import-style.js
+++ b/rules/import-style.js
@@ -246,6 +246,10 @@ const create = context => {
 		});
 
 		context.on('ExportNamedDeclaration', node => {
+			if (!node.source) {
+				return;
+			}
+
 			const moduleName = getStringIfConstant(node.source, sourceCode.getScope(node.source));
 
 			const allowedImportStyles = styles.get(moduleName);

--- a/test/import-style.js
+++ b/test/import-style.js
@@ -117,6 +117,11 @@ test({
 		'export {x} from \'named\'',
 		'export {x as y} from \'named\'',
 
+		// `export` without `from` should not crash
+		'const foo = 1; export {foo}',
+		'export const foo = 1;',
+		'export function foo() {}',
+
 		{
 			code: 'import {inspect} from \'util\'',
 			options: [],


### PR DESCRIPTION
Fixes #2148