### PR TITLE
`prefer-math-min-max`: Ignore Date objects

### DIFF
--- a/rules/prefer-math-min-max.js
+++ b/rules/prefer-math-min-max.js
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import {isBigIntLiteral, isCallExpression} from './ast/index.js';
+import {isBigIntLiteral, isCallExpression, isNewExpression} from './ast/index.js';
 import {fixSpaceAroundKeyword} from './fix/index.js';
 
 const MESSAGE_ID = 'prefer-math-min-max';
@@ -55,6 +55,12 @@ const create = context => {
 		);
 
 		if (hasBigInt) {
+			return;
+		}
+
+		const hasDate = [left, right].some(node => isNewExpression(node, {name: 'Date'}));
+
+		if (hasDate) {
 			return;
 		}
 
@@ -155,6 +161,17 @@ const create = context => {
 							```
 							*/
 							if (variableDeclarator.init?.type === 'Literal' && typeof variableDeclarator.init.value !== 'number') {
+								return;
+							}
+
+							/**
+							Capture the following statement
+
+							```js
+							var foo = new Date()
+							```
+							*/
+							if (isNewExpression(variableDeclarator.init, {name: 'Date'})) {
 								return;
 							}
 

--- a/test/prefer-math-min-max.js
+++ b/test/prefer-math-min-max.js
@@ -13,6 +13,19 @@ test.snapshot({
 		'foo > 10n ? 10n : foo',
 		'foo > BigInt(10) ? BigInt(10) : foo',
 
+		// Ignore Date objects
+		'new Date() > foo ? foo : new Date()',
+		'foo > new Date(0) ? new Date(0) : foo',
+		outdent`
+			var now = new Date();
+			var later = new Date();
+			var value = now > later ? later : now;
+		`,
+		outdent`
+			const start = new Date();
+			var value = start > foo ? foo : start;
+		`,
+
 		// Ignore when you know it is a string
 		outdent`
 			function foo(a = 'string', b) {
@@ -117,6 +130,16 @@ test.snapshot({
 			function foo(a: bigint, b: bigint) {
 				return a > b ? a : b;
 			}
+		`,
+		outdent`
+			function foo(a: Date, b: Date) {
+				return a > b ? a : b;
+			}
+		`,
+		outdent`
+			var foo: Date;
+			var bar: Date;
+			var value = foo > bar ? bar : foo;
 		`,
 		outdent`
 			var foo = 10;


### PR DESCRIPTION
Closes #2900

Date objects compared with `>`/`<` should not be replaced with `Math.min()`/`Math.max()` since those return `NaN` for Date objects.

This follows the same approach used for BigInt in #2527:
- Detect `new Date()` expressions directly in comparison operands
- Detect variables initialized with `new Date()`
- TypeScript `a: Date` annotations were already handled by `isNumberTypeAnnotation`