### PR TITLE
Speed up CI integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,6 @@ jobs:
           - "6"
           - "7"
           - "8"
-          - "9"
     env:
       TIMING: 1
     runs-on: ubuntu-latest

--- a/test/integration/projects.js
+++ b/test/integration/projects.js
@@ -263,24 +263,6 @@ export default [
 			'tests/**',
 		],
 	},
-	{
-		repository: 'https://github.com/microsoft/vscode',
-		ignore: [
-			// Cannot parse `'\033'`
-			'build/**',
-			// Global return
-			'extensions/vscode-colorize-tests/test/colorize-fixtures/test6916.js',
-			'scripts/xterm-update.js',
-			// Invalid syntax
-			'src/vs/platform/files/test/node/fixtures/**',
-			'src/vs/workbench/services/search/test/node/fixtures/examples/**',
-			'extensions/vscode-colorize-perf-tests/test/**',
-			'extensions/copilot/**/fixtures/**',
-			'extensions/copilot/test/scenarios/**',
-			// Uses `/* eslint-env */`
-			'test/unit/electron/renderer.js',
-		],
-	},
 ].flatMap((projectOrProjects, index) =>
 	Array.isArray(projectOrProjects)
 		? projectOrProjects.map(project => ({...normalizeProject(project), group: index}))


### PR DESCRIPTION
Linting VSCode is just way too slow. Sometimes it takes hours. Sometimes it never finishes.