### PR TITLE
`consistent-boolean-name`: Allow boolean-like React refs with `Ref` suffix

### DIFF
--- a/docs/rules/consistent-boolean-name.md
+++ b/docs/rules/consistent-boolean-name.md
@@ -37,6 +37,8 @@ The prefix must be a distinct word part. `isReady`, `is_ready`, and `IS_READY` a
 
 React hook function bindings are checked after the required `use` prefix. For example, `useIsReady` is treated as a boolean hook name, while `useReady` is not. `ignore` patterns still match the original source name, like `useReady`.
 
+React refs initialized with a boolean value may use boolean prefixes when the binding name ends in `Ref` or `Reference`, such as `isMountedRef`, `hasConsentRef`, or `hasConsentReference`. The suffix identifies the binding as a ref object.
+
 This rule intentionally does not check destructuring bindings, imports, class names, or catch parameters.
 
 TypeScript type annotation checks resolve local type aliases and callable interfaces, but not qualified or namespaced type references.

--- a/docs/rules/consistent-boolean-name.md
+++ b/docs/rules/consistent-boolean-name.md
@@ -37,7 +37,7 @@ The prefix must be a distinct word part. `isReady`, `is_ready`, and `IS_READY` a
 
 React hook function bindings are checked after the required `use` prefix. For example, `useIsReady` is treated as a boolean hook name, while `useReady` is not. `ignore` patterns still match the original source name, like `useReady`.
 
-React refs initialized with a boolean value may use boolean prefixes when the binding name ends in `Ref` or `Reference`, such as `isMountedRef`, `hasConsentRef`, or `hasConsentReference`. The suffix identifies the binding as a ref object.
+React refs initialized with a boolean-like value may use boolean prefixes when the binding name ends in `Ref` or `Reference`, such as `isMountedRef`, `hasConsentRef`, or `hasConsentReference`. The suffix identifies the binding as a ref object.
 
 This rule intentionally does not check destructuring bindings, imports, class names, or catch parameters.
 

