### PR TITLE
`explicit-length-check`: Avoid unsafe autofix in negated comparisons

### DIFF
--- a/docs/rules/explicit-length-check.md
+++ b/docs/rules/explicit-length-check.md
@@ -165,7 +165,7 @@ The `non-zero` option can be configured with one of the following:
 
 ## Unsafe to fix case
 
-`.length` check inside `LogicalExpression`s are not safe to fix.
+`.length` check inside some expressions are not safe to fix.
 
 Example:
 
@@ -181,6 +181,13 @@ In this case, the `bothNotEmpty` function returns a `number`, but it will most l
 const bothNotEmpty = (a, b) => a.length > 0 && b.length > 0;
 
 if (bothNotEmpty(foo, bar)) {}
+```
+
+`!foo.length` used as the left side of a comparison is also unsafe to fix due to operator precedence.
+
+```js
+// ❌
+if (!foo.length > 0) {}
 ```
 
 The rule is smart enough to know some `LogicalExpression`s are safe to fix, like when it's inside `if`, `while`, etc.

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -120,7 +120,7 @@ function create(context) {
 	const nonZeroStyle = nonZeroStyles.get(options['non-zero']);
 	const {sourceCode} = context;
 
-	function getProblem({node, isZeroLengthCheck, lengthNode, autoFix}) {
+	function getProblem({node, isZeroLengthCheck, lengthNode, autoFix, shouldSuggest = true}) {
 		const {code, test} = isZeroLengthCheck ? zeroStyle : nonZeroStyle;
 		if (test(node)) {
 			return;
@@ -148,7 +148,7 @@ function create(context) {
 
 		if (autoFix) {
 			problem.fix = fix;
-		} else {
+		} else if (shouldSuggest) {
 			problem.suggest = [
 				{
 					messageId: MESSAGE_ID_SUGGESTION,
@@ -206,11 +206,17 @@ function create(context) {
 		}
 
 		if (node) {
+			const isUnsafeNegationInBinaryExpression = node.type === 'UnaryExpression'
+				&& node.operator === '!'
+				&& node.parent.type === 'BinaryExpression'
+				&& node.parent.left === node;
+
 			return getProblem({
 				node,
 				isZeroLengthCheck,
 				lengthNode,
-				autoFix,
+				autoFix: autoFix && !isUnsafeNegationInBinaryExpression,
+				shouldSuggest: !isUnsafeNegationInBinaryExpression,
 			});
 		}
 	});

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -4,6 +4,7 @@ import {getTester, parsers} from './utils/test.js';
 const {test} = getTester(import.meta);
 
 const TYPE_NON_ZERO = 'non-zero';
+const TYPE_ZERO = 'zero';
 
 const suggestionCase = ({code, messageId, output, desc, options = []}) => ({
 	code,
@@ -110,6 +111,18 @@ test({
 		'const size = props.size || "mini"',
 	],
 	invalid: [
+		{
+			code: 'if (!foo.length > 0) {}',
+			// eslint-disable-next-line unicorn/no-null
+			output: null,
+			errors: [{messageId: TYPE_ZERO}],
+		},
+		{
+			code: 'if (!foo.length === 0) {}',
+			// eslint-disable-next-line unicorn/no-null
+			output: null,
+			errors: [{messageId: TYPE_ZERO}],
+		},
 		suggestionCase({
 			code: 'const x = foo.length || bar()',
 			messageId: TYPE_NON_ZERO,


### PR DESCRIPTION
Fixes #2190