### PR TITLE
`consistent-boolean-name`: Skip React hooks by default

### DIFF
--- a/docs/rules/consistent-boolean-name.md
+++ b/docs/rules/consistent-boolean-name.md
@@ -35,6 +35,8 @@ The plural prefixes (`are`, `have`, `were`) allow names for boolean collections,
 
 The prefix must be a distinct word part. `isReady`, `is_ready`, and `IS_READY` are allowed, but `island` is not considered to have the `is` prefix.
 
+React hooks are checked after the required `use` prefix. For example, `useIsReady` is treated as a boolean hook name, while `useReady` is not.
+
 This rule intentionally does not check destructuring bindings, imports, class names, or catch parameters.
 
 TypeScript type annotation checks resolve local type aliases and callable interfaces, but not qualified or namespaced type references.

--- a/docs/rules/consistent-boolean-name.md
+++ b/docs/rules/consistent-boolean-name.md
@@ -35,7 +35,7 @@ The plural prefixes (`are`, `have`, `were`) allow names for boolean collections,
 
 The prefix must be a distinct word part. `isReady`, `is_ready`, and `IS_READY` are allowed, but `island` is not considered to have the `is` prefix.
 
-React hooks are checked after the required `use` prefix. For example, `useIsReady` is treated as a boolean hook name, while `useReady` is not.
+React hook function bindings are checked after the required `use` prefix. For example, `useIsReady` is treated as a boolean hook name, while `useReady` is not. `ignore` patterns still match the original source name, like `useReady`.
 
 This rule intentionally does not check destructuring bindings, imports, class names, or catch parameters.
 

