### PR TITLE
`logical-assignment-operators`: Do not assume the base rule's `defaultOptions` exist

### DIFF
--- a/rules/logical-assignment-operators.js
+++ b/rules/logical-assignment-operators.js
@@ -113,7 +113,7 @@ const config = {
 		hasSuggestions: baseRule.meta.hasSuggestions,
 		schema: baseRule.meta.schema,
 		defaultOptions: [
-			baseRule.meta.defaultOptions[0],
+			baseRule.meta.defaultOptions?.[0],
 		],
 		messages,
 		languages: [


### PR DESCRIPTION
Fixes #3317
