### PR TITLE
`consistent-destructuring`: Ignore properties without corresponding destructured variable

### DIFF
--- a/docs/rules/consistent-destructuring.md
+++ b/docs/rules/consistent-destructuring.md
@@ -13,6 +13,8 @@ Enforces the use of already destructured variables over accessing the same direc
 
 This rule is partly fixable. It does not suggest adding new properties to existing destructuring patterns, as that could read properties earlier than before.
 
+There is no option to ignore specific sources or properties. Properties without a corresponding destructured variable are ignored by design.
+
 ## Examples
 
 ```js

--- a/test/consistent-destructuring.js
+++ b/test/consistent-destructuring.js
@@ -46,6 +46,24 @@ test({
 			console.log(a, foo.b);
 		`,
 		outdent`
+			const {chrome, ie, safari} = module;
+			if (!module.edge && ie) {
+				module.edge = '12';
+			}
+			console.log(chrome, safari, module.edge);
+		`,
+		outdent`
+			const {getPrototypeOf} = Object;
+			if (getPrototypeOf(object) === Object.prototype) {
+				console.log(object);
+			}
+		`,
+		outdent`
+			const {request: {cache, mode, url}} = event;
+			doSomething(cache, mode, url);
+			doAnother(event.request);
+		`,
+		outdent`
 			const {a} = this;
 			if (a) {
 				console.log(this.expensive);


### PR DESCRIPTION
Fixes #1005