### PR TITLE
`no-invalid-file-input-accept`: Normalize legacy MIME types

### DIFF
--- a/rules/no-invalid-file-input-accept.js
+++ b/rules/no-invalid-file-input-accept.js
@@ -20,8 +20,11 @@ const validWildcardMimeTypes = new Set([
 ]);
 
 const commonMimeTypeMistakes = new Map([
+	['application/x-rar-compressed', 'application/vnd.rar'],
+	['application/x-zip-compressed', 'application/zip'],
 	['image/jpg', 'image/jpeg'],
 	['image/svg', 'image/svg+xml'],
+	['image/x-icon', 'image/vnd.microsoft.icon'],
 ]);
 
 const htmlCharacterReferencePattern = /&(?:#\d+|#x[\da-f]+|[a-z][\da-z]*);/iv;

--- a/test/no-invalid-file-input-accept.js
+++ b/test/no-invalid-file-input-accept.js
@@ -232,6 +232,11 @@ html({
 			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
 		},
 		{
+			code: '<input type="file" accept="image/x-icon, image/vnd.microsoft.icon, application/x-zip-compressed">',
+			output: '<input type="file" accept="image/vnd.microsoft.icon, application/zip">',
+			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
+		},
+		{
 			code: '<input type="file" accept="image/jpg; charset=utf-8">',
 			output: '<input type="file" accept="image/jpeg">',
 			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],

--- a/test/no-invalid-file-input-accept.js
+++ b/test/no-invalid-file-input-accept.js
@@ -181,6 +181,26 @@ jsx({
 	valid: [],
 	invalid: [
 		{
+			code: '<input type="file" accept="image/x-icon" />',
+			output: '<input type="file" accept="image/vnd.microsoft.icon" />',
+			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
+		},
+		{
+			code: '<input type="file" accept="application/x-rar-compressed" />',
+			output: '<input type="file" accept="application/vnd.rar" />',
+			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
+		},
+		{
+			code: '<input type="file" accept="application/x-zip-compressed" />',
+			output: '<input type="file" accept="application/zip" />',
+			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
+		},
+		{
+			code: '<input type="file" accept="image/x-icon, image/vnd.microsoft.icon, application/x-zip-compressed" />',
+			output: '<input type="file" accept="image/vnd.microsoft.icon, application/zip" />',
+			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
+		},
+		{
 			code: '<input type="file" accept="image/jpg; charset=utf-8" />',
 			output: '<input type="file" accept="image/jpeg" />',
 			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
@@ -196,6 +216,21 @@ jsx({
 html({
 	valid: [],
 	invalid: [
+		{
+			code: '<input type="file" accept="image/x-icon">',
+			output: '<input type="file" accept="image/vnd.microsoft.icon">',
+			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
+		},
+		{
+			code: '<input type="file" accept="application/x-rar-compressed">',
+			output: '<input type="file" accept="application/vnd.rar">',
+			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
+		},
+		{
+			code: '<input type="file" accept="application/x-zip-compressed">',
+			output: '<input type="file" accept="application/zip">',
+			errors: [{messageId: 'no-invalid-file-input-accept/normalize'}],
+		},
 		{
 			code: '<input type="file" accept="image/jpg; charset=utf-8">',
 			output: '<input type="file" accept="image/jpeg">',


### PR DESCRIPTION
Fixes #2914