### PR TITLE
`prefer-type-literal-last`: Keep `null` and `undefined` last

### DIFF
--- a/docs/rules/prefer-type-literal-last.md
+++ b/docs/rules/prefer-type-literal-last.md
@@ -11,9 +11,11 @@
 
 This rule enforces putting inline object type literals after other members in TypeScript union and intersection types.
 
-Keeping named or otherwise compact types first makes the important top-level type names easier to scan when an inline type literal spans multiple lines.
+An inline object type literal often spans multiple lines, and when it sits first or in the middle of a union it splits the remaining members across the literal's body, so you have to read past the whole object to see what else the union contains. Keeping the compact, named members together up front lets you scan them at a glance, with the multi-line literal trailing at the end where it does not interrupt the list. A single consistent order also avoids re-deciding the layout for every union.
 
 The rule only moves top-level type literals. It does not sort every type member, and it does not inspect nested type arguments.
+
+`null` and `undefined` are kept at the very end, after the type literals, since a nullish "escape hatch" is conventionally placed last.
 
 Intersection types are reported but not autofixed because changing their order can affect TypeScript overload resolution.
 
@@ -48,4 +50,11 @@ type ElementIntersection = Other & {
 type ElementUnion = Other | {
 	foo: string;
 };
+```
+
+```ts
+// ✅
+type ElementUnion = Other | {
+	foo: string;
+} | undefined;
 ```

--- a/rules/prefer-type-literal-last.js
+++ b/rules/prefer-type-literal-last.js
@@ -6,12 +6,20 @@ const messages = {
 };
 
 const isTypeLiteral = node => node.type === 'TSTypeLiteral';
+
+// `null`/`undefined` are conventionally kept at the very end as a nullish escape hatch, so they don't count as "another type".
+const isNullishType = node => node.type === 'TSUndefinedKeyword' || node.type === 'TSNullKeyword';
+
 const getFirstTypeLiteralBeforeOtherType = types => {
 	let typeLiteral;
 
 	for (const type of types) {
 		if (isTypeLiteral(type)) {
 			typeLiteral ??= type;
+			continue;
+		}
+
+		if (isNullishType(type)) {
 			continue;
 		}
 
@@ -96,8 +104,9 @@ const create = context => {
 				}
 
 				const typeLiterals = node.types.filter(type => isTypeLiteral(type));
-				const otherTypes = node.types.filter(type => !isTypeLiteral(type));
-				const replacement = [...otherTypes, ...typeLiterals]
+				const nullishTypes = node.types.filter(type => isNullishType(type));
+				const otherTypes = node.types.filter(type => !isTypeLiteral(type) && !isNullishType(type));
+				const replacement = [...otherTypes, ...typeLiterals, ...nullishTypes]
 					.map(type => getParenthesizedText(type, context))
 					.join(' | ');
 

--- a/test/prefer-type-literal-last.js
+++ b/test/prefer-type-literal-last.js
@@ -16,6 +16,19 @@ test.typescript({
 				foo: string;
 			};
 		`,
+		// `null`/`undefined` are kept at the end as a nullish escape hatch.
+		'type ElementUnion = {foo: string} | undefined;',
+		'type ElementUnion = {foo: string} | null;',
+		'type ElementUnion = string | {foo: string} | undefined;',
+		'type ElementUnion = {foo: string} | null | undefined;',
+		'type ElementUnion = {foo: string} | {bar: string} | undefined;',
+		// The rule does not force nullish last, so a leading nullish is left alone when the literal is already last.
+		'type ElementUnion = undefined | {foo: string};',
+		outdent`
+			type ElementUnion = {
+				foo: string;
+			} | undefined;
+		`,
 	],
 	invalid: [
 		{
@@ -41,6 +54,21 @@ test.typescript({
 		{
 			code: 'type ElementUnion = {foo: string} | string;',
 			output: 'type ElementUnion = string | {foo: string};',
+			errors: [{messageId: 'prefer-type-literal-last'}],
+		},
+		{
+			code: 'type ElementUnion = {foo: string} | Other | undefined;',
+			output: 'type ElementUnion = Other | {foo: string} | undefined;',
+			errors: [{messageId: 'prefer-type-literal-last'}],
+		},
+		{
+			code: 'type ElementUnion = {foo: string} | undefined | Other;',
+			output: 'type ElementUnion = Other | {foo: string} | undefined;',
+			errors: [{messageId: 'prefer-type-literal-last'}],
+		},
+		{
+			code: 'type ElementUnion = undefined | {foo: string} | Other;',
+			output: 'type ElementUnion = Other | {foo: string} | undefined;',
 			errors: [{messageId: 'prefer-type-literal-last'}],
 		},
 		{


### PR DESCRIPTION
Fixes #3277