### PR TITLE
✨ Quality: Ignore decorators in `throw-new-error` rule

### DIFF
--- a/rules/throw-new-error.js
+++ b/rules/throw-new-error.js
@@ -11,6 +11,10 @@ const customError = /^(?:[A-Z][\da-z]*)*Error$/;
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	context.on('CallExpression', node => {
+		if (node.parent.type === 'Decorator') {
+			return;
+		}
+
 		const {callee} = node;
 		if (!(
 			(callee.type === 'Identifier' && customError.test(callee.name))


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The `throw-new-error` rule enforces that PascalCase functions containing the word "Error" are called with `new`. However, decorator factories like `@RegisterServiceError()` are conventionally PascalCase and should not require `new`. We need to exclude `CallExpression`s that are the direct child of a `Decorator` node from being evaluated by this rule.

**Severity**: `high`
**File**: `rules/throw-new-error.js`

### Solution
The `throw-new-error` rule enforces that PascalCase functions containing the word "Error" are called with `new`. However, decorator factories like `@RegisterServiceError()` are conventionally PascalCase and should not require `new`. We need to exclude `CallExpression`s that are the direct child of a `Decorator` node from being evaluated by this rule.

### Changes
- `rules/throw-new-error.js` (modified)



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2360