### PR TITLE
`explicit-length-check`: Ignore nullable property guards

### DIFF
--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -51,6 +51,13 @@ const zeroStyle = {
 
 const shapeProperties = new Set(['depth', 'height', 'width']);
 
+function isLengthOrSizeMemberExpression(node) {
+	return isMemberExpression(node, {
+		properties: ['length', 'size'],
+		optional: false,
+	});
+}
+
 function getLogicalExpressionRoot(node) {
 	while (
 		isLogicalExpression(node.parent)
@@ -84,6 +91,20 @@ function hasSameObjectShapePropertyCheck({node, lengthNode}) {
 		&& operand.property.type === 'Identifier'
 		&& shapeProperties.has(operand.property.name)
 		&& isSameReference(operand.object, lengthNode.object));
+}
+
+function getLengthCheckMemberExpression(node) {
+	if (node.type !== 'BinaryExpression') {
+		return;
+	}
+
+	if (isLengthOrSizeMemberExpression(node.left)) {
+		return node.left;
+	}
+
+	if (isLengthOrSizeMemberExpression(node.right)) {
+		return node.right;
+	}
 }
 
 function getLengthCheckNode(node) {
@@ -130,6 +151,30 @@ function getLengthCheckNode(node) {
 	}
 
 	return {};
+}
+
+function isSameLengthNonZeroCheck(node, lengthNode) {
+	const comparisonLengthNode = getLengthCheckMemberExpression(node);
+	if (!comparisonLengthNode || !isSameReference(comparisonLengthNode, lengthNode)) {
+		return false;
+	}
+
+	const {isZeroLengthCheck, node: lengthCheckNode} = getLengthCheckNode(comparisonLengthNode);
+	return lengthCheckNode === node && isZeroLengthCheck === false;
+}
+
+function hasSameLengthNonZeroCheck({node, lengthNode}) {
+	const root = getLogicalExpressionRoot(node);
+	if (
+		root.type !== 'LogicalExpression'
+		|| root.operator !== '&&'
+	) {
+		return false;
+	}
+
+	return getLogicalExpressionOperands(root).some(operand =>
+		operand !== node
+		&& isSameLengthNonZeroCheck(operand, lengthNode));
 }
 
 function create(context) {
@@ -179,10 +224,7 @@ function create(context) {
 
 	context.on('MemberExpression', memberExpression => {
 		if (
-			!isMemberExpression(memberExpression, {
-				properties: ['length', 'size'],
-				optional: false,
-			})
+			!isLengthOrSizeMemberExpression(memberExpression)
 			|| memberExpression.object.type === 'ThisExpression'
 		) {
 			return;
@@ -217,7 +259,11 @@ function create(context) {
 		}
 
 		if (node) {
-			if (hasSameObjectShapePropertyCheck({node, lengthNode})) {
+			const isSameLengthGuard = node === lengthNode && hasSameLengthNonZeroCheck({node, lengthNode});
+			if (
+				isSameLengthGuard
+				|| hasSameObjectShapePropertyCheck({node, lengthNode})
+			) {
 				return;
 			}
 

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -58,6 +58,32 @@ function isLengthOrSizeMemberExpression(node) {
 	});
 }
 
+function isTypeScriptExpression(node) {
+	return node?.type === 'TSAsExpression'
+		|| node?.type === 'TSSatisfiesExpression'
+		|| node?.type === 'TSTypeAssertion'
+		|| node?.type === 'TSNonNullExpression';
+}
+
+function unwrapTypeScriptExpression(node) {
+	if (isTypeScriptExpression(node)) {
+		return unwrapTypeScriptExpression(node.expression);
+	}
+
+	return node;
+}
+
+function getLengthCheckParent(node, allowTypeScriptExpression) {
+	node = node.parent;
+	if (allowTypeScriptExpression) {
+		while (isTypeScriptExpression(node)) {
+			node = node.parent;
+		}
+	}
+
+	return node;
+}
+
 function getLogicalExpressionRoot(node) {
 	while (
 		isLogicalExpression(node.parent)
@@ -94,21 +120,36 @@ function hasSameObjectShapePropertyCheck({node, lengthNode}) {
 }
 
 function getLengthCheckMemberExpression(node) {
+	if (node.type === 'UnaryExpression' && node.operator === '!') {
+		return getLengthCheckMemberExpression(node.argument);
+	}
+
+	if (
+		node.type === 'CallExpression'
+		&& node.callee.type === 'Identifier'
+		&& node.callee.name === 'Boolean'
+		&& node.arguments.length === 1
+	) {
+		return getLengthCheckMemberExpression(node.arguments[0]);
+	}
+
 	if (node.type !== 'BinaryExpression') {
 		return;
 	}
 
-	if (isLengthOrSizeMemberExpression(node.left)) {
-		return node.left;
+	const left = unwrapTypeScriptExpression(node.left);
+	if (isLengthOrSizeMemberExpression(left)) {
+		return left;
 	}
 
-	if (isLengthOrSizeMemberExpression(node.right)) {
-		return node.right;
+	const right = unwrapTypeScriptExpression(node.right);
+	if (isLengthOrSizeMemberExpression(right)) {
+		return right;
 	}
 }
 
-function getLengthCheckNode(node) {
-	node = node.parent;
+function getLengthCheckNode(node, {allowTypeScriptExpression = false} = {}) {
+	node = getLengthCheckParent(node, allowTypeScriptExpression);
 
 	// Zero length check
 	if (
@@ -140,7 +181,7 @@ function getLengthCheckNode(node) {
 		|| isCompareRight(node, '>=', 1)
 		// `0 !== foo.length`
 		|| isCompareLeft(node, '!==', 0)
-		// `0 !== foo.length`
+		// `0 != foo.length`
 		|| isCompareLeft(node, '!=', 0)
 		// `0 < foo.length`
 		|| isCompareLeft(node, '<', 0)
@@ -159,12 +200,17 @@ function isSameLengthNonZeroCheck(node, lengthNode) {
 		return false;
 	}
 
-	const {isZeroLengthCheck, node: lengthCheckNode} = getLengthCheckNode(comparisonLengthNode);
-	return lengthCheckNode === node && isZeroLengthCheck === false;
+	const {isZeroLengthCheck, node: lengthCheckNode} = getLengthCheckNode(comparisonLengthNode, {allowTypeScriptExpression: true});
+	if (!lengthCheckNode) {
+		return false;
+	}
+
+	const {isNegative, node: ancestor} = getBooleanAncestor(lengthCheckNode);
+	return ancestor === node && isNegative === isZeroLengthCheck;
 }
 
-function hasSameLengthNonZeroCheck({node, lengthNode}) {
-	const root = getLogicalExpressionRoot(node);
+function isLengthGuardedByNonZeroCheck(lengthNode) {
+	const root = getLogicalExpressionRoot(lengthNode);
 	if (
 		root.type !== 'LogicalExpression'
 		|| root.operator !== '&&'
@@ -173,7 +219,7 @@ function hasSameLengthNonZeroCheck({node, lengthNode}) {
 	}
 
 	return getLogicalExpressionOperands(root).some(operand =>
-		operand !== node
+		operand !== lengthNode
 		&& isSameLengthNonZeroCheck(operand, lengthNode));
 }
 
@@ -259,9 +305,8 @@ function create(context) {
 		}
 
 		if (node) {
-			const isSameLengthGuard = node === lengthNode && hasSameLengthNonZeroCheck({node, lengthNode});
 			if (
-				isSameLengthGuard
+				(node === lengthNode && isLengthGuardedByNonZeroCheck(lengthNode))
 				|| hasSameObjectShapePropertyCheck({node, lengthNode})
 			) {
 				return;

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -79,6 +79,47 @@ test({
 			code: 'const object: {length: number | undefined} = {length: 123}; if (object.length && object.length > 0) {}',
 			languageOptions: {parser: parsers.typescript},
 		},
+		{
+			code: 'const object: {size: number | undefined} = {size: 123}; if (object.size && object.size !== 0) {}',
+			languageOptions: {parser: parsers.typescript},
+			options: [{'non-zero': 'not-equal'}],
+		},
+		{
+			code: 'const object: {size: number | undefined} = {size: 123}; if (object.size && object.size! > 0) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object: {size: number | undefined} = {size: 123}; if (object.size && (object.size as number) > 0) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object: {size: number | undefined} = {size: 123}; if (object.size && (<number>object.size) > 0) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object = {size: 123}; if (object.size && (object.size satisfies number) > 0) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object: {size: number | undefined} = {size: 123}; if (object.size! >= 1) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object: {size: number | undefined} = {size: 123}; if ((object.size as number) >= 1) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object: {size: number | undefined} = {size: 123}; if ((<number>object.size) >= 1) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object = {size: 123}; if ((object.size satisfies number) >= 1) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object: {size: number | undefined} = {size: 123}; if (object.size && object.size! >= 1) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
 
 		// Checking 'non-zero'
 		'if (foo.length === 0) {}',
@@ -211,6 +252,31 @@ test({
 			code: 'if (object.size && object.size > 0) {}',
 			output: 'if (object.size && object.size !== 0) {}',
 			options: [{'non-zero': 'not-equal'}],
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (object.size && other.size > 0) {}',
+			output: 'if (object.size > 0 && other.size > 0) {}',
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (object.size && !(object.size === 0)) {}',
+			output: 'if (object.size && object.size > 0) {}',
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (object.size && Boolean(object.size !== 0)) {}',
+			output: 'if (object.size && object.size > 0) {}',
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (object.size && Boolean(object.size > 0)) {}',
+			output: 'if (object.size && object.size > 0) {}',
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (object.size && !Boolean(object.size === 0)) {}',
+			output: 'if (object.size && object.size > 0) {}',
 			errors: [{messageId: TYPE_NON_ZERO}],
 		},
 		{

--- a/test/explicit-length-check.js
+++ b/test/explicit-length-check.js
@@ -71,6 +71,14 @@ test({
 			code: 'if (foo.length !== 0) {}',
 			options: [{'non-zero': 'not-equal'}],
 		},
+		{
+			code: 'const object: {size: number | null} = {size: 123}; if (object.size && object.size > 0) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
+		{
+			code: 'const object: {length: number | undefined} = {length: 123}; if (object.length && object.length > 0) {}',
+			languageOptions: {parser: parsers.typescript},
+		},
 
 		// Checking 'non-zero'
 		'if (foo.length === 0) {}',
@@ -188,6 +196,40 @@ test({
 			code: 'if (dimensions.width > 0 && dimensions.length) {}',
 			output: 'if (dimensions.width > 0 && dimensions.length > 0) {}',
 			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (object.size && object.size >= 1) {}',
+			output: 'if (object.size && object.size > 0) {}',
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (0 < object.size && object.size) {}',
+			output: 'if (object.size > 0 && object.size) {}',
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (object.size && object.size > 0) {}',
+			output: 'if (object.size && object.size !== 0) {}',
+			options: [{'non-zero': 'not-equal'}],
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (object.size >= 1 && object.size !== 0) {}',
+			output: 'if (object.size > 0 && object.size > 0) {}',
+			errors: [
+				{messageId: TYPE_NON_ZERO},
+				{messageId: TYPE_NON_ZERO},
+			],
+		},
+		{
+			code: 'if (!!object.size && object.size > 0) {}',
+			output: 'if (object.size > 0 && object.size > 0) {}',
+			errors: [{messageId: TYPE_NON_ZERO}],
+		},
+		{
+			code: 'if (!object.size && object.size > 0) {}',
+			output: 'if (object.size === 0 && object.size > 0) {}',
+			errors: [{messageId: TYPE_ZERO}],
 		},
 	],
 });


### PR DESCRIPTION
Fixes #2217