### PR TITLE
`prevent-abbreviations`: Ignore `e2e` and `a11y`

### DIFF
--- a/docs/rules/prevent-abbreviations.md
+++ b/docs/rules/prevent-abbreviations.md
@@ -255,11 +255,11 @@ When a string is given, it's interpreted as a regular expression inside a string
 	'error',
 	{
 		ignore: [
-			'\\.e2e$',
+			'\\.fixtures$',
 			/^ignore/i,
 		],
 	},
 ]
 ```
 
-When checking filenames, only the basename is tested. For example, with a file named `foo.e2e.js`, `ignore: [/\.e2e$/]` would pass and `ignore: [/\.e2e\.js/]` would fail.
+When checking filenames, only the basename is tested. For example, with a file named `foo.fixtures.js`, `ignore: [/\.fixtures$/]` would pass and `ignore: [/\.fixtures\.js/]` would fail.

--- a/rules/shared/abbreviations.js
+++ b/rules/shared/abbreviations.js
@@ -267,5 +267,7 @@ export const defaultIgnore = [
 	// https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1188
 	'i18n',
 	'l10n',
+	'a11y', // Accessibility
+	'e2e', // End-to-end
 	'jQuery',
 ];

--- a/test/prevent-abbreviations.js
+++ b/test/prevent-abbreviations.js
@@ -135,6 +135,9 @@ const tests = {
 		'const i18n = new I18n({ locales: ["en", "fr"] })',
 		'const i18nData = {}',
 		'const l10n = new L10n()',
+		'const e2e = 1',
+		'const e2eTests = []',
+		'const a11y = {}',
 		'const iOS = true',
 		'const jQueryEvent = true',
 		outdent`
@@ -2343,6 +2346,10 @@ test({
 			code: 'foo();',
 			filename: 'Мiръ.html',
 		},
+		{
+			code: 'foo();',
+			filename: 'e2e.js',
+		},
 		// `ignore` option
 		{
 			code: outdent`
@@ -2424,7 +2431,6 @@ test({
 			`,
 			filename: 'some.spec.e2e.test.js',
 			errors: [
-				...createErrors('Please rename the filename `some.spec.e2e.test.js`. Suggested names are: `some.spec.error2error.test.js`, `some.spec.error2event.test.js`, `some.spec.event2error.test.js`, ... (1 more omitted). A more descriptive name will do too.'),
 				{
 					message: 'Please rename the variable `e_at_start`. Suggested names are: `error_at_start`, `event_at_start`. A more descriptive name will do too.',
 					suggestions: 2,


### PR DESCRIPTION
Fixes #2606