### PR TITLE
`isolated-functions`: Add defaults for workerize and common evaluate APIs

### DIFF
--- a/docs/rules/isolated-functions.md
+++ b/docs/rules/isolated-functions.md
@@ -12,7 +12,7 @@ Some functions need to be isolated from their surrounding scope due to execution
 Common scenarios where functions must be isolated:
 
 - Functions passed to `makeSynchronous()` (executed in worker)
-- Functions passed to `workerize()` or specific browser execution APIs
+- Functions passed to `workerize()`
 - Functions passed to `page.evaluate()` in Puppeteer or Playwright style code
 - Functions that will be serialized via `Function.prototype.toString()`
 - Server actions or other remote execution contexts

--- a/docs/rules/isolated-functions.md
+++ b/docs/rules/isolated-functions.md
@@ -12,6 +12,8 @@ Some functions need to be isolated from their surrounding scope due to execution
 Common scenarios where functions must be isolated:
 
 - Functions passed to `makeSynchronous()` (executed in worker)
+- Functions passed to `workerize()` or specific browser execution APIs
+- Functions passed to `page.evaluate()` in Puppeteer or Playwright style code
 - Functions that will be serialized via `Function.prototype.toString()`
 - Server actions or other remote execution contexts
 - Functions with specific JSDoc annotations
@@ -69,9 +71,20 @@ Type: `object`
 ### functions
 
 Type: `string[]`\
-Default: `['makeSynchronous']`
+Default: `['makeSynchronous', 'workerize']`
 
 Array of function names that create isolated execution contexts. Functions passed as arguments to these functions will be considered isolated.
+
+The rule also detects these common isolated execution APIs by default:
+
+- `browser.execute(fn)`
+- `page.evaluate(fn)`
+- `chrome.scripting.executeScript({func: () => {}})`
+- `browser.scripting.executeScript({func: () => {}})`
+
+Generic names like `serialize`, `isolate`, and `memoize` are not enabled by default. Add project-specific serializer names to `functions` when they should be treated as isolated.
+
+Other `evaluate` calls are not enabled by default. Use `selectors` to opt into project-specific APIs that do not use the variable name `page`.
 
 ### selectors
 
