### PR TITLE
`no-array-for-each`: Ignore `strict-callbag-basics` namespaces

### DIFF
--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -388,8 +388,21 @@ const ignoredObjects = [
 	'pIteration',
 	// https://www.npmjs.com/package/effect
 	'Effect',
-	'CB',
 ];
+
+const strictCallbagBasicsPackage = 'strict-callbag-basics';
+
+function isStrictCallbagBasicsNamespace(node, scope) {
+	if (node.type !== 'Identifier') {
+		return false;
+	}
+
+	const variable = findVariable(scope, node);
+	return variable?.defs.some(definition =>
+		definition.type === 'ImportBinding'
+		&& definition.node.type === 'ImportNamespaceSpecifier'
+		&& definition.parent.source.value === strictCallbagBasicsPackage) ?? false;
+}
 
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
@@ -428,18 +441,20 @@ const create = context => {
 	});
 
 	context.on('CallExpression', node => {
+		const scope = sourceCode.getScope(node);
 		if (
 			!isMethodCall(node, {
 				method: 'forEach',
 			})
 			|| isNodeMatches(node.callee.object, ignoredObjects)
+			|| isStrictCallbagBasicsNamespace(node.callee.object, scope)
 		) {
 			return;
 		}
 
 		callExpressions.push({
 			node,
-			scope: sourceCode.getScope(node),
+			scope,
 		});
 	});
 

--- a/rules/no-array-for-each.js
+++ b/rules/no-array-for-each.js
@@ -388,6 +388,7 @@ const ignoredObjects = [
 	'pIteration',
 	// https://www.npmjs.com/package/effect
 	'Effect',
+	'CB',
 ];
 
 /** @param {import('eslint').Rule.RuleContext} context */

--- a/test/no-array-for-each.js
+++ b/test/no-array-for-each.js
@@ -17,6 +17,18 @@ test.snapshot({
 				// My other code...
 			});
 		`,
+		// #1788
+		outdent`
+			import * as CB from "strict-callbag-basics";
+
+			CB.pipe(
+				CB.interval(1000),
+				CB.map(x => x + 1),
+				CB.filter(x => x % 2),
+				CB.take(5),
+				CB.forEach(x => console.log(x))
+			);
+		`,
 		// #2758
 		'Effect.forEach([1,2,3], (n) => Effect.succeed(n))',
 	],

--- a/test/no-array-for-each.js
+++ b/test/no-array-for-each.js
@@ -19,7 +19,7 @@ test.snapshot({
 		`,
 		// #1788
 		outdent`
-			import * as CB from "strict-callbag-basics";
+			import * as CB from 'strict-callbag-basics';
 
 			CB.pipe(
 				CB.interval(1000),
@@ -28,6 +28,11 @@ test.snapshot({
 				CB.take(5),
 				CB.forEach(x => console.log(x))
 			);
+		`,
+		outdent`
+			import * as callbagBasics from 'strict-callbag-basics';
+
+			callbagBasics.forEach(value => console.log(value));
 		`,
 		// #2758
 		'Effect.forEach([1,2,3], (n) => Effect.succeed(n))',
@@ -578,6 +583,17 @@ test({
 			languageOptions: {
 				sourceType: 'script',
 			},
+		},
+		{
+			code: outdent`
+				const CB = [];
+				CB.forEach(element => console.log(element));
+			`,
+			output: outdent`
+				const CB = [];
+				for (const element of CB) console.log(element);
+			`,
+			errors: 1,
 		},
 	],
 });


### PR DESCRIPTION
Fixes #1788