### PR TITLE
`isolated-functions`: Respect configured globals in isolated functions

### DIFF
--- a/docs/rules/isolated-functions.md
+++ b/docs/rules/isolated-functions.md
@@ -18,7 +18,7 @@ Common scenarios where functions must be isolated:
 - Server actions or other remote execution contexts
 - Functions with specific JSDoc annotations
 
-By default, this rule uses ESLint's language options globals and allows global variables (like `console`, `fetch`, etc.) in isolated functions, but prevents usage of variables from the surrounding scope.
+By default, this rule allows ESLint-resolved global variables from configuration or `/* global */` comments (like `console`, `fetch`, etc.) in isolated functions, but prevents usage of variables from the surrounding scope.
 
 ## Examples
 
@@ -142,9 +142,9 @@ Tagged comments also apply to object methods, object properties whose value is a
 ### overrideGlobals
 
 Type: `object`\
-Default: `undefined` (uses ESLint's language options globals)
+Default: `undefined` (uses ESLint-resolved globals from configuration or `/* global */` comments)
 
-Controls how global variables are handled. When not specified, uses ESLint's language options globals. When specified as an object, each key is a global variable name and the value controls its behavior:
+Controls how global variables are handled. When not specified, uses ESLint-resolved globals from configuration or `/* global */` comments. When specified as an object, each key is a global variable name and the value controls its behavior:
 
 - `'readonly'`: Global variable is allowed but cannot be written to
 - `'writable'`: Global variable is allowed and can be read/written
@@ -217,13 +217,13 @@ createLambda({
 });
 ```
 
-### Default behavior (using ESLint's language options)
+### Default behavior (using ESLint-resolved globals)
 
 ```js
-// Uses ESLint's language options globals by default
+// Uses ESLint-resolved globals by default
 makeSynchronous(async () => {
-	console.log('Starting...'); // ✅ Allowed if console is in language options
-	const response = await fetch('https://api.example.com'); // ✅ Allowed if fetch is in language options
+	console.log('Starting...'); // ✅ Allowed if console is configured as a global
+	const response = await fetch('https://api.example.com'); // ✅ Allowed if fetch is configured as a global
 	return response.text();
 });
 ```
@@ -278,22 +278,22 @@ makeSynchronous(async () => {
 To enable a predefined set of globals, use the [`globals` package](https://npmjs.com/package/globals) similarly to how you would use it in `languageOptions` (see [ESLint docs on globals](https://eslint.org/docs/latest/use/configure/language-options#predefined-global-variables)):
 
 ```js
-import globals from 'globals'
+import globals from 'globals';
 
 export default [
 	{
+		languageOptions: {
+			globals: {
+				...globals.builtin,
+				...globals.applescript,
+				...globals.greasemonkey,
+			},
+		},
 		rules: {
 			'unicorn/isolated-functions': [
 				'error',
-				{
-					globals: {
-						...globals.builtin,
-						...globals.applescript,
-						...globals.greasemonkey,
-					},
-				},
 			],
 		},
 	},
-]
+];
 ```

--- a/docs/rules/isolated-functions.md
+++ b/docs/rules/isolated-functions.md
@@ -11,18 +11,19 @@ Some functions need to be isolated from their surrounding scope due to execution
 
 Common scenarios where functions must be isolated:
 
-- Functions passed to `makeSynchronous()` (executed in worker)
+- Functions passed to `makeSynchronous()` (executed in a worker)
 - Functions passed to `workerize()`
 - Functions passed to `page.evaluate()` in Puppeteer or Playwright style code
 - Functions that will be serialized via `Function.prototype.toString()`
 - Server actions or other remote execution contexts
 - Functions with specific JSDoc annotations
 
-By default, this rule allows ES globals and ESLint-resolved global variables from configuration or `/* global */` comments (like `console`, `fetch`, etc.) in isolated functions, but prevents usage of variables from the surrounding scope.
+By default, this rule allows ES globals like `Array` and `Map`, and ESLint-resolved global variables from configuration or `/* global */` comments like `console` and `fetch`, in isolated functions, but prevents usage of variables from the surrounding scope.
 
 ## Examples
 
 ```js
