### PR TITLE
`consistent-function-scoping`: Track JSX references

### DIFF
--- a/docs/rules/consistent-function-scoping.md
+++ b/docs/rules/consistent-function-scoping.md
@@ -129,18 +129,6 @@ function doFoo(foo) {
 }
 ```
 
-It also ignores functions that contain `JSXElement` references:
-
-```jsx
-function doFoo(FooComponent) {
-	function Bar() {
-		return <FooComponent/>;
-	}
-
-	return Bar;
-};
-```
-
 [Immediately invoked function expressions (IIFE)](https://en.wikipedia.org/wiki/Immediately_invoked_function_expression) are ignored:
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Most rules target JavaScript and TypeScript, but [some also lint CSS, HTML, JSON
 npm install --save-dev eslint eslint-plugin-unicorn
 ```
 
-**Requires ESLint `>=9.20.0`, [flat config](https://eslint.org/docs/latest/use/configure/configuration-files), and [ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#how-can-i-make-my-typescript-project-output-esm).**
+**Requires ESLint `>=10.4`, [flat config](https://eslint.org/docs/latest/use/configure/configuration-files), and [ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#how-can-i-make-my-typescript-project-output-esm).**
 
 ## Usage
 

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -219,26 +219,7 @@ const create = context => {
 	const {sourceCode} = context;
 	const {scopeManager} = sourceCode;
 
-	const functions = [];
-
-	context.on(functionTypes, () => {
-		functions.push(false);
-	});
-
-	context.on('JSXElement', () => {
-		// Turn off this rule if we see a JSX element because scope
-		// references does not include JSXElement nodes.
-		if (functions.length > 0) {
-			functions[functions.length - 1] = true;
-		}
-	});
-
 	context.onExit(functionTypes, node => {
-		const currentFunctionHasJsx = functions.pop();
-		if (currentFunctionHasJsx) {
-			return;
-		}
-
 		if (node.type === 'ArrowFunctionExpression' && !checkArrowFunctions) {
 			return;
 		}

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -213,6 +213,14 @@ test({
 				}
 			}
 		`,
+		outdent`
+			function doFoo(Components) {
+				function Bar() {
+					return <Components.Foo />;
+				}
+				return Bar;
+			}
+		`,
 		// `this`
 		outdent`
 			function doFoo(Foo) {
@@ -825,6 +833,17 @@ test({
 			`,
 			errors: [createError('function \'bar\'')],
 		},
+		// Lowercase JSX tags are intrinsic elements, not references.
+		{
+			code: outdent`
+				function foo(foo) {
+					function bar() {
+						return <foo />;
+					}
+				}
+			`,
+			errors: [createError('function \'bar\'')],
+		},
 		{
 			code: outdent`
 				function Foo() {
@@ -967,6 +986,32 @@ test({
 			errors: [createError('arrow function')],
 		},
 	],
+});
+
+test.typescript({
+	testerOptions: {
+		languageOptions: {
+			parserOptions: {
+				ecmaFeatures: {
+					jsx: true,
+				},
+			},
+		},
+	},
+	valid: [
+		{
+			code: outdent`
+				function doFoo(FooComponent) {
+					function Bar() {
+						return <FooComponent />;
+					}
+					return Bar;
+				}
+			`,
+			filename: 'index.tsx',
+		},
+	],
+	invalid: [],
 });
 
 test.typescript({

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -206,26 +206,10 @@ test({
 		outdent`
 			const foo = <JSX/>;
 		`,
-		// Functions that could be extracted are conservatively ignored due to JSX masking references
-		outdent`
-			function Foo() {
-				function Bar () {
-					return <div />
-				}
-				return <div>{ Bar() }</div>
-			}
-		`,
 		outdent`
 			function foo() {
 				function bar() {
 					return <JSX a={foo()}/>;
-				}
-			}
-		`,
-		outdent`
-			function foo() {
-				function bar() {
-					return <JSX/>;
 				}
 			}
 		`,
@@ -826,13 +810,37 @@ test({
 					function Bar () {
 						return <div />
 					}
+					return <div>{ Bar() }</div>
+				}
+			`,
+			errors: [createError('function \'Bar\'')],
+		},
+		{
+			code: outdent`
+				function foo() {
+					function bar() {
+						return <JSX/>;
+					}
+				}
+			`,
+			errors: [createError('function \'bar\'')],
+		},
+		{
+			code: outdent`
+				function Foo() {
+					function Bar () {
+						return <div />
+					}
 					function doBaz() {
 						return 42
 					}
 					return <div>{ doBaz() }</div>
 				}
 			`,
-			errors: [createError('function \'doBaz\'')],
+			errors: [
+				createError('function \'Bar\''),
+				createError('function \'doBaz\''),
+			],
 		},
 		// JSX
 		{


### PR DESCRIPTION
Fixes #2598