### PR TITLE
`expiring-todo-comments` - Refactor messages for clarity and brevity

### DIFF
--- a/rules/expiring-todo-comments.js
+++ b/rules/expiring-todo-comments.js
@@ -29,26 +29,26 @@ const messages = {
 	[MESSAGE_ID_AVOID_MULTIPLE_DATES]:
 		'Avoid using multiple expiration dates in TODO: {{expirationDates}}. {{message}}',
 	[MESSAGE_ID_EXPIRED_TODO]:
-		'There is a TODO that is past due date: {{expirationDate}}. {{message}}',
+		'Past due date: {{expirationDate}}. {{message}}',
 	[MESSAGE_ID_REACHED_PACKAGE_VERSION]:
-		'There is a TODO that is past due package version: {{comparison}}. {{message}}',
+		'Past due package version: {{comparison}}. {{message}}',
 	[MESSAGE_ID_AVOID_MULTIPLE_PACKAGE_VERSIONS]:
-		'Avoid using multiple package versions in TODO: {{versions}}. {{message}}',
+		'Avoid using multiple package versions: {{versions}}. {{message}}',
 	[MESSAGE_ID_HAVE_PACKAGE]:
-		'There is a TODO that is deprecated since you installed: {{package}}. {{message}}',
+		'TODO due since {{package}} was installed. {{message}}',
 	[MESSAGE_ID_DONT_HAVE_PACKAGE]:
-		'There is a TODO that is deprecated since you uninstalled: {{package}}. {{message}}',
+		'TODO due since {{package}} was removed. {{message}}',
 	[MESSAGE_ID_VERSION_MATCHES]:
-		'There is a TODO match for package version: {{comparison}}. {{message}}',
+		'TODO due since the condition was met: {{comparison}}. {{message}}',
 	[MESSAGE_ID_ENGINE_MATCHES]:
-		'There is a TODO match for Node.js version: {{comparison}}. {{message}}',
+		'TODO due since the condition was met: {{comparison}}. {{message}}',
 	[MESSAGE_ID_REMOVE_WHITESPACE]:
 		'Avoid using whitespace on TODO argument. On \'{{original}}\' use \'{{fix}}\'. {{message}}',
 	[MESSAGE_ID_MISSING_AT_SYMBOL]:
 		'Missing \'@\' on TODO argument. On \'{{original}}\' use \'{{fix}}\'. {{message}}',
 	...baseRule.meta.messages,
 	[MESSAGE_ID_CORE_RULE_UNEXPECTED_COMMENT]:
-		'Unexpected \'{{matchedTerm}}\' comment without any conditions: \'{{comment}}\'.',
+		'Unexpected \'{{matchedTerm}}\': \'{{comment}}\'.',
 };
 
 /** @param {string} dirname */


### PR DESCRIPTION
I found the TODOs needlessly verbose, eclipsing the actual message/task at hand:

## Example

```
/source/features/clean-conversation-headers.css
  1:1  warning  There is a TODO that is past due date: 2025-04-01. Revert https://github.com/refined-github/refined-github/pull/8111  unicorn/expiring-todo-comments

/source/features/clean-repo-sidebar.css
  1:1  warning  Unexpected 'todo' comment without any conditions: 'TODO: Remove .Layout-sidebar after...'  unicorn/expiring-todo-comments

/source/features/collapsible-content-button.tsx
  64:2  warning  Unexpected 'todo' comment without any conditions: 'TODO: ensure it's added only once before...'  unicorn/expiring-todo-comments

/source/features/default-branch-button.css
  1:1  warning  There is a TODO that is past due date: 2025-03-01. Revert https://github.com/refined-github/refined-github/pull/7859  unicorn/expiring-todo-comments

/source/features/default-branch-button.tsx
  49:2  warning  Unexpected 'todo' comment without any conditions: 'TODO: Move to excludes after...'  unicorn/expiring-todo-comments

/source/features/extend-diff-expander.css
  1:1  warning  There is a TODO that is past due date: 2025-04-01. Revert https://github.com/refined-github/refined-github/pull/8111  unicorn/expiring-todo-comments

/source/features/extensible-nav.css
  2:2  warning  Unexpected 'todo' comment without any conditions: 'TODO: Remove before shipping. Temporary...'  unicorn/expiring-todo-comments

/source/features/github-bugs.css
  47:1  warning  Unexpected 'todo' comment without any conditions: 'TODO: Drop after React PR conversations'  unicorn/expiring-todo-comments
  69:1  warning  Unexpected 'todo' comment without any conditions: 'TODO: Drop after React PR conversations'  unicorn/expiring-todo-comments

/source/features/no-self-reference.tsx
  24:2  warning  Unexpected 'todo' comment without any conditions: 'TODO: Revert #9086 after...'  unicorn/expiring-todo-comments

/source/features/open-all-conversations.tsx
  13:3  warning  There is a TODO that is past due date: 2026-01-01. Pre-React selector; Drop  unicorn/expiring-todo-comments
  23:4  warning  There is a TODO that is past due date: 2026-01-01. Pre-React selector; Drop  unicorn/expiring-todo-comments
  40:3  warning  There is a TODO that is past due date: 2026-01-01. Pre-React selector; Drop  unicorn/expiring-todo-comments
  64:4  warning  There is a TODO that is past due date: 2026-01-01. Pre-React selector; Drop  unicorn/expiring-todo-comments
``

