### PR TITLE
chore: replace `is-builtin-module` with native `node:module` `isBuiltin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
 		"find-up-simple": "^1.0.1",
 		"globals": "^16.4.0",
 		"indent-string": "^5.0.0",
-		"is-builtin-module": "^5.0.0",
 		"jsesc": "^3.1.0",
 		"pluralize": "^8.0.0",
 		"regexp-tree": "^0.1.27",

--- a/rules/prefer-node-protocol.js
+++ b/rules/prefer-node-protocol.js
@@ -1,4 +1,4 @@
-import isBuiltinModule from 'is-builtin-module';
+import {isBuiltin} from 'node:module';
 import {
 	isStaticRequire,
 	isMethodCall,
@@ -9,6 +9,11 @@ const messages = {
 	[MESSAGE_ID]: 'Prefer `node:{{moduleName}}` over `{{moduleName}}`.',
 };
 const NODE_PROTOCOL = 'node:';
+
+// Deprecated built-in modules that should not get the node: prefix suggestion.
+// node:module.isBuiltin() returns true for these, but they are deprecated
+// and not part of the recommended module set.
+const deprecatedBuiltins = new Set(['punycode', 'sys']);
 
 /**
 @param {import('eslint').Rule.RuleContext} context
@@ -47,8 +52,9 @@ const create = context => {
 		if (!(
 			typeof value === 'string'
 			&& !value.startsWith(NODE_PROTOCOL)
-			&& isBuiltinModule(value)
-			&& isBuiltinModule(`${NODE_PROTOCOL}${value}`)
+			&& !deprecatedBuiltins.has(value)
+			&& isBuiltin(value)
+			&& isBuiltin(`${NODE_PROTOCOL}${value}`)
 		)) {
 			return;
 		}


### PR DESCRIPTION
## Summary

- Replaces the `is-builtin-module` package with Node.js built-in `module.isBuiltin()` (available since Node 16.x)
- The package already requires `node >= 20.10`, so the native API is always available
- Removes 1 production dependency (and its transitive dep `builtin-modules`)

## Notes

The native `isBuiltin()` returns `true` for deprecated modules (`punycode`, `sys`) that `is-builtin-module` explicitly excludes. A small exclusion set preserves the existing behavior — the `prefer-node-protocol` rule will continue to skip deprecated builtins, matching current test expectations.

## Changes

- `rules/prefer-node-protocol.js` — `import isBuiltinModule` → `import { isBuiltin } from 'node:module'`, added `deprecatedBuiltins` set
- `package.json` — removed `is-builtin-module` from dependencies

## Testing

All existing tests pass, including the `punycode` edge case (`import "punycode"` remains valid without triggering the rule).