--- a/rules/consistent-boolean-name.js
+++ b/rules/consistent-boolean-name.js
@@ -6,9 +6,11 @@ import {
 	getAvailableVariableName,
 	getScopes,
 	getVariableIdentifiers,
+	isReactHookName,
 	isNullishType,
 	isTypeParameterType,
 	isUnknownType,
+	lowerFirst,
 	upperFirst,
 } from './utils/index.js';
 import {
@@ -17,6 +19,7 @@ import {
 	isBooleanFunctionReference,
 	isBooleanFunctionTypeAnnotation,
 	isBooleanTypeAnnotation,
+	isFunctionTypeAnnotation,
 } from './utils/is-boolean.js';
 
 const MESSAGE_ID = 'consistent-boolean-name';
@@ -98,6 +101,7 @@ const typeScriptExpressionWrapperTypes = new Set([
 ]);
 const isUpperCase = string => string === string.toUpperCase();
 const stripLeadingUnderscores = name => name.replace(/^_+/, '');
+const isScreamingCase = name => /^[A-Z][\dA-Z_]*$/.test(stripLeadingUnderscores(name));
 
 const isFunction = node => [
 	'ArrowFunctionExpression',
@@ -178,6 +182,18 @@ function getReplacementName(name, prefix) {
 	return isUpperCase(nameWithoutLeadingUnderscores)
 		? `${leadingUnderscores}${prefix.toUpperCase()}_${nameWithoutLeadingUnderscores}`
 		: `${leadingUnderscores}${prefix}${upperFirst(nameWithoutLeadingUnderscores)}`;
+}
+
+function getReactHookReplacementName({name, nameForPrefixCheck}, prefix) {
+	if (name === nameForPrefixCheck) {
+		return getReplacementName(name, prefix);
+	}
+
+	const hookName = isScreamingCase(nameForPrefixCheck)
+		? getReplacementName(nameForPrefixCheck, prefix)
+		: `${prefix}${upperFirst(nameForPrefixCheck)}`;
+
+	return `use${upperFirst(hookName)}`;
 }
 
 const isExportedIdentifier = identifier => {
@@ -262,6 +278,41 @@ function getFunctionDefinitions(variable) {
 
 	const overloadDefinitions = variable.defs.filter(definition => definition.node.type === 'TSDeclareFunction');
 	return overloadDefinitions.length > 0 ? overloadDefinitions : variable.defs;
+}
+
+function isReactHookFunctionBinding(variable, context) {
+	if (
+		variable.name === 'use'
+		|| !isReactHookName(variable.name)
+	) {
+		return false;
+	}
+
+	if (getFunctionDefinitions(variable)) {
+		return true;
+	}
+
+	const definition = getSupportedVariableDefinition(variable);
+
+	if (definition?.type === 'FunctionName') {
+		return isFunction(definition.node);
+	}
+
+	return definition?.type === 'Variable'
+		&& (
+			isFunction(definition.node.init)
+			|| isFunctionTypeAnnotation(definition.name.typeAnnotation, context, context.sourceCode.getScope(definition.name))
+		);
+}
+
+function getNameForPrefixCheck(variable, context) {
+	if (!isReactHookFunctionBinding(variable, context)) {
+		return variable.name;
+	}
+
+	const hookName = variable.name.slice(3);
+
+	return isScreamingCase(hookName) ? hookName : lowerFirst(hookName);
 }
 
 function combineBooleanStates(states) {
@@ -888,7 +939,7 @@ function getPropertyBooleanState(node, context) {
 	return state === unknown && isBooleanProperty(node, context) ? boolean : state;
 }
 
-function getSuggestions(variable, prefixes, context) {
+function getSuggestions(variable, prefixes, context, nameForPrefixCheck) {
 	if (
 		!shouldSuggestRename(variable)
 		|| variable.references.some(reference => reference.vueUsedInTemplate)
@@ -904,7 +955,7 @@ function getSuggestions(variable, prefixes, context) {
 	const suggestions = [];
 
 	for (const prefix of prefixes) {
-		const replacement = getAvailableVariableName(getReplacementName(variable.name, prefix), scopes);
+		const replacement = getAvailableVariableName(getReactHookReplacementName({name: variable.name, nameForPrefixCheck}, prefix), scopes);
 
 		if (!replacement || usedReplacements.has(replacement)) {
 			continue;
@@ -954,7 +1005,13 @@ function isInDeclareContext(node) {
 	return false;
 }
 
-function getAutofix(variable, prefixes, context, suggestions) {
+function getAutofix({
+	variable,
+	prefixes,
+	context,
+	suggestions,
+	nameForPrefixCheck,
+}) {
 	if (
 		!suggestions
 		|| !isAutofixableVariable(variable, context)
@@ -963,7 +1020,7 @@ function getAutofix(variable, prefixes, context, suggestions) {
 	}
 
 	const [prefix] = prefixes;
-	const replacement = getReplacementName(variable.name, prefix);
+	const replacement = getReactHookReplacementName({name: variable.name, nameForPrefixCheck}, prefix);
 	const suggestion = suggestions.find(suggestion => suggestion.data.replacement === replacement);
 
 	return suggestion?.fix;
@@ -982,7 +1039,8 @@ const create = context => {
 			return;
 		}
 
-		const booleanPrefix = getBooleanPrefix(variable.name, prefixes);
+		const nameForPrefixCheck = getNameForPrefixCheck(variable, context);
+		const booleanPrefix = getBooleanPrefix(nameForPrefixCheck, prefixes);
 		if (booleanPrefix) {
 			if (getVariableBooleanState(variable, context) === nonBoolean) {
 				const [definition] = variable.defs;
@@ -991,7 +1049,7 @@ const create = context => {
 					node: definition.name,
 					messageId: MESSAGE_ID_NON_BOOLEAN_PREFIX,
 					data: {
-						name: variable.name,
+						name: nameForPrefixCheck,
 						prefix: booleanPrefix,
 					},
 				});
@@ -1008,16 +1066,22 @@ const create = context => {
 		}
 
 		const [definition] = variable.defs;
-		const suggest = getSuggestions(variable, prefixes, context);
+		const suggest = getSuggestions(variable, prefixes, context, nameForPrefixCheck);
 
 		context.report({
 			node: definition.name,
 			messageId: MESSAGE_ID,
 			data: {
-				name: variable.name,
+				name: nameForPrefixCheck,
 				prefixes: formatPrefixes(prefixes),
 			},
-			fix: getAutofix(variable, prefixes, context, suggest),
+			fix: getAutofix({
+				variable,
+				prefixes,
+				context,
+				suggestions: suggest,
+				nameForPrefixCheck,
+			}),
 			suggest,
 		});
 	};

--- a/rules/no-declarations-before-early-exit.js
+++ b/rules/no-declarations-before-early-exit.js
@@ -1,5 +1,10 @@
 import {isCommentToken, hasSideEffect} from '@eslint-community/eslint-utils';
-import {containsSuspensionPoint, getReferences, trackBranchExits} from './utils/index.js';
+import {
+	containsSuspensionPoint,
+	getReferences,
+	isReactHookName,
+	trackBranchExits,
+} from './utils/index.js';
 
 const MESSAGE_ID = 'no-declarations-before-early-exit';
 const messages = {
@@ -22,10 +27,6 @@ function isGuardStatement(node, branchAlwaysExits) {
 	const alternateExits = Boolean(node.alternate) && branchAlwaysExits(node.alternate);
 	return consequentExits !== alternateExits;
 }
-
-// https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
-const isReactHookName = name =>
-	name === 'use' || /^use[\dA-Z]/.test(name);
 
 // Matches `useFoo(…)` and `Namespace.useFoo(…)` (for example, `React.useMemo(…)`).
 const isReactHookCall = node => {

--- a/rules/utils/index.js
+++ b/rules/utils/index.js
@@ -95,6 +95,7 @@ export {default as isNodeValueNotFunction} from './is-node-value-not-function.js
 export {default as isNodeContainsLexicalThis} from './is-node-contains-lexical-this.js';
 export {default as isOnSameLine} from './is-on-same-line.js';
 export {default as isPromiseType} from './is-promise-type.js';
+export {default as isReactHookName} from './is-react-hook-name.js';
 export {default as isSameIdentifier} from './is-same-identifier.js';
 export {default as isSameReference} from './is-same-reference.js';
 export {default as isUnresolvedVariable} from './is-unresolved-variable.js';

--- a/rules/utils/is-boolean.js
+++ b/rules/utils/is-boolean.js
@@ -16,6 +16,10 @@ const booleanBinaryOperators = new Set([
 
 const booleanTypeStrings = new Set(['boolean', 'true', 'false']);
 const booleanGlobalFunctions = new Set(['isFinite', 'isNaN']);
+const nullishTypeAnnotationTypes = new Set([
+	'TSNullKeyword',
+	'TSUndefinedKeyword',
+]);
 
 const booleanStaticMethods = new Map([
 	['Array', new Set(['isArray'])],
@@ -90,7 +94,16 @@ function isBooleanCallSignatureMembers(members, context, scope, visitedTypeRefer
 		&& callSignatures.every(member => isBooleanTypeAnnotation(member.returnType, context, scope, visitedTypeReferenceNames));
 }
 
-function isBooleanTypeReference(node, context, scope, visitedTypeReferenceNames) {
+const hasCallSignatureMembers = members =>
+	members.some(member => member.type === 'TSCallSignatureDeclaration');
+
+function isTypeReference({
+	node,
+	context,
+	scope,
+	visitedTypeReferenceNames,
+	predicate,
+}) {
 	const name = getTypeReferenceName(node.typeName);
 	if (!name || visitedTypeReferenceNames.has(name)) {
 		return false;
@@ -103,42 +116,54 @@ function isBooleanTypeReference(node, context, scope, visitedTypeReferenceNames)
 	const definitionScope = definition?.type === 'Type'
 		? context.sourceCode.getScope(definition.node)
 		: scope;
-	const result = definition?.type === 'Type'
-		&& definition.node.type === 'TSTypeAliasDeclaration'
-		&& isBooleanTypeAnnotation(definition.node.typeAnnotation, context, definitionScope, visitedTypeReferenceNames);
+	const result = definition?.type === 'Type' && predicate(definition.node, definitionScope);
 
 	visitedTypeReferenceNames.delete(name);
 	return result;
 }
 
-function isBooleanFunctionTypeReference(node, context, scope, visitedTypeReferenceNames) {
-	const name = getTypeReferenceName(node.typeName);
-	if (!name || visitedTypeReferenceNames.has(name)) {
-		return false;
-	}
+const isBooleanTypeReference = (node, context, scope, visitedTypeReferenceNames) => isTypeReference(
+	{
+		node,
+		context,
+		scope,
+		visitedTypeReferenceNames,
+		predicate: (definitionNode, definitionScope) => definitionNode.type === 'TSTypeAliasDeclaration'
+			&& isBooleanTypeAnnotation(definitionNode.typeAnnotation, context, definitionScope, visitedTypeReferenceNames),
+	},
+);
 
-	visitedTypeReferenceNames.add(name);
+const isBooleanFunctionTypeReference = (node, context, scope, visitedTypeReferenceNames) => isTypeReference(
+	{
+		node,
+		context,
+		scope,
+		visitedTypeReferenceNames,
+		predicate: (definitionNode, definitionScope) => (
+			definitionNode.type === 'TSTypeAliasDeclaration'
+			&& isBooleanFunctionTypeAnnotation(definitionNode.typeAnnotation, context, definitionScope, visitedTypeReferenceNames)
+		) || (
+			definitionNode.type === 'TSInterfaceDeclaration'
+			&& isBooleanCallSignatureMembers(definitionNode.body.body, context, definitionScope, visitedTypeReferenceNames)
+		),
+	},
+);
 
-	const variable = resolveVariableName(name, scope);
-	const [definition] = variable?.defs ?? [];
-	const definitionScope = definition?.type === 'Type'
-		? context.sourceCode.getScope(definition.node)
-		: scope;
-	const result = definition?.type === 'Type'
-		&& (
-			(
-				definition.node.type === 'TSTypeAliasDeclaration'
-				&& isBooleanFunctionTypeAnnotation(definition.node.typeAnnotation, context, definitionScope, visitedTypeReferenceNames)
-			)
-			|| (
-				definition.node.type === 'TSInterfaceDeclaration'
-				&& isBooleanCallSignatureMembers(definition.node.body.body, context, definitionScope, visitedTypeReferenceNames)
-			)
-		);
-
-	visitedTypeReferenceNames.delete(name);
-	return result;
-}
+const isFunctionTypeReference = (node, context, scope, visitedTypeReferenceNames) => isTypeReference(
+	{
+		node,
+		context,
+		scope,
+		visitedTypeReferenceNames,
+		predicate: (definitionNode, definitionScope) => (
+			definitionNode.type === 'TSTypeAliasDeclaration'
+			&& isFunctionTypeAnnotation(definitionNode.typeAnnotation, context, definitionScope, visitedTypeReferenceNames)
+		) || (
+			definitionNode.type === 'TSInterfaceDeclaration'
+			&& hasCallSignatureMembers(definitionNode.body.body)
+		),
+	},
+);
 
 function isBooleanTypeAnnotation(node, context, scope, visitedTypeReferenceNames = new Set()) {
 	switch (node?.type) {
@@ -169,6 +194,38 @@ function isBooleanTypeAnnotation(node, context, scope, visitedTypeReferenceNames
 
 		case 'TypeAnnotation': {
 			return node.typeAnnotation?.type === 'BooleanTypeAnnotation';
+		}
+
+		default: {
+			return false;
+		}
+	}
+}
+
+function isFunctionTypeAnnotation(node, context, scope, visitedTypeReferenceNames = new Set()) {
+	switch (node?.type) {
+		case 'TSTypeAnnotation':
+		case 'TSParenthesizedType': {
+			return isFunctionTypeAnnotation(node.typeAnnotation, context, scope, visitedTypeReferenceNames);
+		}
+
+		case 'TSFunctionType': {
+			return true;
+		}
+
+		case 'TSTypeLiteral': {
+			return hasCallSignatureMembers(node.members);
+		}
+
+		case 'TSTypeReference': {
+			return isFunctionTypeReference(node, context, scope, visitedTypeReferenceNames);
+		}
+
+		case 'TSUnionType': {
+			const types = node.types.filter(type => !nullishTypeAnnotationTypes.has(type.type));
+
+			return types.length > 0
+				&& types.every(type => isFunctionTypeAnnotation(type, context, scope, visitedTypeReferenceNames));
 		}
 
 		default: {
@@ -599,6 +656,7 @@ export {
 	isBooleanFunctionTypeAnnotation,
 	isKnownBooleanFunctionReference,
 	isBooleanTypeAnnotation,
+	isFunctionTypeAnnotation,
 };
 
 export default isBooleanExpression;

--- a/rules/utils/is-react-hook-name.js
+++ b/rules/utils/is-react-hook-name.js
@@ -1,0 +1,5 @@
+// https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+const isReactHookName = name =>
+	name === 'use' || /^use[\dA-Z]/.test(name);
+
+export default isReactHookName;

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -51,7 +51,15 @@ const onlyIsPrefixOptions = {
 };
 
 test({
-	valid: [],
+	valid: [
+		{
+			code: 'function useReady() { return true; }',
+			options: [{
+				...onlyIsPrefixOptions,
+				ignore: ['^useReady$'],
+			}],
+		},
+	],
 	invalid: [
 		{
 			code: 'function foo() { const completed = true; return completed; }',
@@ -86,6 +94,235 @@ test({
 				},
 			],
 		}),
+		typescript({
+			code: 'declare function useMyFlag(): boolean;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'declare function useIsMyFlag(): boolean;',
+						},
+					],
+				},
+			],
+		}),
+		{
+			code: 'function useReady() { return true; }',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'ready',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'function useIsReady() { return true; }',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'function useREADY() { return true; }',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'READY',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'function useIS_READY() { return true; }',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'function use2FA() { return true; }',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: '2FA',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'function useIs2FA() { return true; }',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'function useReady() { return true; }',
+			options: [{
+				...onlyIsPrefixOptions,
+				ignore: ['^ready$'],
+			}],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'ready',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'function useIsReady() { return true; }',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'function useIS_COOL() { return 1; }',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'non-boolean-prefix',
+					data: {
+						name: 'IS_COOL',
+						prefix: 'is',
+					},
+				},
+			],
+		},
+		{
+			code: 'const useReady = () => true;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'ready',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'const useIsReady = () => true;',
+						},
+					],
+				},
+			],
+		},
+		typescript({
+			code: 'declare const useReady: () => boolean;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'ready',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'declare const useIsReady: () => boolean;',
+						},
+					],
+				},
+			],
+		}),
+		typescript({
+			code: 'type Hook = () => boolean; declare const useReady: Hook;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'ready',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'type Hook = () => boolean; declare const useIsReady: Hook;',
+						},
+					],
+				},
+			],
+		}),
+		typescript({
+			code: 'interface Hook {(): boolean;} declare const useReady: Hook;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'ready',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'interface Hook {(): boolean;} declare const useIsReady: Hook;',
+						},
+					],
+				},
+			],
+		}),
+		typescript({
+			code: 'declare function useIsCool(): number;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'non-boolean-prefix',
+					data: {
+						name: 'isCool',
+						prefix: 'is',
+					},
+				},
+			],
+		}),
+		typescript({
+			code: 'declare const useIsCool: (() => number) | undefined;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'non-boolean-prefix',
+					data: {
+						name: 'isCool',
+						prefix: 'is',
+					},
+				},
+			],
+		}),
+		{
+			code: 'const useIsReady = true;',
+			output: 'const isUseIsReady = true;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'useIsReady',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'const isUseIsReady = true;',
+						},
+					],
+				},
+			],
+		},
 		typescript({
 			code: 'declare const completed: boolean;',
 			options: [onlyIsPrefixOptions],
@@ -299,6 +536,22 @@ test.snapshot({
 		},
 		typescript('const completed: boolean | undefined = true;'),
 		typescript('type MaybeBoolean = boolean | undefined; const completed: MaybeBoolean = true;'),
+		'function useIsReady() { return true; }',
+		typescript('declare function useIsMyFlag(): boolean;'),
+		typescript('const useIsReady = () => true;'),
+		typescript('declare const useIsReady: () => boolean;'),
+		typescript('type Hook = () => boolean; declare const useIsReady: Hook;'),
+		typescript('interface Hook {(): boolean;} declare const useIsReady: Hook;'),
+		'function useIS_READY() { return true; }',
+		typescript('declare const useIsReady: (() => boolean) | undefined;'),
+		typescript('type Hook = (() => boolean) | undefined; declare const useIsReady: Hook;'),
+		typescript('declare const useReady: (() => boolean) | undefined;'),
+		typescript('type Hook = (() => boolean) | undefined; declare const useReady: Hook;'),
+		'function useCool() { return 1; }',
+		typescript('declare function useCool(): number;'),
+		typescript('declare const useCool: () => number;'),
+		typescript('type Hook = () => number; declare const useCool: Hook;'),
+		typescript('declare const useCool: (() => number) | undefined;'),
 	],
 	invalid: [
 		'const completed = true;',

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -278,7 +278,65 @@ test({
 			],
 		}),
 		typescript({
+			code: 'declare const useReady: {(): boolean};',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'consistent-boolean-name',
+					data: {
+						name: 'ready',
+						prefixes: '`is`',
+					},
+					suggestions: [
+						{
+							messageId: 'rename',
+							output: 'declare const useIsReady: {(): boolean};',
+						},
+					],
+				},
+			],
+		}),
+		typescript({
 			code: 'declare function useIsCool(): number;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'non-boolean-prefix',
+					data: {
+						name: 'isCool',
+						prefix: 'is',
+					},
+				},
+			],
+		}),
+		typescript({
+			code: 'declare const useIsCool: {(): number};',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'non-boolean-prefix',
+					data: {
+						name: 'isCool',
+						prefix: 'is',
+					},
+				},
+			],
+		}),
+		typescript({
+			code: 'type Hook = () => number; declare const useIsCool: Hook;',
+			options: [onlyIsPrefixOptions],
+			errors: [
+				{
+					messageId: 'non-boolean-prefix',
+					data: {
+						name: 'isCool',
+						prefix: 'is',
+					},
+				},
+			],
+		}),
+		typescript({
+			code: 'interface Hook {(): number;} declare const useIsCool: Hook;',
 			options: [onlyIsPrefixOptions],
 			errors: [
 				{
@@ -543,6 +601,7 @@ test.snapshot({
 		typescript('type Hook = () => boolean; declare const useIsReady: Hook;'),
 		typescript('interface Hook {(): boolean;} declare const useIsReady: Hook;'),
 		'function useIS_READY() { return true; }',
+		// Nullable function types are not treated as boolean-returning hooks.
 		typescript('declare const useIsReady: (() => boolean) | undefined;'),
 		typescript('type Hook = (() => boolean) | undefined; declare const useIsReady: Hook;'),
 		typescript('declare const useReady: (() => boolean) | undefined;'),


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3486