+/* global fetch, console */
 import makeSynchronous from 'make-synchronous';
 
 const url = 'https://example.com';
@@ -109,7 +110,7 @@ Selectors must match the function node that should be treated as isolated. To is
 		{
 			selectors: [
 				'FunctionDeclaration[id.name=/lambdaHandler.*/]',
-				'CallExpression[callee.property.name=/CodemodeScript/] > :function'
+				'CallExpression[callee.property.name=/CodemodScript/] > :function'
 			]
 		}
 	]
@@ -146,8 +147,8 @@ Default: `{}`
 
 Overrides how specific global variables are handled. An empty object means no overrides; ES globals and ESLint-resolved globals from configuration or `/* global */` comments still apply. When specified as an object, each key is a global variable name and the value controls its behavior:
 
-- `false` or `'readonly'`: Global variable is allowed but cannot be written to
-- `true`, `'writable'`, or `'writeable'`: Global variable is allowed and can be read/written
+- `'readonly'`: Global variable is allowed but cannot be written to
+- `'writable'`: Global variable is allowed and can be read/written
 - `'off'`: Global variable is not allowed
 
 ```js
@@ -217,10 +218,11 @@ createLambda({
 });
 ```
 
-### Default behavior
+### Configured globals
 
 ```js
-// Uses ES globals and ESLint-resolved globals by default
+/* global console, fetch */
+
 makeSynchronous(async () => {
 	console.log('Starting...'); // ✅ Allowed if console is configured as a global
 	const response = await fetch('https://api.example.com'); // ✅ Allowed if fetch is configured as a global
@@ -248,7 +250,7 @@ makeSynchronous(async () => {
 ```
 
 ```js
-// ✅ All globals used are either default globals or explicitly overridden
+// ✅ All globals used are ES globals, ESLint-resolved globals, or explicitly overridden
 makeSynchronous(async () => {
 	console.log('Starting...'); // ✅ Allowed global
 	const response = await fetch('https://api.example.com'); // ✅ Allowed global

--- a/docs/rules/isolated-functions.md
+++ b/docs/rules/isolated-functions.md
@@ -18,7 +18,7 @@ Common scenarios where functions must be isolated:
 - Server actions or other remote execution contexts
 - Functions with specific JSDoc annotations
 
-By default, this rule allows ESLint-resolved global variables from configuration or `/* global */` comments (like `console`, `fetch`, etc.) in isolated functions, but prevents usage of variables from the surrounding scope.
+By default, this rule allows ES globals and ESLint-resolved global variables from configuration or `/* global */` comments (like `console`, `fetch`, etc.) in isolated functions, but prevents usage of variables from the surrounding scope.
 
 ## Examples
 
@@ -142,12 +142,12 @@ Tagged comments also apply to object methods, object properties whose value is a
 ### overrideGlobals
 
 Type: `object`\
-Default: `undefined` (uses ESLint-resolved globals from configuration or `/* global */` comments)
+Default: `{}`
 
-Controls how global variables are handled. When not specified, uses ESLint-resolved globals from configuration or `/* global */` comments. When specified as an object, each key is a global variable name and the value controls its behavior:
+Overrides how specific global variables are handled. An empty object means no overrides; ES globals and ESLint-resolved globals from configuration or `/* global */` comments still apply. When specified as an object, each key is a global variable name and the value controls its behavior:
 
-- `'readonly'`: Global variable is allowed but cannot be written to
-- `'writable'`: Global variable is allowed and can be read/written
+- `false` or `'readonly'`: Global variable is allowed but cannot be written to
+- `true`, `'writable'`, or `'writeable'`: Global variable is allowed and can be read/written
 - `'off'`: Global variable is not allowed
 
 ```js
