### PR TITLE
`consistent-function-scoping`: Fix TypeScript false positives for lexical `this`

### DIFF
--- a/rules/utils/index.js
+++ b/rules/utils/index.js
@@ -41,6 +41,7 @@ export {default as isNewExpressionWithParentheses} from './is-new-expression-wit
 export {default as isNumber} from './is-number.js';
 export {default as isNodeValueNotDomNode} from './is-node-value-not-dom-node.js';
 export {default as isNodeValueNotFunction} from './is-node-value-not-function.js';
+export {default as isNodeContainsLexicalThis} from './is-node-contains-lexical-this.js';
 export {default as isOnSameLine} from './is-on-same-line.js';
 export {default as isSameIdentifier} from './is-same-identifier.js';
 export {default as isSameReference} from './is-same-reference.js';

--- a/rules/utils/is-node-contains-lexical-this.js
+++ b/rules/utils/is-node-contains-lexical-this.js
@@ -1,0 +1,65 @@
+/**
+Check whether a node subtree contains lexical `this`.
+
+This is parser-agnostic and intentionally does not use `scope.thisFound`, because that flag is inconsistent across supported parsers.
+*/
+const isNodeContainsLexicalThis = (node, visitorKeys) => {
+	if (node.type === 'ThisExpression') {
+		return true;
+	}
+
+	if (
+		node.type === 'FunctionDeclaration'
+		|| node.type === 'FunctionExpression'
+	) {
+		// `this` inside non-arrow functions is rebound and does not affect outer arrows.
+		return false;
+	}
+
+	if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
+		// Class bodies create their own `this`, but computed keys/superclass are evaluated in outer scope.
+		if (node.superClass && isNodeContainsLexicalThis(node.superClass, visitorKeys)) {
+			return true;
+		}
+
+		for (const classElement of node.body.body) {
+			if (classElement.computed && isNodeContainsLexicalThis(classElement.key, visitorKeys)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	const keys = visitorKeys[node.type];
+
+	if (!keys) {
+		return false;
+	}
+
+	for (const key of keys) {
+		const value = node[key];
+
+		if (!value) {
+			continue;
+		}
+
+		if (Array.isArray(value)) {
+			for (const childNode of value) {
+				if (childNode && isNodeContainsLexicalThis(childNode, visitorKeys)) {
+					return true;
+				}
+			}
+
+			continue;
+		}
+
+		if (isNodeContainsLexicalThis(value, visitorKeys)) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+export default isNodeContainsLexicalThis;

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -248,6 +248,20 @@ test({
 				return doBar();
 			};
 		`,
+		outdent`
+			function doFoo(Foo) {
+				const doBar = (value = this) => value;
+				return doBar();
+			};
+		`,
+		outdent`
+			function doFoo(Foo) {
+				const doBar = () => class C {
+					[this.x]() {}
+				};
+				return doBar();
+			};
+		`,
 		// `arguments`
 		outdent`
 			function doFoo(Foo) {
@@ -951,6 +965,21 @@ test.typescript({
 			export function a(x: number) {
 				const b = (y: number) => (z: number): number => x + y + z;
 				return b(1)(2);
+			}
+		`,
+		// #2088
+		outdent`
+			class Foo {
+				public bar = new FinalizationRegistry(() => {
+					console.log(this);
+				})
+			}
+		`,
+		// #2088
+		outdent`
+			function foo(this: unknown) {
+				const bar = () => console.log(this);
+				return [].map(() => bar);
 			}
 		`,
 	],


### PR DESCRIPTION
Fixes #2088