@@ -154,6 +167,7 @@ Controls how global variables are handled. When not specified, uses ESLint's lan
 		{
 			functions: [
 				'makeSynchronous',
+				'workerize',
 				'createWorker',
 				'serializeFunction'
 			]

--- a/rules/isolated-functions.js
+++ b/rules/isolated-functions.js
@@ -1,5 +1,5 @@
 import globals from 'globals';
-import {functionTypes} from './ast/index.js';
+import {functionTypes, isMemberExpression, isMethodCall} from './ast/index.js';
 
 const MESSAGE_ID_EXTERNALLY_SCOPED_VARIABLE = 'externally-scoped-variable';
 const messages = {
@@ -8,10 +8,77 @@ const messages = {
 
 /** @type {{functions: string[], selectors: string[], comments: string[], overrideGlobals?: import('eslint').Linter.Globals}} */
 const defaultOptions = {
-	functions: ['makeSynchronous'],
+	functions: ['makeSynchronous', 'workerize'],
 	selectors: [],
 	comments: ['@isolated'],
 	overrideGlobals: {},
+};
+
+const scriptingObjects = ['browser', 'chrome'];
+
+const getObjectPropertyName = node => {
+	if (node.computed && node.key.type !== 'Literal') {
+		return;
+	}
+
+	if (node.key.type === 'Identifier') {
+		return node.key.name;
+	}
+
+	if (node.key.type === 'Literal' && typeof node.key.value === 'string') {
+		return node.key.value;
+	}
+};
+
+const getDefaultArgumentCallReason = node => {
+	if (
+		node.parent.type !== 'CallExpression'
+		|| node.parent.arguments[0] !== node
+		|| node.parent.callee.type !== 'MemberExpression'
+	) {
+		return;
+	}
+
+	if (isMethodCall(node.parent, {object: 'browser', method: 'execute'})) {
+		return 'callee of method named "browser.execute"';
+	}
+
+	if (isMethodCall(node.parent, {object: 'page', method: 'evaluate'})) {
+		return 'callee of method named "page.evaluate"';
+	}
+};
+
+const getScriptingExecuteScriptObjectName = node => {
+	if (
+		!isMethodCall(node, {method: 'executeScript'})
+		|| !isMemberExpression(node.callee.object, {
+			objects: scriptingObjects,
+			property: 'scripting',
+		})
+	) {
+		return;
+	}
+
+	return node.callee.object.object.name;
+};
+
+const getExecuteScriptPropertyReason = node => {
+	if (
+		node.parent.type !== 'Property'
+		|| getObjectPropertyName(node.parent) !== 'func'
+		|| node.parent.parent.type !== 'ObjectExpression'
+		|| node.parent.parent.parent.type !== 'CallExpression'
+		|| node.parent.parent.parent.arguments[0] !== node.parent.parent
+	) {
+		return;
+	}
+
+	const scriptingObjectName = getScriptingExecuteScriptObjectName(node.parent.parent.parent);
+	if (!scriptingObjectName) {
+		return;
+	}
+
+	return `property "func" passed to "${scriptingObjectName}.scripting.executeScript"`;
 };
 
 /** @param {import('eslint').Rule.RuleContext} context */
@@ -127,6 +194,8 @@ const create = context => {
 		) {
 			return `callee of function named ${JSON.stringify(node.parent.callee.name)}`;
 		}
+
+		return getDefaultArgumentCallReason(node) ?? getExecuteScriptPropertyReason(node);
 	};
 
 	context.onExit(

--- a/rules/isolated-functions.js
+++ b/rules/isolated-functions.js
@@ -34,7 +34,6 @@ const getDefaultArgumentCallReason = node => {
 	if (
 		node.parent.type !== 'CallExpression'
 		|| node.parent.arguments[0] !== node
-		|| node.parent.callee.type !== 'MemberExpression'
 	) {
 		return;
 	}
@@ -65,6 +64,7 @@ const getScriptingExecuteScriptObjectName = node => {
 const getExecuteScriptPropertyReason = node => {
 	if (
 		node.parent.type !== 'Property'
+		|| node.parent.kind !== 'init'
 		|| getObjectPropertyName(node.parent) !== 'func'
 		|| node.parent.parent.type !== 'ObjectExpression'
 		|| node.parent.parent.parent.type !== 'CallExpression'

--- a/test/isolated-functions.js
+++ b/test/isolated-functions.js
@@ -5,6 +5,11 @@ const {test} = getTester(import.meta);
 
 const error = data => ({messageId: 'externally-scoped-variable', data});
 const fooInMakeSynchronousError = error({name: 'foo', reason: 'callee of function named "makeSynchronous"'});
+const fooInWorkerizeError = error({name: 'foo', reason: 'callee of function named "workerize"'});
+const fooInBrowserExecuteError = error({name: 'foo', reason: 'callee of method named "browser.execute"'});
+const fooInPageEvaluateError = error({name: 'foo', reason: 'callee of method named "page.evaluate"'});
+const fooInChromeScriptingExecuteScriptError = error({name: 'foo', reason: 'property "func" passed to "chrome.scripting.executeScript"'});
+const fooInBrowserScriptingExecuteScriptError = error({name: 'foo', reason: 'property "func" passed to "browser.scripting.executeScript"'});
 
 test({
 	/** @type {import('eslint').RuleTester.ValidTestCase[]} */
@@ -96,6 +101,68 @@ test({
 				});
 			`,
 		},
+		{
+			name: 'generic function names are not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				memoize(() => foo.slice());
+				serialize(() => foo.slice());
+				isolate(() => foo.slice());
+			`,
+		},
+		{
+			name: 'dynamic computed executeScript func property is not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				const func = 'func';
+				chrome.scripting.executeScript({
+					target: {tabId: 1},
+					[func]: () => foo.slice(),
+				});
+			`,
+		},
+		{
+			name: 'computed browser execution method names are not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				browser['execute'](() => foo.slice());
+				page['evaluate'](() => foo.slice());
+				chrome.scripting['executeScript']({
+					target: {tabId: 1},
+					func: () => foo.slice(),
+				});
+			`,
+		},
+		{
+			name: 'later executeScript object arguments are not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				chrome.scripting.executeScript(target, {
+					func: () => foo.slice(),
+				});
+			`,
+		},
+		{
+			name: 'non-page evaluate methods are not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				frame.evaluate(() => foo.slice());
+			`,
+		},
+		{
+			name: 'later browser.execute function arguments are not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				browser.execute(() => 'browser', () => foo.slice());
+			`,
+		},
+		{
+			name: 'later page.evaluate function arguments are not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				page.evaluate(() => 'page', () => foo.slice());
+			`,
+		},
 	],
 	/** @type {import('eslint').RuleTester.InvalidTestCase[]} */
 	invalid: [
@@ -106,6 +173,89 @@ test({
 				makeSynchronous(() => foo.slice());
 			`,
 			errors: [fooInMakeSynchronousError],
+		},
+		{
+			name: 'out of scope variable under workerize',
+			code: outdent`
+				const foo = 'hi';
+				workerize(() => foo.slice());
+			`,
+			errors: [fooInWorkerizeError],
+		},
+		{
+			name: 'out of scope variable under browser.execute',
+			code: outdent`
+				const foo = 'hi';
+				browser.execute(() => foo.slice());
+			`,
+			errors: [fooInBrowserExecuteError],
+		},
+		{
+			name: 'out of scope variable under page.evaluate',
+			code: outdent`
+				const foo = 'hi';
+				page.evaluate(() => foo.slice());
+			`,
+			errors: [fooInPageEvaluateError],
+		},
+		{
+			name: 'out of scope variable under chrome.scripting.executeScript',
+			code: outdent`
+				const foo = 'hi';
+				chrome.scripting.executeScript({
+					target: {tabId: 1},
+					func: () => foo.slice(),
+				});
+			`,
+			errors: [fooInChromeScriptingExecuteScriptError],
+		},
+		{
+			name: 'out of scope variable under browser.scripting.executeScript',
+			code: outdent`
+				const foo = 'hi';
+				browser.scripting.executeScript({
+					target: {tabId: 1},
+					func: () => foo.slice(),
+				});
+			`,
+			errors: [fooInBrowserScriptingExecuteScriptError],
+		},
+		{
+			name: 'out of scope variable under executeScript static computed func property',
+			code: outdent`
+				const foo = 'hi';
+				chrome.scripting.executeScript({
+					target: {tabId: 1},
+					['func']: () => foo.slice(),
+				});
+			`,
+			errors: [fooInChromeScriptingExecuteScriptError],
+		},
+		{
+			name: 'out of scope variable under executeScript function expression',
+			code: outdent`
+				const foo = 'hi';
+				chrome.scripting.executeScript({
+					target: {tabId: 1},
+					func: function () {
+						return foo.slice();
+					},
+				});
+			`,
+			errors: [fooInChromeScriptingExecuteScriptError],
+		},
+		{
+			name: 'out of scope variable under executeScript method shorthand',
+			code: outdent`
+				const foo = 'hi';
+				browser.scripting.executeScript({
+					target: {tabId: 1},
+					func() {
+						return foo.slice();
+					},
+				});
+			`,
+			errors: [fooInBrowserScriptingExecuteScriptError],
 		},
 		{
 			name: 'out of scope variable under makeSynchronous (async arrow function)',

--- a/test/isolated-functions.js
+++ b/test/isolated-functions.js
@@ -134,6 +134,28 @@ test({
 			`,
 		},
 		{
+			name: 'executeScript func identifier value is not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				const func = () => foo.slice();
+				chrome.scripting.executeScript({func});
+			`,
+		},
+		{
+			name: 'executeScript func accessors are not isolated by default',
+			code: outdent`
+				const foo = 'hi';
+				chrome.scripting.executeScript({
+					get func() {
+						return () => foo.slice();
+					},
+					set func(value) {
+						foo.slice(value);
+					},
+				});
+			`,
+		},
+		{
 			name: 'later executeScript object arguments are not isolated by default',
 			code: outdent`
 				const foo = 'hi';


### PR DESCRIPTION
Fixes #3464 