### PR TITLE
`better-dom-traversing`: Ignore `props.children`

### DIFF
--- a/docs/rules/better-dom-traversing.md
+++ b/docs/rules/better-dom-traversing.md
@@ -15,6 +15,8 @@ Use named first-child properties instead of positional access, selectors instead
 
 This rule is syntax-based and reports common DOM traversal patterns. Suggestions are intentionally manual because the replacement can change behavior in some cases, such as `undefined` versus `null` for empty child collections, exact-depth parent traversal versus selector-based ancestor lookup, or chained `querySelector()` calls that only search inside the first matching element.
 
+`props.children` access is ignored because it is component data, not DOM traversal.
+
 ## Examples
 
 ```js

--- a/rules/better-dom-traversing.js
+++ b/rules/better-dom-traversing.js
@@ -38,6 +38,20 @@ const isDomCollectionMemberExpression = (node, property) =>
 		computed: false,
 	});
 
+const isPropsChildrenMemberExpression = node =>
+	isDomCollectionMemberExpression(node, 'children')
+	&& (
+		(
+			node.object.type === 'Identifier'
+			&& node.object.name === 'props'
+		)
+		|| isMemberExpression(node.object, {
+			property: 'props',
+			optional: false,
+			computed: false,
+		})
+	);
+
 const isNumericIndexMemberExpression = node =>
 	isNonOptionalMemberExpression(node)
 	&& node.computed
@@ -223,6 +237,10 @@ const create = context => {
 		if (
 			!collectionName
 			|| isNodeValueNotDomNode(node.object.object)
+			|| (
+				collectionName === 'children'
+				&& isPropsChildrenMemberExpression(node.object)
+			)
 			|| isNestedIndexedDomCollection(node)
 		) {
 			return;

--- a/rules/better-dom-traversing.js
+++ b/rules/better-dom-traversing.js
@@ -38,7 +38,7 @@ const isDomCollectionMemberExpression = (node, property) =>
 		computed: false,
 	});
 
-const isPropsChildrenMemberExpression = node =>
+const isPropertiesChildrenMemberExpression = node =>
 	isDomCollectionMemberExpression(node, 'children')
 	&& (
 		(
@@ -239,7 +239,7 @@ const create = context => {
 			|| isNodeValueNotDomNode(node.object.object)
 			|| (
 				collectionName === 'children'
-				&& isPropsChildrenMemberExpression(node.object)
+				&& isPropertiesChildrenMemberExpression(node.object)
 			)
 			|| isNestedIndexedDomCollection(node)
 		) {

--- a/test/better-dom-traversing.js
+++ b/test/better-dom-traversing.js
@@ -4,6 +4,14 @@ import notDomNodeTypes from './utils/not-dom-node-types.js';
 
 const {test} = getTester(import.meta);
 
+const jsxLanguageOptions = {
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+};
+
 test.snapshot({
 	valid: [
 		// Already preferred APIs
@@ -66,6 +74,20 @@ test.snapshot({
 		...notDomNodeTypes.map(data => `(${data}).childNodes[0];`),
 		...notDomNodeTypes.map(data => `(${data}).parentElement.parentElement;`),
 		...notDomNodeTypes.map(data => `(${data}).querySelector("a").querySelector("b");`),
+
+		// React props children are not DOM traversal
+		{
+			code: 'class Component { render() { return <div>{this.props.children[0]}</div>; } }',
+			languageOptions: jsxLanguageOptions,
+		},
+		{
+			code: 'const Component = props => <div>{props.children[0]}</div>;',
+			languageOptions: jsxLanguageOptions,
+		},
+		{
+			code: 'const child = component.props.children[0];',
+			languageOptions: jsxLanguageOptions,
+		},
 	],
 	invalid: [
 		'element.childNodes[0];',

--- a/test/better-dom-traversing.js
+++ b/test/better-dom-traversing.js
@@ -75,7 +75,7 @@ test.snapshot({
 		...notDomNodeTypes.map(data => `(${data}).parentElement.parentElement;`),
 		...notDomNodeTypes.map(data => `(${data}).querySelector("a").querySelector("b");`),
 
-		// React props children are not DOM traversal
+		// Component `props.children` is not DOM traversal
 		{
 			code: 'class Component { render() { return <div>{this.props.children[0]}</div>; } }',
 			languageOptions: jsxLanguageOptions,
@@ -85,8 +85,10 @@ test.snapshot({
 			languageOptions: jsxLanguageOptions,
 		},
 		{
+			code: 'const child = props.children[1];',
+		},
+		{
 			code: 'const child = component.props.children[0];',
-			languageOptions: jsxLanguageOptions,
 		},
 	],
 	invalid: [


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3126