### PR TITLE
Avoid running CI twice for local PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,13 @@
 name: CI
+
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - main
+
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - '*'
   push:
     branches:
       - main


### PR DESCRIPTION
This is wasting GHA minutes:

<img width="611" height="82" alt="Screenshot 11" src="https://github.com/user-attachments/assets/cbc97a0f-278c-4677-8367-afc85d9bec25" />

I had this config in Refined GitHub for a while: https://github.com/refined-github/refined-github/blob/f93c8b2305e3eed82e12447a5780ba90e47c2553/.github/workflows/test.yml#L3-L10

It means:

- only run CI on local pushes to `main`
- other branches will run CI only when PRs are open