### PR TITLE
`prefer-type-error`: Don't flag `typeof x === 'undefined'` existence checks

### DIFF
--- a/docs/rules/prefer-type-error.md
+++ b/docs/rules/prefer-type-error.md
@@ -15,6 +15,8 @@ It's aware of the most commonly used type checking operators and identifiers lik
 
 The rule investigates every throw-statement which throws a generic `Error`. It will fail if the throw-statement is the only expression in the surrounding block and is preceded by an if-statement whose condition consists of type-checks exclusively. You have to replace the `Error` with a `TypeError`.
 
+Comparing `typeof x` against `'undefined'` is treated as an existence or environment check (for example, `typeof window !== 'undefined'`) rather than a type check, so it's not reported.
+
 ## Examples
 
 ```js

--- a/rules/prefer-type-error.js
+++ b/rules/prefer-type-error.js
@@ -1,4 +1,4 @@
-import {isNewExpression} from './ast/index.js';
+import {isLiteral, isNewExpression} from './ast/index.js';
 
 const MESSAGE_ID = 'prefer-type-error';
 const messages = {
@@ -86,6 +86,19 @@ const isErrorConstructor = node => {
 	return false;
 };
 
+const isTypeofExpression = node => node.type === 'UnaryExpression' && node.operator === 'typeof';
+const isUndefinedString = node => isLiteral(node, 'undefined');
+
+// Comparing `typeof x` against `'undefined'` is an existence/environment check (e.g. `typeof window !== 'undefined'`), not a value type check.
+const isExistenceCheck = node => {
+	const {operator, left, right} = node;
+	if (operator !== '==' && operator !== '!=' && operator !== '===' && operator !== '!==') {
+		return false;
+	}
+
+	return (isTypeofExpression(left) && isUndefinedString(right)) || (isTypeofExpression(right) && isUndefinedString(left));
+};
+
 const isTypecheckingExpression = (node, callExpression) => {
 	switch (node.type) {
 		case 'Identifier': {
@@ -112,6 +125,10 @@ const isTypecheckingExpression = (node, callExpression) => {
 
 			if (operator === 'instanceof') {
 				return !isErrorConstructor(right);
+			}
+
+			if (isExistenceCheck(node)) {
+				return false;
 			}
 
 			return isTypecheckingExpression(left, callExpression)

--- a/test/prefer-type-error.js
+++ b/test/prefer-type-error.js
@@ -281,6 +281,33 @@ test({
 		'if (foo instanceof CustomError) throw new Error("message")',
 		'if (foo instanceof lib.Error) throw new Error("message")',
 		'if (foo instanceof lib.CustomError) throw new Error("message")',
+		// `typeof x` compared against `'undefined'` is an existence/environment check, not a type check
+		outdent`
+			if (typeof window !== 'undefined') {
+				throw new Error('This package requires a browser environment.');
+			}
+		`,
+		outdent`
+			if (typeof process === 'undefined') {
+				throw new Error('This package requires Node.js.');
+			}
+		`,
+		outdent`
+			if ('undefined' === typeof self) {
+				throw new Error('No global available.');
+			}
+		`,
+		outdent`
+			if (typeof window !== 'undefined' && typeof foo !== 'string') {
+				throw new Error('Mixed environment and type check.');
+			}
+		`,
+		// Loose equality against `'undefined'` is also an existence check
+		outdent`
+			if (typeof window != 'undefined') {
+				throw new Error('This package requires a browser environment.');
+			}
+		`,
 	],
 	invalid: [
 		{
@@ -382,6 +409,20 @@ test({
 			`,
 			output: outdent`
 				if (typeof foo == 'Foo' || 'Foo' === typeof foo) {
+					throw new TypeError();
+				}
+			`,
+			errors,
+		},
+		{
+			// `typeof` against a real type string (not `'undefined'`) is still a type check
+			code: outdent`
+				if (typeof foo === 'string') {
+					throw new Error();
+				}
+			`,
+			output: outdent`
+				if (typeof foo === 'string') {
 					throw new TypeError();
 				}
 			`,


### PR DESCRIPTION
Fixes #2719