### PR TITLE
`consistent-destructuring`: Fix false positive after reassignment

### DIFF
--- a/rules/consistent-destructuring.js
+++ b/rules/consistent-destructuring.js
@@ -55,12 +55,17 @@ const isRootVariableReassigned = (declaration, memberExpressionNode, memberScope
 			return false;
 		}
 
-		if (reference.from.variableScope !== memberScope.variableScope) {
+		const [referenceStart] = sourceCode.getRange(reference.identifier);
+		if (referenceStart < declarationEnd) {
 			return false;
 		}
 
-		const [referenceStart, referenceEnd] = sourceCode.getRange(reference.identifier);
-		return referenceStart >= declarationEnd && referenceEnd <= memberStart;
+		// Be conservative: writes from other variable scopes may run before this read via calls/closures.
+		if (reference.from.variableScope !== memberScope.variableScope) {
+			return true;
+		}
+
+		return referenceStart <= memberStart;
 	});
 };
 

--- a/test/consistent-destructuring.js
+++ b/test/consistent-destructuring.js
@@ -213,6 +213,23 @@ test({
 		outdent`
 			let foo = bar;
 			const {a} = foo;
+			reassign();
+			console.log(foo.a);
+			function reassign() {
+				foo = baz;
+			}
+		`,
+		outdent`
+			let foo = bar;
+			const {a} = foo;
+			function reassign() {
+				foo = baz;
+			}
+			console.log(foo.a);
+		`,
+		outdent`
+			let foo = bar;
+			const {a} = foo;
 			foo = baz;
 			console.log(foo.a);
 		`,
@@ -233,6 +250,34 @@ test({
 		`,
 	],
 	invalid: [
+		invalidTestCase({
+			code: outdent`
+				let foo = bar;
+				foo = baz;
+				const {a} = foo;
+				console.log(foo.a);
+			`,
+			suggestions: [outdent`
+				let foo = bar;
+				foo = baz;
+				const {a} = foo;
+				console.log(a);
+			`],
+		}),
+		invalidTestCase({
+			code: outdent`
+				let foo = bar;
+				const {a} = foo;
+				console.log(foo.a);
+				foo = baz;
+			`,
+			suggestions: [outdent`
+				let foo = bar;
+				const {a} = foo;
+				console.log(a);
+				foo = baz;
+			`],
+		}),
 		invalidTestCase({
 			code: outdent`
 				const {a} = foo;
@@ -454,24 +499,6 @@ test({
 			`,
 			suggestions: [outdent`
 				const {a, ...b} = foo;
-				console.log(a);
-			`],
-		}),
-		invalidTestCase({
-			code: outdent`
-				let foo = bar;
-				const {a} = foo;
-				function reassign() {
-					foo = baz;
-				}
-				console.log(foo.a);
-			`,
-			suggestions: [outdent`
-				let foo = bar;
-				const {a} = foo;
-				function reassign() {
-					foo = baz;
-				}
 				console.log(a);
 			`],
 		}),


### PR DESCRIPTION
Fixes #1407