--- a/rules/consistent-boolean-name.js
+++ b/rules/consistent-boolean-name.js
@@ -102,6 +102,7 @@ const typeScriptExpressionWrapperTypes = new Set([
 const isUpperCase = string => string === string.toUpperCase();
 const stripLeadingUnderscores = name => name.replace(/^_+/, '');
 const isScreamingCase = name => /^[A-Z][\dA-Z_]*$/.test(stripLeadingUnderscores(name));
+const hasReactRefSuffix = name => /(?:Ref|Reference)$/.test(stripLeadingUnderscores(name));
 
 const isFunction = node => [
 	'ArrowFunctionExpression',
@@ -256,6 +257,9 @@ const isDestructuredVariable = variable =>
 	variable.defs.length > 0
 	&& variable.defs.every(definition => isDestructuredDefinition(definition));
 
+const hasWriteAfterInitialization = variable =>
+	variable.references.some(reference => !reference.init && reference.isWrite());
+
 const isBooleanFunctionDefinition = (definition, context) =>
 	definition.type === 'FunctionName'
 	&& isFunction(definition.node)
@@ -330,6 +334,35 @@ function getNameForPrefixCheck(variable, context) {
 	const hookName = variable.name.slice(3);
 
 	return isScreamingCase(hookName) ? hookName : lowerFirst(hookName);
+}
+
+function isReactUseRefCall(node) {
+	if (node?.type !== 'CallExpression') {
+		return false;
+	}
+
+	const {callee} = node;
+	if (callee.type === 'Identifier') {
+		return callee.name === 'useRef';
+	}
+
+	return callee.type === 'MemberExpression'
+		&& !callee.computed
+		&& !callee.optional
+		&& callee.object.type === 'Identifier'
+		&& callee.object.name === 'React'
+		&& callee.property.type === 'Identifier'
+		&& callee.property.name === 'useRef';
+}
+
+function isBooleanReactRefVariable(variable, context) {
+	const definition = getSupportedVariableDefinition(variable);
+
+	return definition?.type === 'Variable'
+		&& !hasWriteAfterInitialization(variable)
+		&& hasReactRefSuffix(variable.name)
+		&& isReactUseRefCall(definition.node.init)
+		&& getExpressionBooleanState(definition.node.init.arguments[0], context) === boolean;
 }
 
 function combineBooleanStates(states) {
@@ -1062,7 +1095,10 @@ const create = context => {
 		const nameForPrefixCheck = getNameForPrefixCheck(variable, context);
 		const booleanPrefix = getBooleanPrefix(nameForPrefixCheck, prefixes);
 		if (booleanPrefix) {
-			if (getVariableBooleanState(variable, context) === nonBoolean) {
+			if (
+				getVariableBooleanState(variable, context) === nonBoolean
+				&& !isBooleanReactRefVariable(variable, context)
+			) {
 				const [definition] = variable.defs;
 
 				context.report({

--- a/rules/consistent-boolean-name.js
+++ b/rules/consistent-boolean-name.js
@@ -102,7 +102,7 @@ const typeScriptExpressionWrapperTypes = new Set([
 const isUpperCase = string => string === string.toUpperCase();
 const stripLeadingUnderscores = name => name.replace(/^_+/, '');
 const isScreamingCase = name => /^[A-Z][\dA-Z_]*$/.test(stripLeadingUnderscores(name));
-const hasReactRefSuffix = name => /(?:Ref|Reference)$/.test(stripLeadingUnderscores(name));
+const hasReactReferenceSuffix = name => /(?:Ref|Reference)$/.test(stripLeadingUnderscores(name));
 
 const isFunction = node => [
 	'ArrowFunctionExpression',
@@ -336,7 +336,7 @@ function getNameForPrefixCheck(variable, context) {
 	return isScreamingCase(hookName) ? hookName : lowerFirst(hookName);
 }
 
-function isReactUseRefCall(node) {
+function isReactUseReferenceCall(node) {
 	if (node?.type !== 'CallExpression') {
 		return false;
 	}
@@ -355,13 +355,13 @@ function isReactUseRefCall(node) {
 		&& callee.property.name === 'useRef';
 }
 
-function isBooleanReactRefVariable(variable, context) {
+function isBooleanReactReferenceVariable(variable, context) {
 	const definition = getSupportedVariableDefinition(variable);
 
 	return definition?.type === 'Variable'
 		&& !hasWriteAfterInitialization(variable)
-		&& hasReactRefSuffix(variable.name)
-		&& isReactUseRefCall(definition.node.init)
+		&& hasReactReferenceSuffix(variable.name)
+		&& isReactUseReferenceCall(definition.node.init)
 		&& getExpressionBooleanState(definition.node.init.arguments[0], context) === boolean;
 }
 
@@ -1097,7 +1097,7 @@ const create = context => {
 		if (booleanPrefix) {
 			if (
 				getVariableBooleanState(variable, context) === nonBoolean
-				&& !isBooleanReactRefVariable(variable, context)
+				&& !isBooleanReactReferenceVariable(variable, context)
 			) {
 				const [definition] = variable.defs;
 

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -109,6 +109,18 @@ test({
 				},
 			],
 		}),
+		typeAware({
+			code: 'declare function useRef<T>(value: T): {current: T}; const hasConsentRef = useRef("no");',
+			errors: [{messageId: 'non-boolean-prefix'}],
+		}),
+		typeAware({
+			code: 'declare function useRef<T>(value: T): {current: T}; const hasConsent = useRef(false);',
+			errors: [{messageId: 'non-boolean-prefix'}],
+		}),
+		typeAware({
+			code: 'declare function useRef<T>(value: T): {current: T}; let hasConsentRef = useRef(false); hasConsentRef = "yes";',
+			errors: [{messageId: 'non-boolean-prefix'}],
+		}),
 		{
 			code: 'function useReady() { return true; }',
 			options: [onlyIsPrefixOptions],
@@ -597,6 +609,10 @@ test.snapshot({
 		},
 		typescript('const completed: boolean | undefined = true;'),
 		typescript('type MaybeBoolean = boolean | undefined; const completed: MaybeBoolean = true;'),
+		'const consentRef = useRef(false);',
+		typeAware('declare function useRef<T>(value: T): {current: T}; const hasConsentRef = useRef(false);'),
+		typeAware('declare function useRef<T>(value: T): {current: T}; const hasConsentReference = useRef(false);'),
+		typeAware('declare const React: {useRef<T>(value: T): {current: T}}; const isMountedRef = React.useRef(false);'),
 		'function useIsReady() { return true; }',
 		typescript('declare function useIsMyFlag(): boolean;'),
 		typescript('const useIsReady = () => true;'),

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -609,7 +609,7 @@ test.snapshot({
 		},
 		typescript('const completed: boolean | undefined = true;'),
 		typescript('type MaybeBoolean = boolean | undefined; const completed: MaybeBoolean = true;'),
-		'const consentRef = useRef(false);',
+		typeAware('declare function useRef<T>(value: T): {current: T}; const consentRef = useRef(false);'),
 		typeAware('declare function useRef<T>(value: T): {current: T}; const hasConsentRef = useRef(false);'),
 		typeAware('declare function useRef<T>(value: T): {current: T}; const hasConsentReference = useRef(false);'),
 		typeAware('declare const React: {useRef<T>(value: T): {current: T}}; const isMountedRef = React.useRef(false);'),


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/pull/3487#issuecomment-4888959504