### PR TITLE
`consistent-function-scoping`: Ignore functions in Jest mock factories

### DIFF
--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -139,3 +139,15 @@ useEffect(() => {
 	getItems();
 }, [])
 ```
+
+Functions inside `jest.mock()` factories are ignored because Jest restricts those factories from referencing out-of-scope variables:
+
+```js
+jest.mock('module', () => {
+	function createMock() {
+		return 'mock';
+	}
+
+	return createMock;
+});
+```

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -99,6 +99,25 @@ const isArrowFunctionNodeWithThis = (node, visitorKeys) =>
 	// Include both params and body, because parameter defaults can reference lexical `this`.
 	&& isNodeContainsLexicalThis(node, visitorKeys);
 
+function isInsideJestMockFactory(node) {
+	let current = node;
+	while (current.parent) {
+		const {parent} = current;
+		if (
+			parent.type === 'CallExpression'
+			&& parent.arguments[1] === current
+			&& functionTypes.includes(current.type)
+			&& isNodeMatches(parent.callee, ['jest.mock'])
+		) {
+			return true;
+		}
+
+		current = parent;
+	}
+
+	return false;
+}
+
 const iifeFunctionTypes = new Set([
 	'FunctionExpression',
 	'ArrowFunctionExpression',
@@ -151,6 +170,7 @@ function checkNode(node, scopeManager, sourceCode) {
 	if (
 		!scope
 		|| isArrowFunctionNodeWithThis(node, sourceCode.visitorKeys)
+		|| isInsideJestMockFactory(node)
 	) {
 		return true;
 	}

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -417,6 +417,15 @@ test({
 			});
 		`,
 		outdent`
+			jest.mock("module", function() {
+				function createMock() {
+					return "mock";
+				}
+
+				return createMock;
+			});
+		`,
+		outdent`
 			jest.mock("module", () => ({
 				default: function MockComponent() {
 					const createMock = () => "mock";

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -405,6 +405,25 @@ test({
 				return (dispatch) => dispatch({ type });
 			}
 		`,
+		// #805 - Jest mock factories cannot reference out-of-scope variables.
+		'jest.mock("next/dynamic", () => () => "dynamic-drawer");',
+		outdent`
+			jest.mock("module", () => {
+				function createMock() {
+					return "mock";
+				}
+
+				return createMock;
+			});
+		`,
+		outdent`
+			jest.mock("module", () => ({
+				default: function MockComponent() {
+					const createMock = () => "mock";
+					return createMock();
+				},
+			}));
+		`,
 		// Should ignore functions inside arrow functions
 		{
 			code: outdent`
@@ -848,6 +867,19 @@ test({
 				}
 			`,
 			errors: [createError('arrow function')],
+		},
+		{
+			code: 'jest.doMock("module", () => () => "mock");',
+			errors: [createError('arrow function')],
+		},
+		{
+			code: outdent`
+				jest.doMock("module", () => {
+					function createMock() {}
+					return createMock;
+				});
+			`,
+			errors: [createError('function \'createMock\'')],
 		},
 		{
 			code: outdent`


### PR DESCRIPTION
Fixes #805