### PR TITLE
`prevent-abbreviations`: Handle exported TS interfaces and enums

### DIFF
--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -195,6 +195,14 @@ const getMessage = (discouragedName, replacements, nameTypeText) => {
 	};
 };
 
+const declarationTypes = new Set([
+	'FunctionDeclaration',
+	'ClassDeclaration',
+	'TSTypeAliasDeclaration',
+	'TSInterfaceDeclaration',
+	'TSEnumDeclaration',
+]);
+
 const isExportedIdentifier = identifier => {
 	if (
 		identifier.parent.type === 'VariableDeclarator'
@@ -207,21 +215,7 @@ const isExportedIdentifier = identifier => {
 	}
 
 	if (
-		identifier.parent.type === 'FunctionDeclaration'
-		&& identifier.parent.id === identifier
-	) {
-		return identifier.parent.parent.type === 'ExportNamedDeclaration';
-	}
-
-	if (
-		identifier.parent.type === 'ClassDeclaration'
-		&& identifier.parent.id === identifier
-	) {
-		return identifier.parent.parent.type === 'ExportNamedDeclaration';
-	}
-
-	if (
-		identifier.parent.type === 'TSTypeAliasDeclaration'
+		declarationTypes.has(identifier.parent.type)
 		&& identifier.parent.id === identifier
 	) {
 		return identifier.parent.parent.type === 'ExportNamedDeclaration';

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1893,6 +1893,79 @@ test.typescript({
 			`,
 			errors: 2,
 		},
+
+		// TypeScript type references should be autofixed
+		{
+			code: outdent`
+				enum Btn {
+					Primary,
+				}
+				let test: Btn;
+			`,
+			output: outdent`
+				enum Button {
+					Primary,
+				}
+				let test: Button;
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				class Btn {}
+				let test: Btn;
+			`,
+			output: outdent`
+				class Button {}
+				let test: Button;
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				interface Btn {
+					id: number;
+				}
+				let test: Btn;
+			`,
+			output: outdent`
+				interface Button {
+					id: number;
+				}
+				let test: Button;
+			`,
+			errors: 1,
+		},
+		{
+			code: 'type Btn = {};',
+			output: 'type Button = {};',
+			errors: 1,
+		},
+		{
+			code: 'interface Btn {}',
+			output: 'interface Button {}',
+			errors: 1,
+		},
+
+		// Exported TypeScript interface/enum should NOT be autofixed
+		{
+			code: outdent`
+				export interface Btn {
+					id: number;
+				}
+				let test: Btn;
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				export enum Btn {
+					Primary,
+				}
+				let test: Btn;
+			`,
+			errors: 1,
+		},
 	],
 });
 


### PR DESCRIPTION
Fixes #766