### PR TITLE
`name-replacements`: Handle TypeScript parameter properties

### DIFF
--- a/docs/rules/name-replacements.md
+++ b/docs/rules/name-replacements.md
@@ -17,7 +17,7 @@ You can find the default replacements [here](https://github.com/sindresorhus/esl
 
 This rule is automatically fixable only for variable names with exactly one replacement defined. Ambiguous variable names and checked property names can be manually fixed with editor suggestions when the rename is local to source text. Filename reports and exported-name property reports do not provide editor suggestions.
 
-Parameter names do not provide autofixes or editor suggestions when the function has an attached JSDoc `@param` comment, as those name references are not normal variable references and would otherwise be left stale. TypeScript parameter properties also do not provide autofixes or editor suggestions, as they declare a class property whose references may be outside the current variable scope. TypeScript type predicate and assertion signature parameter references are updated when the parameter is renamed.
+Parameter names do not provide autofixes or editor suggestions when the function has an attached JSDoc `@param` comment, as those name references are not normal variable references and would otherwise be left stale. TypeScript parameter properties also do not provide autofixes or editor suggestions, as the corresponding class property references are not part of the parameter variable's references. TypeScript type predicate and assertion signature parameter references are updated when the parameter is renamed.
 
 ## React
 

--- a/docs/rules/name-replacements.md
+++ b/docs/rules/name-replacements.md
@@ -17,7 +17,7 @@ You can find the default replacements [here](https://github.com/sindresorhus/esl
 
 This rule is automatically fixable only for variable names with exactly one replacement defined. Ambiguous variable names and checked property names can be manually fixed with editor suggestions when the rename is local to source text. Filename reports and exported-name property reports do not provide editor suggestions.
 
-Parameter names do not provide autofixes or editor suggestions when the function has an attached JSDoc `@param` comment, as those name references are not normal variable references and would otherwise be left stale. TypeScript type predicate and assertion signature parameter references are updated when the parameter is renamed.
+Parameter names do not provide autofixes or editor suggestions when the function has an attached JSDoc `@param` comment, as those name references are not normal variable references and would otherwise be left stale. TypeScript parameter properties also do not provide autofixes or editor suggestions, as they declare a class property whose references may be outside the current variable scope. TypeScript type predicate and assertion signature parameter references are updated when the parameter is renamed.
 
 ## React
 

--- a/rules/name-replacements.js
+++ b/rules/name-replacements.js
@@ -320,9 +320,26 @@ const getParentFunctionLikeNode = identifier => {
 	}
 };
 
+const isTSParameterPropertyName = node => {
+	if (node.parent.type === 'TSParameterProperty') {
+		return node.parent.parameter === node;
+	}
+
+	return (
+		node.parent.type === 'AssignmentPattern'
+		&& node.parent.left === node
+		&& node.parent.parent.type === 'TSParameterProperty'
+		&& node.parent.parent.parameter === node.parent
+	);
+};
+
 const shouldFixParameter = (definition, context) => {
 	if (definition.type !== 'Parameter') {
 		return true;
+	}
+
+	if (isTSParameterPropertyName(definition.name)) {
+		return false;
 	}
 
 	const functionNode = getParentFunctionLikeNode(definition.name);

--- a/test/name-replacements.js
+++ b/test/name-replacements.js
@@ -2043,6 +2043,34 @@ test.typescript({
 			}],
 		},
 		{
+			code: outdent`
+				class ValidationException {
+					constructor(private readonly e: Error) {}
+
+					getError(): Error {
+						return this.e;
+					}
+				}
+			`,
+			errors: [{
+				message: 'Please rename the variable `e`. Suggested names are: `error`, `event_`. A more descriptive name will do too.',
+				suggestions: [],
+			}],
+		},
+		{
+			code: outdent`
+				function getError(err = 123) {
+					return err;
+				}
+			`,
+			output: outdent`
+				function getError(error = 123) {
+					return error;
+				}
+			`,
+			errors: 1,
+		},
+		{
 			code: 'const foo = (extr\u{61}Params     ?    :    string) => {}',
 			output: 'const foo = (extraParameters?:    string) => {}',
 			errors: 1,

--- a/test/name-replacements.js
+++ b/test/name-replacements.js
@@ -2013,6 +2013,36 @@ test.typescript({
 			errors: 1,
 		},
 		{
+			code: outdent`
+				class ValidationException {
+					constructor(private readonly err: JsonRpcErrorLocal) {}
+
+					getError(): JsonRpcErrorLocal {
+						return this.err;
+					}
+				}
+			`,
+			errors: [{
+				message: 'The variable `err` should be named `error`. A more descriptive name will do too.',
+				suggestions: [],
+			}],
+		},
+		{
+			code: outdent`
+				class ValidationException {
+					constructor(private err = 123) {}
+
+					getError() {
+						return this.err;
+					}
+				}
+			`,
+			errors: [{
+				message: 'The variable `err` should be named `error`. A more descriptive name will do too.',
+				suggestions: [],
+			}],
+		},
+		{
 			code: 'const foo = (extr\u{61}Params     ?    :    string) => {}',
 			output: 'const foo = (extraParameters?:    string) => {}',
 			errors: 1,


### PR DESCRIPTION
Fixes #3574