### PR TITLE
`prefer-simple-condition-first`: Treat `== null` checks as simple

### DIFF
--- a/docs/rules/prefer-simple-condition-first.md
+++ b/docs/rules/prefer-simple-condition-first.md
@@ -16,6 +16,7 @@ A condition is considered "simple" if it is:
 - A bare identifier (`foo`)
 - A negated simple condition (`!foo`)
 - A strict equality or inequality comparison between identifiers, `typeof identifier`, literals, signed number literals, and negative BigInt literals, with at least one identifier or `typeof identifier` (`foo === 1`, `a !== b`, `index === -1`, `typeof value === 'string'`)
+- A loose equality or inequality comparison between an identifier and `null`, in either operand order (`foo == null`, `null != foo`)
 
 The rule checks each complete chain of the same logical operator and reports it once when a simple condition follows a complex condition. Conditions are reordered as a stable group, preserving the relative order among both the simple and complex conditions.
 

--- a/rules/prefer-simple-condition-first.js
+++ b/rules/prefer-simple-condition-first.js
@@ -1,4 +1,5 @@
 import {isCommentToken} from '@eslint-community/eslint-utils';
+import {isNullLiteral} from './ast/index.js';
 import {
 	isParenthesized,
 	getParenthesizedText,
@@ -68,13 +69,21 @@ function isSimple(node) {
 		return isSimple(node.argument);
 	}
 
-	if (
-		node.type === 'BinaryExpression'
-		&& (node.operator === '===' || node.operator === '!==')
-	) {
+	if (node.type === 'BinaryExpression') {
 		const left = unwrapTypeScriptExpression(node.left);
 		const right = unwrapTypeScriptExpression(node.right);
+		if (
+			(node.operator === '==' || node.operator === '!=')
+			&& (
+				(left.type === 'Identifier' && isNullLiteral(right))
+				|| (isNullLiteral(left) && right.type === 'Identifier')
+			)
+		) {
+			return true;
+		}
+
 		return isSimpleOperand(left) && isSimpleOperand(right)
+			&& (node.operator === '===' || node.operator === '!==')
 			&& (isIdentifierOrTypeofIdentifier(left) || isIdentifierOrTypeofIdentifier(right));
 	}
 

--- a/test/prefer-simple-condition-first.js
+++ b/test/prefer-simple-condition-first.js
@@ -27,6 +27,7 @@ test({
 		'if (value != null && ready);',
 		'if (null == value && ready);',
 		'if (null != value && ready);',
+		'if (!(value == null) && ready);',
 		'if (first() && second());',
 
 		// A single condition has no ordering to enforce
@@ -98,6 +99,11 @@ test({
 		{
 			code: 'if ((foo ? bar : baz) || value == null);',
 			output: 'if ((value == null) || (foo ? bar : baz));',
+			errors: [error],
+		},
+		{
+			code: 'if ((foo ? bar : baz) && !(value == null));',
+			output: 'if (!(value == null) && (foo ? bar : baz));',
 			errors: [error],
 		},
 
@@ -204,6 +210,8 @@ test({
 		{code: 'if (check() || ready);', errors: [unsafeError]},
 		{code: 'if (check() && a && b);', errors: [unsafeError]},
 		{code: 'if ((first ? second : third) && check() && ready);', errors: [unsafeError]},
+		{code: 'if (check() && value == null);', errors: [unsafeError]},
+		{code: 'if (check() || null != value);', errors: [unsafeError]},
 		{code: 'if (new Example() && ready);', errors: [unsafeError]},
 		{code: 'if ((state.ready = true) && ready);', errors: [unsafeError]},
 		{code: 'if (++counter && ready);', errors: [unsafeError]},
@@ -276,6 +284,11 @@ test.typescript({
 		{
 			code: 'if ((foo ? bar : baz) && (value as string) != null);',
 			output: 'if (((value as string) != null) && (foo ? bar : baz));',
+			errors: [error],
+		},
+		{
+			code: 'if ((foo ? bar : baz) && (value as string) == null);',
+			output: 'if (((value as string) == null) && (foo ? bar : baz));',
 			errors: [error],
 		},
 		{

--- a/test/prefer-simple-condition-first.js
+++ b/test/prefer-simple-condition-first.js
@@ -23,6 +23,10 @@ test({
 		'if (!(typeof value === "string") && ready);',
 		'if (index === -1n && ready);',
 		'if (-1n === index && ready);',
+		'if (value == null && ready);',
+		'if (value != null && ready);',
+		'if (null == value && ready);',
+		'if (null != value && ready);',
 		'if (first() && second());',
 
 		// A single condition has no ordering to enforce
@@ -79,6 +83,21 @@ test({
 		{
 			code: 'if ((foo ? bar : baz) && index === -1n);',
 			output: 'if ((index === -1n) && (foo ? bar : baz));',
+			errors: [error],
+		},
+		{
+			code: 'if ((foo ? bar : baz) && value == null);',
+			output: 'if ((value == null) && (foo ? bar : baz));',
+			errors: [error],
+		},
+		{
+			code: 'if ((foo ? bar : baz) && null != value);',
+			output: 'if ((null != value) && (foo ? bar : baz));',
+			errors: [error],
+		},
+		{
+			code: 'if ((foo ? bar : baz) || value == null);',
+			output: 'if ((value == null) || (foo ? bar : baz));',
 			errors: [error],
 		},
 
@@ -194,6 +213,14 @@ test({
 		{code: 'if (true && ready);', errors: [unsafeError]},
 		{code: 'if (-1 && ready);', errors: [unsafeError]},
 		{code: 'if (index === +1n && ready);', errors: [unsafeError]},
+		{code: 'if (value == 1 && ready);', errors: [unsafeError]},
+		{code: 'if (value != 1 && ready);', errors: [unsafeError]},
+		{code: 'if (value == undefined && ready);', errors: [unsafeError]},
+		{code: 'if (value != undefined && ready);', errors: [unsafeError]},
+		{code: 'if (typeof value == null && ready);', errors: [unsafeError]},
+		{code: 'if (typeof value != null && ready);', errors: [unsafeError]},
+		{code: 'if (object.value == null && ready);', errors: [unsafeError]},
+		{code: 'if (getValue() != null && ready);', errors: [unsafeError]},
 		{code: 'if (typeof object.value === "string" && ready);', errors: [unsafeError]},
 		{code: 'if ((foo + bar) && ready);', errors: [unsafeError]},
 		{code: 'if ((key in object) && ready);', errors: [unsafeError]},
@@ -244,6 +271,16 @@ test.typescript({
 		{
 			code: 'if ((foo ? bar : baz) && (ready as boolean));',
 			output: 'if ((ready as boolean) && (foo ? bar : baz));',
+			errors: [error],
+		},
+		{
+			code: 'if ((foo ? bar : baz) && (value as string) != null);',
+			output: 'if (((value as string) != null) && (foo ? bar : baz));',
+			errors: [error],
+		},
+		{
+			code: 'if ((foo ? bar : baz) && null != (value as string));',
+			output: 'if ((null != (value as string)) && (foo ? bar : baz));',
 			errors: [error],
 		},
 		{


### PR DESCRIPTION
Fixes #3558