### PR TITLE
`no-useless-promise-resolve-reject`: Handle `await`ed calls

### DIFF
--- a/rules/no-useless-promise-resolve-reject.js
+++ b/rules/no-useless-promise-resolve-reject.js
@@ -1,4 +1,4 @@
-import {getParenthesizedRange, shouldAddParenthesesToAwaitExpressionArgument} from './utils/index.js';
+import {getParenthesizedRange, shouldAddParenthesesToAwaitExpressionArgument, wouldRemoveComments} from './utils/index.js';
 import {isFunction, isMethodCall} from './ast/index.js';
 
 const MESSAGE_ID_RESOLVE = 'resolve';
@@ -116,6 +116,29 @@ function getAwaitedResolveArgumentText(node, context) {
 	return text;
 }
 
+function getFixTarget({
+	callExpression,
+	parent,
+	expression,
+	isAwaited,
+	isReject,
+	context,
+}) {
+	if (isAwaited && !isReject) {
+		return getParenthesizedRange(callExpression, context);
+	}
+
+	if (isReject && parent.type === 'YieldExpression') {
+		return getParenthesizedRange(parent, context);
+	}
+
+	if (parent.type === 'ArrowFunctionExpression') {
+		return isReject ? getParenthesizedRange(expression, context) : callExpression;
+	}
+
+	return parent;
+}
+
 function fix(callExpression, isInTryStatement, context) {
 	if (callExpression.arguments.length > 1) {
 		return;
@@ -129,10 +152,6 @@ function fix(callExpression, isInTryStatement, context) {
 		return;
 	}
 
-	if (context.sourceCode.getCommentsInside(callExpression).length > 0) {
-		return;
-	}
-
 	const isReject = callee.property.name === 'reject';
 	const isYieldExpression = parent.type === 'YieldExpression';
 	if (
@@ -142,6 +161,18 @@ function fix(callExpression, isInTryStatement, context) {
 			|| (isYieldExpression && parent.parent.type !== 'ExpressionStatement')
 		)
 	) {
+		return;
+	}
+
+	const fixTarget = getFixTarget({
+		callExpression,
+		parent,
+		expression,
+		isAwaited,
+		isReject,
+		context,
+	});
+	if (wouldRemoveComments(context, fixTarget, errorOrValue ? [errorOrValue] : [])) {
 		return;
 	}
 

--- a/rules/no-useless-promise-resolve-reject.js
+++ b/rules/no-useless-promise-resolve-reject.js
@@ -1,4 +1,4 @@
-import {getParenthesizedRange} from './utils/index.js';
+import {getParenthesizedRange, shouldAddParenthesesToAwaitExpressionArgument} from './utils/index.js';
 import {isFunction, isMethodCall} from './ast/index.js';
 
 const MESSAGE_ID_RESOLVE = 'resolve';
@@ -64,9 +64,29 @@ function isPromiseCallback(node) {
 	return false;
 }
 
+function getCallExpressionInfo(callExpression) {
+	if (
+		callExpression.parent.type === 'AwaitExpression'
+		&& callExpression.parent.argument === callExpression
+	) {
+		return {
+			expression: callExpression.parent,
+			parent: callExpression.parent.parent,
+			isAwaited: true,
+		};
+	}
+
+	return {
+		expression: callExpression,
+		parent: callExpression.parent,
+		isAwaited: false,
+	};
+}
+
 function createProblem(callExpression, fix) {
-	const {callee, parent} = callExpression;
+	const {callee} = callExpression;
 	const method = callee.property.name;
+	const {parent} = getCallExpressionInfo(callExpression);
 	const type = parent.type === 'YieldExpression' ? 'yield' : 'return';
 
 	return {
@@ -77,15 +97,39 @@ function createProblem(callExpression, fix) {
 	};
 }
 
+function getArgumentText(node, context) {
+	const text = node ? context.sourceCode.getText(node) : '';
+	return node?.type === 'SequenceExpression' ? `(${text})` : text;
+}
+
+function getAwaitedResolveArgumentText(node, context) {
+	const text = getArgumentText(node, context) || 'undefined';
+
+	if (
+		node
+		&& node.type !== 'SequenceExpression'
+		&& shouldAddParenthesesToAwaitExpressionArgument(node)
+	) {
+		return `(${text})`;
+	}
+
+	return text;
+}
+
 function fix(callExpression, isInTryStatement, context) {
 	if (callExpression.arguments.length > 1) {
 		return;
 	}
 
-	const {callee, parent, arguments: callArguments} = callExpression;
+	const {callee, arguments: callArguments} = callExpression;
+	const {expression, parent, isAwaited} = getCallExpressionInfo(callExpression);
 	const [errorOrValue] = callArguments;
 
 	if (errorOrValue?.type === 'SpreadElement') {
+		return;
+	}
+
+	if (context.sourceCode.getCommentsInside(callExpression).length > 0) {
 		return;
 	}
 
@@ -104,11 +148,7 @@ function fix(callExpression, isInTryStatement, context) {
 	return function (fixer) {
 		const isArrowFunctionBody = parent.type === 'ArrowFunctionExpression';
 
-		let text = errorOrValue ? context.sourceCode.getText(errorOrValue) : '';
-
-		if (errorOrValue?.type === 'SequenceExpression') {
-			text = `(${text})`;
-		}
+		let text = getArgumentText(errorOrValue, context);
 
 		if (isReject) {
 			// `return Promise.reject()` -> `throw undefined`
@@ -128,12 +168,18 @@ function fix(callExpression, isInTryStatement, context) {
 			if (isArrowFunctionBody) {
 				text = `{ ${text} }`;
 				return fixer.replaceTextRange(
-					getParenthesizedRange(callExpression, context),
+					getParenthesizedRange(expression, context),
 					text,
 				);
 			}
 		} else {
-			// eslint-disable-next-line no-lonely-if
+			if (isAwaited) {
+				return fixer.replaceTextRange(
+					getParenthesizedRange(callExpression, context),
+					getAwaitedResolveArgumentText(errorOrValue, context),
+				);
+			}
+
 			if (isYieldExpression) {
 				text = `yield${text ? ' ' : ''}${text}`;
 			} else if (parent.type === 'ReturnStatement') {
@@ -158,6 +204,8 @@ function fix(callExpression, isInTryStatement, context) {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	context.on('CallExpression', callExpression => {
+		const {expression, parent} = getCallExpressionInfo(callExpression);
+
 		if (!(
 			isMethodCall(callExpression, {
 				object: 'Promise',
@@ -167,16 +215,16 @@ const create = context => {
 			})
 			&& (
 				(
-					callExpression.parent.type === 'ArrowFunctionExpression'
-					&& callExpression.parent.body === callExpression
+					parent.type === 'ArrowFunctionExpression'
+					&& parent.body === expression
 				)
 				|| (
-					callExpression.parent.type === 'ReturnStatement'
-					&& callExpression.parent.argument === callExpression
+					parent.type === 'ReturnStatement'
+					&& parent.argument === expression
 				)
 				|| (
-					callExpression.parent.type === 'YieldExpression'
-					&& !callExpression.parent.delegate && callExpression.parent.argument === callExpression
+					parent.type === 'YieldExpression'
+					&& !parent.delegate && parent.argument === expression
 				)
 			)
 		)) {

--- a/test/no-useless-promise-resolve-reject.js
+++ b/test/no-useless-promise-resolve-reject.js
@@ -71,6 +71,7 @@ test({
 				}
 			}
 		`,
+		// Awaited calls that are not returned/yielded
 		outdent`
 			async function foo() {
 				const value = await Promise.resolve(bar);

--- a/test/no-useless-promise-resolve-reject.js
+++ b/test/no-useless-promise-resolve-reject.js
@@ -1,5 +1,5 @@
 import outdent from 'outdent';
-import {getTester} from './utils/test.js';
+import {getTester, parsers} from './utils/test.js';
 
 const {test} = getTester(import.meta);
 
@@ -69,6 +69,16 @@ test({
 				function bar() {
 					return Promise.resolve(baz);
 				}
+			}
+		`,
+		outdent`
+			async function foo() {
+				const value = await Promise.resolve(bar);
+			}
+		`,
+		outdent`
+			async function foo() {
+				await Promise.reject(error);
 			}
 		`,
 		// Delegate yield expressions
@@ -173,6 +183,20 @@ test({
 			code: 'async () => await Promise.resolve(foo + bar)',
 			errors: [returnResolveError],
 			output: 'async () => await (foo + bar)',
+		},
+		{
+			code: outdent`
+				async function foo(): Promise<number> {
+					return await Promise.resolve(42);
+				}
+			`,
+			languageOptions: {parser: parsers.typescript},
+			errors: [returnResolveError],
+			output: outdent`
+				async function foo(): Promise<number> {
+					return await 42;
+				}
+			`,
 		},
 		{
 			code: outdent`
@@ -577,6 +601,16 @@ test({
 			`,
 			errors: [returnRejectError],
 		},
+		{
+			code: outdent`
+				async function foo() {
+					try {
+						return await Promise.reject(error);
+					} catch {}
+				}
+			`,
+			errors: [returnRejectError],
+		},
 		// Spread arguments
 		{
 			code: 'async () => Promise.resolve(...bar);',
@@ -659,26 +693,26 @@ test({
 				output: `promise.${method}(() => { return bar; })`,
 			},
 			{
-				code: `promise.${method}(async () => await Promise.resolve(foo + bar))`,
-				errors: [returnResolveError],
-				output: `promise.${method}(async () => await (foo + bar))`,
+				code: `promise.${method}(() => Promise.reject(bar))`,
+				errors: [returnRejectError],
+				output: `promise.${method}(() => { throw bar; })`,
 			},
 			{
-				code: `promise.${method}(async () => Promise.reject(bar))`,
+				code: `promise.${method}(() => { return Promise.reject(bar); })`,
 				errors: [returnRejectError],
-				output: `promise.${method}(async () => { throw bar; })`,
-			},
-			{
-				code: `promise.${method}(async () => await Promise.reject(bar))`,
-				errors: [returnRejectError],
-				output: `promise.${method}(async () => { throw bar; })`,
-			},
-			{
-				code: `promise.${method}(async () => { return Promise.reject(bar); })`,
-				errors: [returnRejectError],
-				output: `promise.${method}(async () => { throw bar; })`,
+				output: `promise.${method}(() => { throw bar; })`,
 			},
 		]),
+		{
+			code: 'promise.then(async () => await Promise.resolve(foo + bar))',
+			errors: [returnResolveError],
+			output: 'promise.then(async () => await (foo + bar))',
+		},
+		{
+			code: 'promise.catch(async () => await Promise.reject(bar))',
+			errors: [returnRejectError],
+			output: 'promise.catch(async () => { throw bar; })',
+		},
 		{
 			code: 'promise.then(() => {}, () => Promise.resolve(bar))',
 			errors: [returnResolveError],
@@ -695,14 +729,14 @@ test({
 			output: 'promise.then(() => {}, () => { return bar; })',
 		},
 		{
-			code: 'promise.then(() => {}, async () => Promise.reject(bar))',
+			code: 'promise.then(() => {}, () => Promise.reject(bar))',
 			errors: [returnRejectError],
-			output: 'promise.then(() => {}, async () => { throw bar; })',
+			output: 'promise.then(() => {}, () => { throw bar; })',
 		},
 		{
-			code: 'promise.then(() => {}, async () => { return Promise.reject(bar); })',
+			code: 'promise.then(() => {}, () => { return Promise.reject(bar); })',
 			errors: [returnRejectError],
-			output: 'promise.then(() => {}, async () => { throw bar; })',
+			output: 'promise.then(() => {}, () => { throw bar; })',
 		},
 	],
 });

--- a/test/no-useless-promise-resolve-reject.js
+++ b/test/no-useless-promise-resolve-reject.js
@@ -32,7 +32,7 @@ test({
 			`,
 		]),
 		// Sync function returning Promise.resolve/reject
-		...['resolve, reject'].flatMap(method => [
+		...['resolve', 'reject'].flatMap(method => [
 			`() => Promise.${method}(bar);`,
 			outdent`
 				() => {
@@ -161,6 +161,15 @@ test({
 			errors: [returnResolveError],
 		},
 		{
+			code: 'async () => await (Promise.resolve(foo) /* keep */)',
+			errors: [returnResolveError],
+		},
+		{
+			code: 'async () => await /* keep */ Promise.resolve(foo)',
+			errors: [returnResolveError],
+			output: 'async () => await /* keep */ foo',
+		},
+		{
 			code: 'async () => await Promise.resolve(foo + bar)',
 			errors: [returnResolveError],
 			output: 'async () => await (foo + bar)',
@@ -250,9 +259,30 @@ test({
 			`,
 		},
 		{
+			code: 'async () => await Promise.reject(error)',
+			errors: [returnRejectError],
+			output: 'async () => { throw error; }',
+		},
+		{
 			code: outdent`
 				async function foo() {
 					return await Promise.reject(/* keep */ error);
+				}
+			`,
+			errors: [returnRejectError],
+		},
+		{
+			code: 'async () => await /* keep */ Promise.reject(error)',
+			errors: [returnRejectError],
+		},
+		{
+			code: 'async () => (await Promise.reject(error) /* keep */)',
+			errors: [returnRejectError],
+		},
+		{
+			code: outdent`
+				async function foo() {
+					return /* keep */ await Promise.reject(error);
 				}
 			`,
 			errors: [returnRejectError],
@@ -323,6 +353,19 @@ test({
 				});
 			`,
 		},
+		{
+			code: outdent`
+				async function * foo() {
+					yield await Promise.resolve(foo + bar);
+				}
+			`,
+			errors: [yieldResolveError],
+			output: outdent`
+				async function * foo() {
+					yield await (foo + bar);
+				}
+			`,
+		},
 		// Async generator yielding Promise.reject
 		{
 			code: outdent`
@@ -350,6 +393,43 @@ test({
 				});
 			`,
 		},
+		{
+			code: outdent`
+				async function * foo() {
+					yield await Promise.reject(error);
+				}
+			`,
+			errors: [yieldRejectError],
+			output: outdent`
+				async function * foo() {
+					throw error;
+				}
+			`,
+		},
+		{
+			code: outdent`
+				async function * foo() {
+					yield /* keep */ Promise.reject(error);
+				}
+			`,
+			errors: [yieldRejectError],
+		},
+		{
+			code: outdent`
+				async function * foo() {
+					(yield Promise.reject(error) /* keep */);
+				}
+			`,
+			errors: [yieldRejectError],
+		},
+		{
+			code: outdent`
+				async function * foo() {
+					(/* keep */ yield Promise.reject(error));
+				}
+			`,
+			errors: [yieldRejectError],
+		},
 		// No arguments
 		{
 			code: 'async () => Promise.resolve();',
@@ -360,6 +440,11 @@ test({
 			code: 'async () => await Promise.resolve();',
 			errors: [returnResolveError],
 			output: 'async () => await undefined;',
+		},
+		{
+			code: 'async () => await Promise.reject();',
+			errors: [returnRejectError],
+			output: 'async () => { throw undefined; };',
 		},
 		{
 			code: outdent`
@@ -417,6 +502,10 @@ test({
 		{
 			code: 'async () => await Promise.resolve(bar, baz);',
 			errors: [returnResolveError],
+		},
+		{
+			code: 'async () => await Promise.reject(bar, baz);',
+			errors: [returnRejectError],
 		},
 		// Sequence expressions
 		{
@@ -498,6 +587,10 @@ test({
 			errors: [returnResolveError],
 		},
 		{
+			code: 'async () => await Promise.reject(...bar);',
+			errors: [returnRejectError],
+		},
+		{
 			code: 'async () => Promise.reject(...bar);',
 			errors: [returnRejectError],
 		},
@@ -566,7 +659,17 @@ test({
 				output: `promise.${method}(() => { return bar; })`,
 			},
 			{
+				code: `promise.${method}(async () => await Promise.resolve(foo + bar))`,
+				errors: [returnResolveError],
+				output: `promise.${method}(async () => await (foo + bar))`,
+			},
+			{
 				code: `promise.${method}(async () => Promise.reject(bar))`,
+				errors: [returnRejectError],
+				output: `promise.${method}(async () => { throw bar; })`,
+			},
+			{
+				code: `promise.${method}(async () => await Promise.reject(bar))`,
 				errors: [returnRejectError],
 				output: `promise.${method}(async () => { throw bar; })`,
 			},

--- a/test/no-useless-promise-resolve-reject.js
+++ b/test/no-useless-promise-resolve-reject.js
@@ -141,6 +141,32 @@ test({
 		},
 		{
 			code: outdent`
+				async function foo() {
+					return await Promise.resolve(foo());
+				}
+			`,
+			errors: [returnResolveError],
+			output: outdent`
+				async function foo() {
+					return await foo();
+				}
+			`,
+		},
+		{
+			code: outdent`
+				async function foo() {
+					return await Promise.resolve(/* keep */ foo());
+				}
+			`,
+			errors: [returnResolveError],
+		},
+		{
+			code: 'async () => await Promise.resolve(foo + bar)',
+			errors: [returnResolveError],
+			output: 'async () => await (foo + bar)',
+		},
+		{
+			code: outdent`
 				(async function() {
 					return Promise.resolve(bar);
 				});
@@ -209,6 +235,27 @@ test({
 					throw bar;
 				}
 			`,
+		},
+		{
+			code: outdent`
+				async function foo() {
+					return await Promise.reject(error);
+				}
+			`,
+			errors: [returnRejectError],
+			output: outdent`
+				async function foo() {
+					throw error;
+				}
+			`,
+		},
+		{
+			code: outdent`
+				async function foo() {
+					return await Promise.reject(/* keep */ error);
+				}
+			`,
+			errors: [returnRejectError],
 		},
 		{
 			code: outdent`
@@ -310,6 +357,11 @@ test({
 			output: 'async () => {};',
 		},
 		{
+			code: 'async () => await Promise.resolve();',
+			errors: [returnResolveError],
+			output: 'async () => await undefined;',
+		},
+		{
 			code: outdent`
 				async function foo() {
 					return Promise.resolve();
@@ -362,6 +414,10 @@ test({
 			code: 'async () => Promise.reject(bar, baz);',
 			errors: [returnRejectError],
 		},
+		{
+			code: 'async () => await Promise.resolve(bar, baz);',
+			errors: [returnResolveError],
+		},
 		// Sequence expressions
 		{
 			code: outdent`
@@ -409,6 +465,23 @@ test({
 			code: outdent`
 				async function foo() {
 					try {
+						return await Promise.resolve(bar);
+					} catch {}
+				}
+			`,
+			errors: [returnResolveError],
+			output: outdent`
+				async function foo() {
+					try {
+						return await bar;
+					} catch {}
+				}
+			`,
+		},
+		{
+			code: outdent`
+				async function foo() {
+					try {
 						return Promise.reject(1);
 					} catch {}
 				}
@@ -418,6 +491,10 @@ test({
 		// Spread arguments
 		{
 			code: 'async () => Promise.resolve(...bar);',
+			errors: [returnResolveError],
+		},
+		{
+			code: 'async () => await Promise.resolve(...bar);',
 			errors: [returnResolveError],
 		},
 		{


### PR DESCRIPTION
Fixes #3503