### PR TITLE
`no-useless-undefined`: Flag `return undefined` for `void` return type

### DIFF
--- a/docs/rules/no-useless-undefined.md
+++ b/docs/rules/no-useless-undefined.md
@@ -15,6 +15,8 @@ This rule does not check function call arguments in TypeScript files because Typ
 
 Using `undefined` as arrow function body sometimes makes the purpose more explicit. You can use the `checkArrowFunctionBody: false` option to allow this.
 
+In TypeScript, when a function has an explicit return type, `return undefined` is only reported if that type is `undefined` or `void`. When the return type is a union with a real value type, such as `number | undefined`, the explicit `undefined` is kept, since it can document intent and avoid conflicts with the [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return) rule.
+
 ## Examples
 
 ```js

--- a/rules/no-useless-undefined.js
+++ b/rules/no-useless-undefined.js
@@ -86,8 +86,12 @@ const getFunction = scope => {
 	}
 };
 
-const isUndefinedReturnType = functionNode =>
-	functionNode.returnType?.typeAnnotation?.type === 'TSUndefinedKeyword';
+// Matches a "pure-nothing" return type (`undefined` or `void`), where `return undefined` is always useless.
+// Union types like `number | undefined` are intentionally excluded, so the explicit `undefined` is preserved (#880).
+const isUndefinedOrVoidReturnType = functionNode => {
+	const type = functionNode.returnType?.typeAnnotation?.type;
+	return type === 'TSUndefinedKeyword' || type === 'TSVoidKeyword';
+};
 
 const isFunctionBindCall = node =>
 	!node.optional
@@ -309,7 +313,7 @@ const create = context => {
 			&& parent.argument === node
 		) {
 			const functionNode = getFunction(sourceCode.getScope(node));
-			if (functionNode?.returnType && !isUndefinedReturnType(functionNode)) {
+			if (functionNode?.returnType && !isUndefinedOrVoidReturnType(functionNode)) {
 				return;
 			}
 

--- a/test/no-useless-undefined.js
+++ b/test/no-useless-undefined.js
@@ -388,6 +388,33 @@ test.typescript({
 		`,
 		'const foo = (): undefined => undefined;',
 		'const foo = (): string => undefined;',
+		// Explicit `return undefined` is allowed when the return type is a union with a real value type
+		outdent`
+			function foo(): number | undefined {
+				if (bar) {
+					return 2;
+				}
+
+				return undefined;
+			}
+		`,
+		outdent`
+			function foo(): number | void {
+				if (bar) {
+					return 2;
+				}
+
+				return undefined;
+			}
+		`,
+		'function foo(): any {return undefined;}',
+		'function foo(): unknown {return undefined;}',
+		// `never` is neither `undefined` nor `void`
+		'function foo(): never {return undefined;}',
+		// Union order does not matter
+		'function foo(): undefined | number {return undefined;}',
+		// `Promise<void>` is a type reference, not the `void` keyword
+		'async function foo(): Promise<void> {return undefined;}',
 		'createContext<T>(undefined);',
 		'React.createContext<T>(undefined);',
 		{
@@ -455,6 +482,60 @@ test.typescript({
 		{
 			code: 'const foo = function (): undefined {return undefined};',
 			output: 'const foo = function (): undefined {return};',
+			errors,
+		},
+		{
+			code: 'function shouldBeFlagged(): void {return undefined;}',
+			output: 'function shouldBeFlagged(): void {return;}',
+			errors,
+		},
+		{
+			code: 'const foo = function (): void {return undefined};',
+			output: 'const foo = function (): void {return};',
+			errors,
+		},
+		{
+			code: 'const foo = (): void => {return undefined};',
+			output: 'const foo = (): void => {return};',
+			errors,
+		},
+		{
+			code: outdent`
+				class A {
+					method(): void {
+						return undefined;
+					}
+				}
+			`,
+			output: outdent`
+				class A {
+					method(): void {
+						return;
+					}
+				}
+			`,
+			errors,
+		},
+		// The return type of the innermost function is used, not the outer one
+		{
+			code: outdent`
+				function outer(): string {
+					function inner(): void {
+						return undefined;
+					}
+
+					return 'foo';
+				}
+			`,
+			output: outdent`
+				function outer(): string {
+					function inner(): void {
+						return;
+					}
+
+					return 'foo';
+				}
+			`,
 			errors,
 		},
 		{


### PR DESCRIPTION
Fixes #3330