### PR TITLE
`prefer-string-slice`: Improve autofix

### DIFF
--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -1,5 +1,5 @@
 import {getStaticValue} from '@eslint-community/eslint-utils';
-import {getParenthesizedText, getParenthesizedRange} from './utils/index.js';
+import {getParenthesizedText, getParenthesizedRange, isDecimalInteger} from './utils/index.js';
 import {replaceArgument} from './fix/index.js';
 import {isNumericLiteral, isMethodCall} from './ast/index.js';
 import {getNegativeIndexLengthNode} from './shared/negative-index.js';
@@ -54,7 +54,7 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 		}
 
 		const lengthNode = getNegativeIndexLengthNode(secondArgument, node.callee.object);
-		if (lengthNode && secondArgument.left === lengthNode) {
+		if (lengthNode && secondArgument.left === lengthNode && isDecimalInteger(secondArgument.right.raw)) {
 			yield replaceSecondArgument(`-${secondArgument.right.value}`);
 			return;
 		}
@@ -121,7 +121,7 @@ function * fixSubstringArguments({node, fixer, context, abort}) {
 		const nonZeroArgumentText = getParenthesizedText(nonZeroArgument, context);
 		const lengthNode = getNegativeIndexLengthNode(nonZeroArgument, node.callee.object);
 
-		if (lengthNode && nonZeroArgument.left === lengthNode) {
+		if (lengthNode && nonZeroArgument.left === lengthNode && isDecimalInteger(nonZeroArgument.right.raw)) {
 			yield replaceSecondArgument(`-${nonZeroArgument.right.value}`);
 			return;
 		}

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -2,6 +2,7 @@ import {getStaticValue} from '@eslint-community/eslint-utils';
 import {getParenthesizedText, getParenthesizedRange} from './utils/index.js';
 import {replaceArgument} from './fix/index.js';
 import {isNumericLiteral, isMethodCall} from './ast/index.js';
+import {getNegativeIndexLengthNode} from './shared/negative-index.js';
 
 const MESSAGE_ID_SUBSTR = 'substr';
 const MESSAGE_ID_SUBSTRING = 'substring';
@@ -52,6 +53,12 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 			return;
 		}
 
+		const lengthNode = getNegativeIndexLengthNode(secondArgument, node.callee.object);
+		if (lengthNode && secondArgument.left === lengthNode) {
+			yield replaceSecondArgument(`-${secondArgument.right.value}`);
+			return;
+		}
+
 		yield fixer.insertTextBeforeRange(secondArgumentRange, 'Math.max(0, ');
 		yield fixer.insertTextAfterRange(secondArgumentRange, ')');
 		return;
@@ -69,7 +76,6 @@ function * fixSubstringArguments({node, fixer, context, abort}) {
 	const [firstArgument, secondArgument] = node.arguments;
 
 	const firstNumber = firstArgument ? getNumericValue(firstArgument) : undefined;
-	const firstArgumentText = getParenthesizedText(firstArgument, context);
 	const replaceFirstArgument = text => replaceArgument(fixer, firstArgument, text, context);
 
 	if (!secondArgument) {
@@ -89,7 +95,6 @@ function * fixSubstringArguments({node, fixer, context, abort}) {
 	}
 
 	const secondNumber = getNumericValue(secondArgument);
-	const secondArgumentText = getParenthesizedText(secondArgument, context);
 	const replaceSecondArgument = text => replaceArgument(fixer, secondArgument, text, context);
 
 	if (firstNumber !== undefined && secondNumber !== undefined) {
@@ -111,7 +116,17 @@ function * fixSubstringArguments({node, fixer, context, abort}) {
 
 	if (firstNumber === 0 || secondNumber === 0) {
 		yield replaceFirstArgument('0');
-		yield replaceSecondArgument(`Math.max(0, ${firstNumber === 0 ? secondArgumentText : firstArgumentText})`);
+
+		const nonZeroArgument = firstNumber === 0 ? secondArgument : firstArgument;
+		const nonZeroArgumentText = getParenthesizedText(nonZeroArgument, context);
+		const lengthNode = getNegativeIndexLengthNode(nonZeroArgument, node.callee.object);
+
+		if (lengthNode && nonZeroArgument.left === lengthNode) {
+			yield replaceSecondArgument(`-${nonZeroArgument.right.value}`);
+			return;
+		}
+
+		yield replaceSecondArgument(`Math.max(0, ${nonZeroArgumentText})`);
 		return;
 	}
 

--- a/rules/prefer-string-slice.js
+++ b/rules/prefer-string-slice.js
@@ -21,6 +21,18 @@ const getNumericValue = node => {
 	}
 };
 
+const getNegativeIndexText = (node, objectNode, sourceCode) => {
+	const lengthNode = getNegativeIndexLengthNode(node, objectNode);
+	if (
+		lengthNode
+		&& node.left === lengthNode
+		&& isDecimalInteger(node.right.raw)
+		&& sourceCode.getCommentsInside(node).length === 0
+	) {
+		return `-${node.right.value}`;
+	}
+};
+
 // This handles cases where the argument is very likely to be a number, such as `.substring('foo'.length)`.
 const isLengthProperty = node => (
 	node?.type === 'MemberExpression'
@@ -53,9 +65,9 @@ function * fixSubstrArguments({node, fixer, context, abort}) {
 			return;
 		}
 
-		const lengthNode = getNegativeIndexLengthNode(secondArgument, node.callee.object);
-		if (lengthNode && secondArgument.left === lengthNode && isDecimalInteger(secondArgument.right.raw)) {
-			yield replaceSecondArgument(`-${secondArgument.right.value}`);
+		const negativeIndexText = getNegativeIndexText(secondArgument, node.callee.object, sourceCode);
+		if (negativeIndexText) {
+			yield replaceSecondArgument(negativeIndexText);
 			return;
 		}
 
@@ -118,14 +130,13 @@ function * fixSubstringArguments({node, fixer, context, abort}) {
 		yield replaceFirstArgument('0');
 
 		const nonZeroArgument = firstNumber === 0 ? secondArgument : firstArgument;
-		const nonZeroArgumentText = getParenthesizedText(nonZeroArgument, context);
-		const lengthNode = getNegativeIndexLengthNode(nonZeroArgument, node.callee.object);
-
-		if (lengthNode && nonZeroArgument.left === lengthNode && isDecimalInteger(nonZeroArgument.right.raw)) {
-			yield replaceSecondArgument(`-${nonZeroArgument.right.value}`);
+		const negativeIndexText = getNegativeIndexText(nonZeroArgument, node.callee.object, context.sourceCode);
+		if (negativeIndexText) {
+			yield replaceSecondArgument(negativeIndexText);
 			return;
 		}
 
+		const nonZeroArgumentText = getParenthesizedText(nonZeroArgument, context);
 		yield replaceSecondArgument(`Math.max(0, ${nonZeroArgumentText})`);
 		return;
 	}

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -288,6 +288,16 @@ test({
 			output: 'foo.slice(0, Math.max(0, bar.length - 1))',
 			errors: errorsSubstring,
 		},
+		{
+			code: 'foo.substr(0, foo.length - 1.5)',
+			output: 'foo.slice(0, Math.max(0, foo.length - 1.5))',
+			errors: errorsSubstr,
+		},
+		{
+			code: 'foo.substring(0, foo.length - 1.5)',
+			output: 'foo.slice(0, Math.max(0, foo.length - 1.5))',
+			errors: errorsSubstring,
+		},
 		// Extra arguments
 		{
 			code: 'foo.substring(1, 2, 3)',

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -253,6 +253,41 @@ test({
 			output: '"foo".slice(1, 3)',
 			errors: errorsSubstring,
 		},
+		{
+			code: 'foo.substr(0, foo.length - 1)',
+			output: 'foo.slice(0, -1)',
+			errors: errorsSubstr,
+		},
+		{
+			code: 'foo.substring(0, foo.length - 1)',
+			output: 'foo.slice(0, -1)',
+			errors: errorsSubstring,
+		},
+		{
+			code: 'foo.substring(foo.length - 1, 0)',
+			output: 'foo.slice(0, -1)',
+			errors: errorsSubstring,
+		},
+		{
+			code: 'foo.substr(0, foo.length - x)',
+			output: 'foo.slice(0, Math.max(0, foo.length - x))',
+			errors: errorsSubstr,
+		},
+		{
+			code: 'foo.substring(0, foo.length - x)',
+			output: 'foo.slice(0, Math.max(0, foo.length - x))',
+			errors: errorsSubstring,
+		},
+		{
+			code: 'foo.substr(0, bar.length - 1)',
+			output: 'foo.slice(0, Math.max(0, bar.length - 1))',
+			errors: errorsSubstr,
+		},
+		{
+			code: 'foo.substring(0, bar.length - 1)',
+			output: 'foo.slice(0, Math.max(0, bar.length - 1))',
+			errors: errorsSubstring,
+		},
 		// Extra arguments
 		{
 			code: 'foo.substring(1, 2, 3)',

--- a/test/prefer-string-slice.js
+++ b/test/prefer-string-slice.js
@@ -298,6 +298,16 @@ test({
 			output: 'foo.slice(0, Math.max(0, foo.length - 1.5))',
 			errors: errorsSubstring,
 		},
+		{
+			code: 'foo.substr(0, foo.length - /* keep */ 1)',
+			output: 'foo.slice(0, Math.max(0, foo.length - /* keep */ 1))',
+			errors: errorsSubstr,
+		},
+		{
+			code: 'foo.substring(0, foo.length - /* keep */ 1)',
+			output: 'foo.slice(0, Math.max(0, foo.length - /* keep */ 1))',
+			errors: errorsSubstring,
+		},
 		// Extra arguments
 		{
 			code: 'foo.substring(1, 2, 3)',


### PR DESCRIPTION
closes #2505 

I noticed this issue and attempted an implementation.

The rule now produces `str.slice(0, -x)` instead of `str.slice(0, Math.max(0, str.length - x))` when x is a positive numeric literal.

Please let me know if there’s anything I should adjust.