@@ -217,10 +217,10 @@ createLambda({
 });
 ```
 
-### Default behavior (using ESLint-resolved globals)
+### Default behavior
 
 ```js
-// Uses ESLint-resolved globals by default
+// Uses ES globals and ESLint-resolved globals by default
 makeSynchronous(async () => {
 	console.log('Starting...'); // ✅ Allowed if console is configured as a global
 	const response = await fetch('https://api.example.com'); // ✅ Allowed if fetch is configured as a global
@@ -228,7 +228,9 @@ makeSynchronous(async () => {
 });
 ```
 
-### Allowing specific globals
+### Overriding specific globals
+
+`overrideGlobals` only overrides the listed names. It does not replace ES globals or ESLint-resolved globals from configuration or `/* global */` comments.
 
 ```js
 {
@@ -246,7 +248,7 @@ makeSynchronous(async () => {
 ```
 
 ```js
-// ✅ All globals used are explicitly allowed
+// ✅ All globals used are either default globals or explicitly overridden
 makeSynchronous(async () => {
 	console.log('Starting...'); // ✅ Allowed global
 	const response = await fetch('https://api.example.com'); // ✅ Allowed global
@@ -257,7 +259,7 @@ makeSynchronous(async () => {
 makeSynchronous(async () => {
 	const response = await fetch('https://api.example.com', {
 		headers: {
-			'Authorization': `Bearer ${process.env.API_TOKEN}` // ❌ 'process' is not in allowed globals
+			'Authorization': `Bearer ${process.env.API_TOKEN}` // ❌ 'process' is not configured as an ESLint global or overrideGlobals entry
 		}
 	});
 

--- a/rules/isolated-functions.js
+++ b/rules/isolated-functions.js
@@ -98,12 +98,56 @@ const create = context => {
 
 	options.comments = options.comments.map(comment => comment.toLowerCase());
 
-	const allowedGlobals = {
+	const configuredGlobals = {
 		...(globals[`es${context.languageOptions.ecmaVersion}`] ?? globals.builtins),
 		...context.languageOptions.globals,
-		...options.overrideGlobals,
 	};
 	const checked = new WeakSet();
+
+	const getAllowedGlobalValue = reference => {
+		const {identifier, resolved} = reference;
+		const {name} = identifier;
+
+		if (Object.hasOwn(options.overrideGlobals, name)) {
+			const overrideGlobalValue = options.overrideGlobals[name];
+
+			if (overrideGlobalValue === 'off') {
+				return 'off';
+			}
+
+			if (
+				resolved
+				&& (
+					resolved.scope.type !== 'global'
+					|| resolved.defs.length > 0
+				)
+			) {
+				return;
+			}
+
+			return overrideGlobalValue;
+		}
+
+		if (
+			Object.hasOwn(configuredGlobals, name)
+			&& configuredGlobals[name] === 'off'
+		) {
+			return 'off';
+		}
+
+		if (!sourceCode.isGlobalReference(identifier)) {
+			return;
+		}
+
+		if (
+			!Object.hasOwn(configuredGlobals, name)
+			&& !resolved?.eslintExplicitGlobal
+		) {
+			return;
+		}
+
+		return resolved?.writeable ? 'writable' : 'readonly';
+	};
 
 	function * getFunctionContextProblems(node, reason, root = node) {
 		const messageId = functionContextReferenceMessageIds.get(node.type);
@@ -173,18 +217,20 @@ const create = context => {
 				continue;
 			}
 
-			if (Object.hasOwn(allowedGlobals, identifier.name) && allowedGlobals[identifier.name] !== 'off') {
+			const allowedGlobalValue = getAllowedGlobalValue(reference);
+			let problemReason = reason;
+
+			if (allowedGlobalValue !== undefined && allowedGlobalValue !== 'off') {
 				if (reference.isReadOnly()) {
 					continue;
 				}
 
-				const globalsValue = allowedGlobals[identifier.name];
-				const isGlobalWritable = [true, 'writable', 'writeable'].includes(globalsValue);
+				const isGlobalWritable = [true, 'writable', 'writeable'].includes(allowedGlobalValue);
 				if (isGlobalWritable) {
 					continue;
 				}
 
-				reason += ' (global variable is not writable)';
+				problemReason += ' (global variable is not writable)';
 			}
 
 			// Could consider checking for typeof operator here, like in no-undef?
@@ -192,7 +238,7 @@ const create = context => {
 			context.report({
 				node: identifier,
 				messageId: MESSAGE_ID_EXTERNALLY_SCOPED_VARIABLE,
-				data: {name: identifier.name, reason},
+				data: {name: identifier.name, reason: problemReason},
 			});
 		}
 

--- a/rules/isolated-functions.js
+++ b/rules/isolated-functions.js
@@ -115,13 +115,7 @@ const create = context => {
 				return 'off';
 			}
 
-			if (
-				resolved
-				&& (
-					resolved.scope.type !== 'global'
-					|| resolved.defs.length > 0
-				)
-			) {
+			if (resolved && !sourceCode.isGlobalReference(identifier)) {
 				return;
 			}
 

--- a/test/isolated-functions.js
+++ b/test/isolated-functions.js
@@ -85,6 +85,24 @@ test({
 			`,
 		},
 		{
+			name: 'allow global variables from ESLint comments',
+			code: outdent`
+				/* global foo */
+				makeSynchronous(function () {
+					return foo.slice();
+				});
+			`,
+		},
+		{
+			name: 'allow writable global variables from ESLint comments',
+			code: outdent`
+				/* global foo:writable */
+				makeSynchronous(function () {
+					foo = 1;
+				});
+			`,
+		},
+		{
 			name: 'typescript types are allowed to be out-of-scope',
 			languageOptions: {
 				parser: parsers.typescript,
@@ -610,6 +628,88 @@ test({
 				});
 			`,
 			errors: [error({name: 'URL', reason: 'callee of function named "makeSynchronous"'})],
+		},
+		{
+			name: 'readonly global variables from ESLint comments cannot be written',
+			code: outdent`
+				/* global foo */
+				makeSynchronous(function () {
+					foo = 1;
+				});
+			`,
+			errors: [
+				error({
+					name: 'foo',
+					reason: 'callee of function named "makeSynchronous" (global variable is not writable)',
+				}),
+			],
+		},
+		{
+			name: 'disabled global variables from ESLint comments are disallowed',
+			code: outdent`
+				/* global foo:off */
+				makeSynchronous(function () {
+					return foo.slice();
+				});
+			`,
+			errors: [fooInMakeSynchronousError],
+		},
+		{
+			name: 'ESLint comment globals do not allow captured module variables',
+			code: outdent`
+				/* global foo */
+				const foo = 'hi';
+				makeSynchronous(function () {
+					return foo.slice();
+				});
+			`,
+			errors: [fooInMakeSynchronousError],
+		},
+		{
+			name: 'language option globals do not allow captured module variables',
+			languageOptions: {globals: {foo: true}},
+			code: outdent`
+				const foo = 'hi';
+				makeSynchronous(function () {
+					return foo.slice();
+				});
+			`,
+			errors: [fooInMakeSynchronousError],
+		},
+		{
+			name: 'override globals do not allow captured module variables',
+			options: [{overrideGlobals: {foo: true}}],
+			code: outdent`
+				const foo = 'hi';
+				makeSynchronous(function () {
+					return foo.slice();
+				});
+			`,
+			errors: [fooInMakeSynchronousError],
+		},
+		{
+			name: 'override globals do not allow captured script variables',
+			languageOptions: {sourceType: 'script'},
+			options: [{overrideGlobals: {foo: true}}],
+			code: outdent`
+				var foo = 'hi';
+				makeSynchronous(function () {
+					return foo.slice();
+				});
+			`,
+			errors: [fooInMakeSynchronousError],
+		},
+		{
+			name: 'override globals do not allow captured script functions',
+			languageOptions: {sourceType: 'script'},
+			options: [{overrideGlobals: {foo: true}}],
+			code: outdent`
+				function foo() {}
+				makeSynchronous(function () {
+					return foo();
+				});
+			`,
+			errors: [fooInMakeSynchronousError],
 		},
 		{
 			name: 'inherited object properties are not treated as globals',

--- a/test/isolated-functions.js
+++ b/test/isolated-functions.js
@@ -53,7 +53,7 @@ test({
 			`,
 		},
 		{
-			name: 'default global variables come from language options',
+			name: 'default configured globals are allowed',
 			code: 'makeSynchronous(() => process.env.MAP ? new Map() : new URL("https://example.com"))',
 		},
 		{
@@ -97,6 +97,15 @@ test({
 			name: 'allow writable global variables from ESLint comments',
 			code: outdent`
 				/* global foo:writable */
+				makeSynchronous(function () {
+					foo = 1;
+				});
+			`,
+		},
+		{
+			name: 'allow writable global variables from language options',
+			languageOptions: {globals: {foo: 'writable'}},
+			code: outdent`
 				makeSynchronous(function () {
 					foo = 1;
 				});
@@ -656,22 +665,22 @@ test({
 		{
 			name: 'disabled global variables from ESLint comments are disallowed',
 			code: outdent`
-				/* global foo:off */
+				/* global Array:off */
 				makeSynchronous(function () {
-					return foo.slice();
+					return new Array();
 				});
 			`,
-			errors: [fooInMakeSynchronousError],
+			errors: [error({name: 'Array', reason: 'callee of function named "makeSynchronous"'})],
 		},
 		{
 			name: 'disabled global variables from language options are disallowed',
-			languageOptions: {globals: {foo: 'off'}},
+			languageOptions: {globals: {Array: 'off'}},
 			code: outdent`
 				makeSynchronous(function () {
-					return foo.slice();
+					return new Array();
 				});
 			`,
-			errors: [fooInMakeSynchronousError],
+			errors: [error({name: 'Array', reason: 'callee of function named "makeSynchronous"'})],
 		},
 		{
 			name: 'override globals take precedence over ESLint comments',

--- a/test/isolated-functions.js
+++ b/test/isolated-functions.js
@@ -103,6 +103,15 @@ test({
 			`,
 		},
 		{
+			name: 'override globals can allow writable globals',
+			options: [{overrideGlobals: {foo: 'writable'}}],
+			code: outdent`
+				makeSynchronous(function () {
+					foo = 1;
+				});
+			`,
+		},
+		{
 			name: 'typescript types are allowed to be out-of-scope',
 			languageOptions: {
 				parser: parsers.typescript,
@@ -653,6 +662,32 @@ test({
 				});
 			`,
 			errors: [fooInMakeSynchronousError],
+		},
+		{
+			name: 'disabled global variables from language options are disallowed',
+			languageOptions: {globals: {foo: 'off'}},
+			code: outdent`
+				makeSynchronous(function () {
+					return foo.slice();
+				});
+			`,
+			errors: [fooInMakeSynchronousError],
+		},
+		{
+			name: 'override globals take precedence over ESLint comments',
+			options: [{overrideGlobals: {foo: 'readonly'}}],
+			code: outdent`
+				/* global foo:writable */
+				makeSynchronous(function () {
+					foo = 1;
+				});
+			`,
+			errors: [
+				error({
+					name: 'foo',
+					reason: 'callee of function named "makeSynchronous" (global variable is not writable)',
+				}),
+			],
 		},
 		{
 			name: 'ESLint comment globals do not allow captured module variables',


### PR DESCRIPTION
Fixes #3492