### PR TITLE
`name-replacements`: Exclude Vite type declaration from rename

### DIFF
--- a/rules/shared/name-replacements.js
+++ b/rules/shared/name-replacements.js
@@ -309,6 +309,9 @@ export const defaultAllowList = {
 	getInitialProps: true,
 	getServerSideProps: true,
 	getStaticProps: true,
+	// Vite environment variables type
+	// https://vite.dev/guide/env-and-mode#intellisense-for-typescript
+	ImportMetaEnv: true,
 	// The name iOS is a standard name for an OS
 	iOS: true,
 	// React PropTypes
@@ -327,4 +330,7 @@ export const defaultIgnore = [
 	'a11y', // Accessibility
 	'e2e', // End-to-end
 	'jQuery',
+	// Vite type declaration file
+	// https://vite.dev/guide/env-and-mode#intellisense-for-typescript
+	'vite-env',
 ];

--- a/test/name-replacements.js
+++ b/test/name-replacements.js
@@ -1988,7 +1988,10 @@ test.typescript({
 			},
 		},
 	},
-	valid: [],
+	valid: [
+		// Vite type declaration
+		'interface ImportMetaEnv {}',
+	],
 	invalid: [
 		// Types
 		...[
@@ -2470,6 +2473,11 @@ test({
 		{
 			code: 'foo();',
 			filename: 'e2e.js',
+		},
+		// Vite type declaration
+		{
+			code: 'foo();',
+			filename: 'vite-env.d.ts',
 		},
 		// `ignore` option
 		{


### PR DESCRIPTION
Fixes #3371