### PR TITLE
`consistent-boolean-name`: Do not check destructured bindings

### DIFF
--- a/rules/consistent-boolean-name.js
+++ b/rules/consistent-boolean-name.js
@@ -198,6 +198,11 @@ const isBooleanVariable = (variable, context) => {
 		return false;
 	}
 
+	// Destructuring patterns (`const {completed} = task`, `const [enabled] = list`) are intentionally not checked, since renaming a destructured binding is more involved than renaming a plain identifier.
+	if (definition.type === 'Variable' && definition.node.id.type !== 'Identifier') {
+		return false;
+	}
+
 	// A setter parameter's name is positional and dictated by the accessor, not chosen freely.
 	if (definition.type === 'Parameter' && definition.node.parent?.kind === 'set') {
 		return false;

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -395,6 +395,14 @@ test.snapshot({
 		typescript('type BooleanAlias = BooleanAlias; const completed: BooleanAlias = true;'),
 		typeAware('declare const options: {enabled: string}; const completed = options.enabled;'),
 		typeAware('type BooleanAlias = boolean; declare const isEnabled: BooleanAlias; const isCompleted = isEnabled;'),
+		// Destructured bindings are intentionally not checked, even with type information.
+		typeAware('declare const options: {strict: boolean}; const {strict} = options;'),
+		typeAware('declare const options: {strict: boolean}; const {strict: renamed} = options;'),
+		typeAware('declare const options: {strict?: boolean}; const {strict = true} = options;'),
+		typeAware('declare const values: [boolean]; const [enabled] = values;'),
+		typeAware('declare const o: {a: {b: boolean}}; const {a: {b}} = o;'),
+		// Destructured parameters are likewise not checked.
+		typeAware('function foo({strict}: {strict: boolean}) {}'),
 	],
 	invalid: [
 		typescript('const completed: boolean = true;'),


### PR DESCRIPTION
Fixes #3316