### PR TITLE
`consistent-boolean-name`: Don't crash on Svelte `{#each}` bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
 		"open-editor": "^6.0.0",
 		"outdent": "^0.8.0",
 		"pretty-ms": "^9.3.0",
+		"svelte": "^5.56.3",
+		"svelte-eslint-parser": "^1.8.0",
 		"typescript": "^6.0.3",
 		"vue-eslint-parser": "^10.4.1",
 		"yaml": "^2.9.0"

--- a/rules/consistent-boolean-name.js
+++ b/rules/consistent-boolean-name.js
@@ -216,6 +216,11 @@ const isBooleanVariable = (variable, context) => {
 	}
 
 	if (definition.type === 'Parameter') {
+		// Some parsers (such as Svelte's `{#each}` bindings) create `Parameter` definitions whose owner is not a function and has no `params` list.
+		if (!isFunction(definition.node)) {
+			return false;
+		}
+
 		const parameter = findParameter(definition.node.params, name);
 
 		return parameter?.type === 'AssignmentPattern'

--- a/scripts/parsers.js
+++ b/scripts/parsers.js
@@ -10,6 +10,7 @@ const loadModule = createRequire(import.meta.url);
 const typescriptEslintParserOriginal = loadModule('@typescript-eslint/parser');
 const vueEslintParserOriginal = loadModule('vue-eslint-parser');
 const htmlEslintParserOriginal = loadModule('@html-eslint/parser');
+const svelteEslintParserOriginal = loadModule('svelte-eslint-parser');
 
 function addGlobals(scopeManager, names) {
 	const globalScope = scopeManager.scopes[0];
@@ -106,3 +107,5 @@ export const typescriptEslintParser = getParser('TypeScript', typescriptEslintPa
 export const vueEslintParser = getParser('Vue', vueEslintParserOriginal);
 
 export const htmlEslintParser = getParser('HTML', htmlEslintParserOriginal);
+
+export const svelteEslintParser = getParser('Svelte', svelteEslintParserOriginal);

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -688,3 +688,12 @@ test.snapshot({
 		}),
 	],
 });
+
+// Svelte `{#each}` bindings are `Parameter` definitions whose owner is the each-block, not a function.
+test.svelte({
+	valid: [
+		'<script>let items = [];</script>{#each items as item}{item}{/each}',
+		'<script>let entries = [];</script>{#each entries as [key, value]}{key}{value}{/each}',
+	],
+	invalid: [],
+});

--- a/test/utils/parsers.js
+++ b/test/utils/parsers.js
@@ -1,5 +1,6 @@
 import {
 	htmlEslintParser,
+	svelteEslintParser,
 	typescriptEslintParser,
 	vueEslintParser,
 } from '../../scripts/parsers.js';
@@ -23,10 +24,16 @@ const htmlParser = {
 	implementation: htmlEslintParser,
 };
 
+const svelteParser = {
+	name: 'svelte',
+	implementation: svelteEslintParser,
+};
+
 const parsers = Object.fromEntries([
 	htmlParser,
 	typescriptParser,
 	vueParser,
+	svelteParser,
 ].map(parser => [parser.name, parser]));
 
 export default parsers;


### PR DESCRIPTION
Fixes #3403