### PR TITLE
`custom-error-definition`: Don't require `options` parameter when forwarded to `super()` inline

### DIFF
--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -123,6 +123,17 @@ class CustomError extends Error {
 
 ```js
 // ✅
+// The message is hard-coded and `options` is passed to `super()` directly, so no `options` parameter is needed.
+class CustomError extends Error {
+	constructor(cause) {
+		super('My custom error', {cause});
+		this.name = 'CustomError';
+	}
+}
+```
+
+```js
+// ✅
 class CustomError extends TypeError {
 	constructor() {
 		super();

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -3,7 +3,10 @@ import {
 	getParenthesizedText,
 	isNodeMatchesNameOrPath,
 } from './utils/index.js';
-import {isUndefined} from './ast/index.js';
+import {
+	getStaticStringValue,
+	isUndefined,
+} from './ast/index.js';
 
 const MESSAGE_ID_INVALID_EXPORT = 'invalidExport';
 const MESSAGE_ID_DO_NOT_PASS_MESSAGE_TO_SUPER = 'doNotPassMessageToSuper';
@@ -200,6 +203,33 @@ const isSameIdentifier = (node, identifier) =>
 	node?.type === 'Identifier'
 	&& node.name === identifier.name;
 
+const isCauseProperty = property =>
+	property.type === 'Property'
+	&& !property.computed
+	&& (
+		(
+			property.key.type === 'Identifier'
+			&& property.key.name === 'cause'
+		)
+		|| (
+			property.key.type === 'Literal'
+			&& property.key.value === 'cause'
+		)
+	);
+
+const hasInlineErrorOptions = (superCallExpression, shouldPassMessageToSuper) => {
+	if (shouldPassMessageToSuper) {
+		return false;
+	}
+
+	const [messageArgument, optionsArgument] = superCallExpression.arguments;
+	return superCallExpression.arguments.length === 2
+		&& getStaticStringValue(messageArgument) !== undefined
+		&& optionsArgument.type === 'ObjectExpression'
+		&& optionsArgument.properties.length === 1
+		&& isCauseProperty(optionsArgument.properties[0]);
+};
+
 const getErrorOptionsProblem = (context, constructor, superExpression, hasMessageAccessor) => {
 	const parameters = constructor.value.params;
 	const firstParameter = parameters[0];
@@ -236,6 +266,11 @@ const getErrorOptionsProblem = (context, constructor, superExpression, hasMessag
 	const messageArgumentText = shouldPassMessageToSuper ? firstParameterIdentifier.name : 'undefined';
 
 	if (!optionsParameter) {
+		// When `options` is already forwarded to `super()` (e.g. `super('Fixed message', {cause})`), a dedicated `options` parameter isn't needed.
+		if (hasInlineErrorOptions(superCallExpression, shouldPassMessageToSuper)) {
+			return;
+		}
+
 		return {
 			node: firstParameter,
 			messageId: MESSAGE_ID_MISSING_OPTIONS_PARAMETER,

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -89,6 +89,15 @@ const tests = {
 				}
 			}
 		`,
+		// `options` is forwarded to `super()` inline, so no dedicated `options` parameter is needed
+		outdent`
+			class FooError extends Error {
+				constructor(cause) {
+					super('The request timed out', {cause});
+					this.name = 'FooError';
+				}
+			}
+		`,
 		outdent`
 			class FooError extends Error {
 				constructor() {
@@ -684,6 +693,45 @@ const tests = {
 					}
 				}
 			`,
+		},
+		{
+			code: outdent`
+				class FooError extends Error {
+					constructor(cause) {
+						super('Fixed message', cause);
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [
+				missingOptionsParameterError,
+			],
+		},
+		{
+			code: outdent`
+				class FooError extends Error {
+					constructor(details) {
+						super('Fixed message', {details});
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [
+				missingOptionsParameterError,
+			],
+		},
+		{
+			code: outdent`
+				class FooError extends Error {
+					constructor(message) {
+						super('Fixed message', {cause: message});
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [
+				missingOptionsParameterError,
+			],
 		},
 		{
 			code: outdent`


### PR DESCRIPTION
Fixes #3374