### PR TITLE
`prevent-abbreviations`: Avoid unsafe parameter autofixes

### DIFF
--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -17,7 +17,7 @@ You can find the default replacements [here](https://github.com/sindresorhus/esl
 
 This rule is automatically fixable only for variable names with exactly one replacement defined. Ambiguous variable names and checked property names can be manually fixed with editor suggestions when the rename is local to source text. Filename reports and exported-name property reports do not provide editor suggestions.
 
-Parameter names are not autofixed when the function has an attached JSDoc `@param` comment, as those name references are not normal variable references and would otherwise be left stale. TypeScript type predicate and assertion signature parameter references are updated when the parameter is renamed.
+Parameter names do not provide autofixes or editor suggestions when the function has an attached JSDoc `@param` comment, as those name references are not normal variable references and would otherwise be left stale. TypeScript type predicate and assertion signature parameter references are updated when the parameter is renamed.
 
 ## Examples
 

--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -17,6 +17,8 @@ You can find the default replacements [here](https://github.com/sindresorhus/esl
 
 This rule is automatically fixable only for variable names with exactly one replacement defined. Ambiguous variable names and checked property names can be manually fixed with editor suggestions when the rename is local to source text. Filename reports and exported-name property reports do not provide editor suggestions.
 
+Parameter names are not autofixed when the function has an attached JSDoc `@param` comment or a TypeScript type predicate/assertion return type, as those references are not normal variable references and would otherwise be left stale.
+
 ## Examples
 
 ```js

--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -17,7 +17,7 @@ You can find the default replacements [here](https://github.com/sindresorhus/esl
 
 This rule is automatically fixable only for variable names with exactly one replacement defined. Ambiguous variable names and checked property names can be manually fixed with editor suggestions when the rename is local to source text. Filename reports and exported-name property reports do not provide editor suggestions.
 
-Parameter names are not autofixed when the function has an attached JSDoc `@param` comment or a TypeScript type predicate/assertion return type, as those references are not normal variable references and would otherwise be left stale.
+Parameter names are not autofixed when the function has an attached JSDoc `@param` comment, as those name references are not normal variable references and would otherwise be left stale. TypeScript type predicate and assertion signature parameter references are updated when the parameter is renamed.
 
 ## Examples
 

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -260,6 +260,7 @@ const functionLikeTypesWithReturnType = new Set([
 	...functionTypes,
 	'TSCallSignatureDeclaration',
 	'TSConstructSignatureDeclaration',
+	'TSConstructorType',
 	'TSDeclareFunction',
 	'TSEmptyBodyFunctionExpression',
 	'TSFunctionType',

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -293,7 +293,7 @@ const findAttachedComment = (node, sourceCode) => {
 	return previousToken;
 };
 
-const hasAttachedJSDocParameterComment = (node, sourceCode) => {
+const hasAttachedJSDocumentParameterComment = (node, sourceCode) => {
 	const comment = findAttachedComment(node, sourceCode);
 
 	return Boolean(
@@ -326,7 +326,7 @@ const shouldFixParameter = (definition, context) => {
 		return true;
 	}
 
-	return !hasAttachedJSDocParameterComment(functionNode, context.sourceCode);
+	return !hasAttachedJSDocumentParameterComment(functionNode, context.sourceCode);
 };
 
 const shouldFix = variable => getVariableIdentifiers(variable)

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -13,7 +13,7 @@ import {
 } from './utils/index.js';
 import {defaultReplacements, defaultAllowList, defaultIgnore} from './shared/abbreviations.js';
 import {renameVariable} from './fix/index.js';
-import {isStaticRequire} from './ast/index.js';
+import {functionTypes, isStaticRequire} from './ast/index.js';
 
 const MESSAGE_ID_REPLACE = 'replace';
 const MESSAGE_ID_SUGGESTION = 'suggestion';
@@ -237,12 +237,108 @@ const isExportedIdentifier = identifier => {
 	return false;
 };
 
+const isParameterDefinition = definition => definition.type === 'Parameter';
+
+const isComment = token => token?.type === 'Block' || token?.type === 'Line';
+
+const commentAttachmentParentTypes = new Set([
+	'AssignmentExpression',
+	'ExportDefaultDeclaration',
+	'ExportNamedDeclaration',
+	'ExpressionStatement',
+	'MethodDefinition',
+	'Property',
+	'PropertyDefinition',
+	'VariableDeclaration',
+	'VariableDeclarator',
+]);
+
+const functionLikeTypesWithReturnType = new Set([
+	...functionTypes,
+	'TSCallSignatureDeclaration',
+	'TSConstructSignatureDeclaration',
+	'TSDeclareFunction',
+	'TSFunctionType',
+	'TSMethodSignature',
+]);
+
+const findAttachedComment = (node, sourceCode) => {
+	let previousToken = sourceCode.getTokenBefore(node, {includeComments: true});
+	let commentableNode = node;
+
+	while (
+		!isComment(previousToken)
+		&& commentAttachmentParentTypes.has(commentableNode.parent.type)
+	) {
+		commentableNode = commentableNode.parent;
+		previousToken = sourceCode.getTokenBefore(commentableNode, {includeComments: true});
+	}
+
+	if (!isComment(previousToken)) {
+		return;
+	}
+
+	const commentEnd = sourceCode.getLoc(previousToken).end;
+	const nodeStart = sourceCode.getLoc(commentableNode).start;
+
+	if (commentEnd.line < nodeStart.line - 1) {
+		return;
+	}
+
+	return previousToken;
+};
+
+const hasAttachedJSDocParameterComment = (node, sourceCode) => {
+	const comment = findAttachedComment(node, sourceCode);
+
+	return Boolean(
+		comment?.type === 'Block'
+		&& comment.value.trimStart().startsWith('*')
+		&& /@param\b/u.test(comment.value),
+	);
+};
+
+const getParentFunctionLikeNode = identifier => {
+	let {parent} = identifier;
+
+	while (parent) {
+		if (functionLikeTypesWithReturnType.has(parent.type)) {
+			return parent;
+		}
+
+		parent = parent.parent;
+	}
+};
+
+const hasTypePredicateReturnType = node =>
+	node.returnType?.typeAnnotation?.type === 'TSTypePredicate';
+
+const shouldFixParameter = (definition, context) => {
+	if (!isParameterDefinition(definition)) {
+		return true;
+	}
+
+	const functionNode = getParentFunctionLikeNode(definition.name);
+
+	if (!functionNode) {
+		return true;
+	}
+
+	return Boolean(
+		!hasAttachedJSDocParameterComment(functionNode, context.sourceCode)
+		&& !hasTypePredicateReturnType(functionNode),
+	);
+};
+
 const shouldFix = variable => getVariableIdentifiers(variable)
 	.every(identifier =>
 		!isExportedIdentifier(identifier)
 		// In typescript parser, only `JSXOpeningElement` is added to variable
 		// `<foo></foo>` -> `<bar></foo>` will cause parse error
 		&& identifier.type !== 'JSXIdentifier');
+
+const shouldAutofix = (variable, context) =>
+	shouldFix(variable) && shouldFixParameter(variable.defs[0], context);
 
 const isDefaultOrNamespaceImportName = identifier => {
 	if (
@@ -347,6 +443,30 @@ const isInternalImport = node => {
 	);
 };
 
+const shouldCheckDefaultOrNamespaceImportName = (definition, options) => {
+	if (!isDefaultOrNamespaceImportName(definition.name)) {
+		return true;
+	}
+
+	if (!options.checkDefaultAndNamespaceImports) {
+		return false;
+	}
+
+	return options.checkDefaultAndNamespaceImports !== 'internal' || isInternalImport(definition);
+};
+
+const shouldCheckShorthandImportName = (definition, options, context) => {
+	if (!isShorthandImportLocal(definition.name, context)) {
+		return true;
+	}
+
+	if (!options.checkShorthandImports) {
+		return false;
+	}
+
+	return options.checkShorthandImports !== 'internal' || isInternalImport(definition);
+};
+
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const options = prepareOptions(context.options[0]);
@@ -407,30 +527,12 @@ const create = context => {
 
 		const [definition] = variable.defs;
 
-		if (isDefaultOrNamespaceImportName(definition.name)) {
-			if (!options.checkDefaultAndNamespaceImports) {
-				return;
-			}
-
-			if (
-				options.checkDefaultAndNamespaceImports === 'internal'
-				&& !isInternalImport(definition)
-			) {
-				return;
-			}
+		if (!shouldCheckDefaultOrNamespaceImportName(definition, options)) {
+			return;
 		}
 
-		if (isShorthandImportLocal(definition.name, context)) {
-			if (!options.checkShorthandImports) {
-				return;
-			}
-
-			if (
-				options.checkShorthandImports === 'internal'
-				&& !isInternalImport(definition)
-			) {
-				return;
-			}
+		if (!shouldCheckShorthandImportName(definition, options, context)) {
+			return;
 		}
 
 		if (
@@ -459,7 +561,7 @@ const create = context => {
 
 		if (
 			variableReplacements.total === 1
-			&& shouldFix(variable)
+			&& shouldAutofix(variable, context)
 			&& variableReplacements.samples[0]
 			&& !variable.references.some(reference => reference.vueUsedInTemplate)
 		) {

--- a/rules/prevent-abbreviations.js
+++ b/rules/prevent-abbreviations.js
@@ -237,8 +237,6 @@ const isExportedIdentifier = identifier => {
 	return false;
 };
 
-const isParameterDefinition = definition => definition.type === 'Parameter';
-
 const isComment = token => token?.type === 'Block' || token?.type === 'Line';
 
 const commentAttachmentParentTypes = new Set([
@@ -249,6 +247,11 @@ const commentAttachmentParentTypes = new Set([
 	'MethodDefinition',
 	'Property',
 	'PropertyDefinition',
+	'TSAbstractMethodDefinition',
+	'TSAbstractPropertyDefinition',
+	'TSPropertySignature',
+	'TSTypeAliasDeclaration',
+	'TSTypeAnnotation',
 	'VariableDeclaration',
 	'VariableDeclarator',
 ]);
@@ -258,6 +261,7 @@ const functionLikeTypesWithReturnType = new Set([
 	'TSCallSignatureDeclaration',
 	'TSConstructSignatureDeclaration',
 	'TSDeclareFunction',
+	'TSEmptyBodyFunctionExpression',
 	'TSFunctionType',
 	'TSMethodSignature',
 ]);
@@ -310,11 +314,8 @@ const getParentFunctionLikeNode = identifier => {
 	}
 };
 
-const hasTypePredicateReturnType = node =>
-	node.returnType?.typeAnnotation?.type === 'TSTypePredicate';
-
 const shouldFixParameter = (definition, context) => {
-	if (!isParameterDefinition(definition)) {
+	if (definition.type !== 'Parameter') {
 		return true;
 	}
 
@@ -324,10 +325,7 @@ const shouldFixParameter = (definition, context) => {
 		return true;
 	}
 
-	return Boolean(
-		!hasAttachedJSDocParameterComment(functionNode, context.sourceCode)
-		&& !hasTypePredicateReturnType(functionNode),
-	);
+	return !hasAttachedJSDocParameterComment(functionNode, context.sourceCode);
 };
 
 const shouldFix = variable => getVariableIdentifiers(variable)
@@ -582,6 +580,7 @@ const create = context => {
 		if (
 			!problem.fix
 			&& shouldFix(variable)
+			&& shouldFixParameter(variable.defs[0], context)
 			&& !variable.references.some(reference => reference.vueUsedInTemplate)
 		) {
 			const suggestions = getSuggestions(

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -679,6 +679,136 @@ const tests = {
 			output: 'error => error',
 			errors: 1,
 		},
+		{
+			code: 'ctx => ctx.body',
+			output: 'context => context.body',
+			errors: 1,
+		},
+		{
+			code: outdent`
+				function middleware(ctx) {
+					return ctx.body;
+				}
+			`,
+			output: outdent`
+				function middleware(context) {
+					return context.body;
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				/**
+				 * @param {object} ctx Koa context.
+				 */
+				function middleware(ctx) {
+					return ctx.body;
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				/**
+				 * @param {unknown} e Value.
+				 */
+				function handle(e) {
+					return e;
+				}
+			`,
+			errors: [
+				{
+					message: 'Please rename the variable `e`. Suggested names are: `error`, `event_`. A more descriptive name will do too.',
+					suggestions: createRenameSuggestions([
+						['error', outdent`
+							/**
+							 * @param {unknown} e Value.
+							 */
+							function handle(error) {
+								return error;
+							}
+						`],
+						['event_', outdent`
+							/**
+							 * @param {unknown} e Value.
+							 */
+							function handle(event_) {
+								return event_;
+							}
+						`],
+					]),
+				},
+			],
+		},
+		{
+			code: outdent`
+				/**
+				 * @param {object} ctx Koa context.
+				 */
+				const middleware = ctx => ctx.body;
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				/**
+				 * @param {object} ctx Koa context.
+				 */
+				export function middleware(ctx) {
+					return ctx.body;
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				/**
+				 * @param {object} ctx Koa context.
+				 */
+				export default function middleware(ctx) {
+					return ctx.body;
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				const middleware = {
+					/**
+					 * @param {object} ctx Koa context.
+					 */
+					handle(ctx) {
+						return ctx.body;
+					},
+				};
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				class Middleware {
+					/**
+					 * @param {object} ctx Koa context.
+					 */
+					handle(ctx) {
+						return ctx.body;
+					}
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				/**
+				 * @param {object} ctx Koa context.
+				 */
+				module.exports = function middleware(ctx) {
+					return ctx.body;
+				};
+			`,
+			errors: 1,
+		},
 
 		{
 			code: outdent`
@@ -1764,6 +1894,46 @@ test.typescript({
 		{
 			code: 'const foo = (extr\u0061Params     ?    :    string) => {}',
 			output: 'const foo = (extraParameters?:    string) => {}',
+			errors: 1,
+		},
+		{
+			code: 'const isString = (val: unknown) => typeof val === "string"',
+			output: 'const isString = (value: unknown) => typeof value === "string"',
+			errors: 1,
+		},
+		{
+			code: 'type Callback = (val: unknown) => string',
+			output: 'type Callback = (value: unknown) => string',
+			errors: 1,
+		},
+		{
+			code: 'const isString = (val: unknown): val is string => typeof val === "string"',
+			errors: 1,
+		},
+		{
+			code: 'type Predicate = (val: unknown) => val is string',
+			errors: 1,
+		},
+		{
+			code: 'interface Predicate { (val: unknown): val is string; }',
+			errors: 1,
+		},
+		{
+			code: outdent`
+				function assertString(val: unknown): asserts val is string {
+					if (typeof val !== "string") {
+						throw new TypeError();
+					}
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: 'type AssertString = (val: unknown) => asserts val is string',
+			errors: 1,
+		},
+		{
+			code: 'interface AssertString { (val: unknown): asserts val is string; }',
 			errors: 1,
 		},
 

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -1901,6 +1901,11 @@ test.typescript({
 			errors: 1,
 		},
 		{
+			code: 'type Constructor = new (ctx: object) => object',
+			output: 'type Constructor = new (context: object) => object',
+			errors: 1,
+		},
+		{
 			code: 'interface Middleware { handle: (ctx: object) => void; }',
 			output: 'interface Middleware { handle: (context: object) => void; }',
 			errors: 1,
@@ -2040,11 +2045,41 @@ test.typescript({
 		{
 			code: outdent`
 				/**
+				 * @param e Value.
+				 */
+				function isError(e: unknown): e is Error {
+					return e instanceof Error;
+				}
+			`,
+			errors: [
+				{
+					message: 'Please rename the variable `e`. Suggested names are: `error`, `event_`. A more descriptive name will do too.',
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: outdent`
+				/**
 				 * @param ctx Koa context.
 				 */
 				type Middleware = (ctx: object) => void;
 			`,
 			errors: 1,
+		},
+		{
+			code: outdent`
+				/**
+				 * @param e Value.
+				 */
+				type Constructor = new (e: unknown) => object;
+			`,
+			errors: [
+				{
+					message: 'Please rename the variable `e`. Suggested names are: `error`, `event_`. A more descriptive name will do too.',
+					suggestions: [],
+				},
+			],
 		},
 		{
 			code: outdent`

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -720,24 +720,7 @@ const tests = {
 			errors: [
 				{
 					message: 'Please rename the variable `e`. Suggested names are: `error`, `event_`. A more descriptive name will do too.',
-					suggestions: createRenameSuggestions([
-						['error', outdent`
-							/**
-							 * @param {unknown} e Value.
-							 */
-							function handle(error) {
-								return error;
-							}
-						`],
-						['event_', outdent`
-							/**
-							 * @param {unknown} e Value.
-							 */
-							function handle(event_) {
-								return event_;
-							}
-						`],
-					]),
+					suggestions: [],
 				},
 			],
 		},
@@ -794,6 +777,17 @@ const tests = {
 					handle(ctx) {
 						return ctx.body;
 					}
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				class Middleware {
+					/**
+					 * @param {object} ctx Koa context.
+					 */
+					handle = ctx => ctx.body;
 				}
 			`,
 			errors: 1,
@@ -1907,15 +1901,58 @@ test.typescript({
 			errors: 1,
 		},
 		{
+			code: 'interface Middleware { handle: (ctx: object) => void; }',
+			output: 'interface Middleware { handle: (context: object) => void; }',
+			errors: 1,
+		},
+		{
+			code: 'declare function middleware(ctx: object): void;',
+			output: 'declare function middleware(context: object): void;',
+			errors: 1,
+		},
+		{
+			code: 'abstract class Middleware { abstract handle(ctx: object): void; }',
+			output: 'abstract class Middleware { abstract handle(context: object): void; }',
+			errors: 1,
+		},
+		{
+			code: 'class Middleware { handle = ctx => ctx.body; }',
+			output: 'class Middleware { handle = context => context.body; }',
+			errors: 1,
+		},
+		{
+			code: 'abstract class Middleware { abstract handle: (ctx: object) => void; }',
+			output: 'abstract class Middleware { abstract handle: (context: object) => void; }',
+			errors: 1,
+		},
+		{
 			code: 'const isString = (val: unknown): val is string => typeof val === "string"',
+			output: 'const isString = (value: unknown): value is string => typeof value === "string"',
 			errors: 1,
 		},
 		{
 			code: 'type Predicate = (val: unknown) => val is string',
+			output: 'type Predicate = (value: unknown) => value is string',
 			errors: 1,
 		},
 		{
 			code: 'interface Predicate { (val: unknown): val is string; }',
+			output: 'interface Predicate { (value: unknown): value is string; }',
+			errors: 1,
+		},
+		{
+			code: 'interface Predicate { isString(val: unknown): val is string; }',
+			output: 'interface Predicate { isString(value: unknown): value is string; }',
+			errors: 1,
+		},
+		{
+			code: 'declare function isString(val: unknown): val is string;',
+			output: 'declare function isString(value: unknown): value is string;',
+			errors: 1,
+		},
+		{
+			code: 'abstract class Predicate { abstract isString(val: unknown): val is string; }',
+			output: 'abstract class Predicate { abstract isString(value: unknown): value is string; }',
 			errors: 1,
 		},
 		{
@@ -1926,14 +1963,151 @@ test.typescript({
 					}
 				}
 			`,
+			output: outdent`
+				function assertString(value: unknown): asserts value is string {
+					if (typeof value !== "string") {
+						throw new TypeError();
+					}
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				function assertValue(val: unknown): asserts val {
+					if (!val) {
+						throw new TypeError();
+					}
+				}
+			`,
+			output: outdent`
+				function assertValue(value: unknown): asserts value {
+					if (!value) {
+						throw new TypeError();
+					}
+				}
+			`,
 			errors: 1,
 		},
 		{
 			code: 'type AssertString = (val: unknown) => asserts val is string',
+			output: 'type AssertString = (value: unknown) => asserts value is string',
 			errors: 1,
 		},
 		{
 			code: 'interface AssertString { (val: unknown): asserts val is string; }',
+			output: 'interface AssertString { (value: unknown): asserts value is string; }',
+			errors: 1,
+		},
+		{
+			code: 'interface AssertString { assertString(val: unknown): asserts val is string; }',
+			output: 'interface AssertString { assertString(value: unknown): asserts value is string; }',
+			errors: 1,
+		},
+		{
+			code: 'declare function assertString(val: unknown): asserts val is string;',
+			output: 'declare function assertString(value: unknown): asserts value is string;',
+			errors: 1,
+		},
+		{
+			code: 'abstract class AssertString { abstract assertString(val: unknown): asserts val is string; }',
+			output: 'abstract class AssertString { abstract assertString(value: unknown): asserts value is string; }',
+			errors: 1,
+		},
+		{
+			code: 'const isError = (e: unknown): e is Error => e instanceof Error',
+			errors: [
+				{
+					message: 'Please rename the variable `e`. Suggested names are: `error`, `event_`. A more descriptive name will do too.',
+					suggestions: createRenameSuggestions([
+						['error', 'const isError = (error: unknown): error is Error => error instanceof Error'],
+						['event_', 'const isError = (event_: unknown): event_ is Error => event_ instanceof Error'],
+					]),
+				},
+			],
+		},
+		{
+			code: outdent`
+				/**
+				 * @param val Value.
+				 */
+				function isString(val: unknown): val is string {
+					return typeof val === "string";
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				/**
+				 * @param ctx Koa context.
+				 */
+				type Middleware = (ctx: object) => void;
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				/**
+				 * @param ctx Koa context.
+				 */
+				declare function middleware(ctx: object): void;
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				interface Middleware {
+					/**
+					 * @param ctx Koa context.
+					 */
+					handle: (ctx: object) => void;
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				interface Middleware {
+					/**
+					 * @param ctx Koa context.
+					 */
+					handle(ctx: object): void;
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				type Middleware = {
+					/**
+					 * @param ctx Koa context.
+					 */
+					handle: (ctx: object) => void;
+				};
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				abstract class Middleware {
+					/**
+					 * @param ctx Koa context.
+					 */
+					abstract handle(ctx: object): void;
+				}
+			`,
+			errors: 1,
+		},
+		{
+			code: outdent`
+				abstract class Middleware {
+					/**
+					 * @param ctx Koa context.
+					 */
+					abstract handle: (ctx: object) => void;
+				}
+			`,
 			errors: 1,
 		},
 


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/733
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/765