### PR TITLE
`custom-error-definition`: Avoid requiring native ErrorOptions for custom bases

### DIFF
--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -9,11 +9,21 @@
 <!-- end auto-generated rule header -->
 <!-- Do not manually modify this header. Run: `npm run fix:eslint-docs` -->
 
-Enforces the only valid way of `Error` subclassing. It works with any superclass whose name ends in `Error`.
+Enforces a consistent way of defining `Error` subclasses. It works with superclasses whose names match the rule's `*Error` naming pattern.
 
-When a named error constructor accepts a message, it should also accept `options` and pass it to `super()` so native `Error#cause` is preserved.
+When a named error constructor accepts a message, it should also accept `options` and pass it to `super()` so native `Error#cause` is preserved. This convention is only enforced for native error bases that accept `ErrorOptions` as their second parameter.
 
-Custom error base classes may use the second `super()` argument for a different purpose. When a second `super()` argument is already present, the rule does not enforce the native `options` parameter or forwarding convention.
+Custom error base classes may use different constructor parameters, so the rule does not enforce the native `ErrorOptions` convention for them.
+
+```js
+// ✅
+class UserNotFoundError extends GraphQLError {
+	constructor(userId) {
+		super(`User "${userId}" does not exist`, {extensions: {code: 'NOT_FOUND'}});
+		this.name = 'UserNotFoundError';
+	}
+}
+```
 
 ## Examples
 

--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -9,11 +9,11 @@
 <!-- end auto-generated rule header -->
 <!-- Do not manually modify this header. Run: `npm run fix:eslint-docs` -->
 
-Enforces the only valid way of `Error` subclassing. It works with any super class that ends in `Error`.
+Enforces the only valid way of `Error` subclassing. It works with any superclass whose name ends in `Error`.
 
 When a named error constructor accepts a message, it should also accept `options` and pass it to `super()` so native `Error#cause` is preserved.
 
-Custom error base classes may use the second `super()` argument for a different purpose. When that argument is already present, the rule does not require an additional `options` parameter.
+Custom error base classes may use the second `super()` argument for a different purpose. When a second `super()` argument is already present, the rule does not enforce the native `options` parameter or forwarding convention.
 
 ## Examples
 

--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -11,7 +11,7 @@
 
 Enforces a consistent way of defining `Error` subclasses. It works with superclasses whose names match the rule's `*Error` naming pattern.
 
-When a named error constructor accepts a message, it should also accept `options` and pass it to `super()` so native `Error#cause` is preserved. This convention is only enforced for native error bases that accept `ErrorOptions` as their second parameter.
+When a named error constructor accepts a message, it should also accept `options` and pass it to `super()` so native `Error#cause` is preserved. This convention is only enforced for native error bases that accept `ErrorOptions` as their second parameter. `AggregateError` accepts `ErrorOptions` as its third parameter, while `SuppressedError` does not accept `ErrorOptions`, so neither uses this convention.
 
 Custom error base classes may use different constructor parameters, so the rule does not enforce the native `ErrorOptions` convention for them.
 

--- a/docs/rules/custom-error-definition.md
+++ b/docs/rules/custom-error-definition.md
@@ -13,6 +13,8 @@ Enforces the only valid way of `Error` subclassing. It works with any super clas
 
 When a named error constructor accepts a message, it should also accept `options` and pass it to `super()` so native `Error#cause` is preserved.
 
+Custom error base classes may use the second `super()` argument for a different purpose. When that argument is already present, the rule does not require an additional `options` parameter.
+
 ## Examples
 
 ```js

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -8,6 +8,7 @@ import {
 	getStaticStringValue,
 	isUndefined,
 } from './ast/index.js';
+import builtinErrors from './shared/builtin-errors.js';
 
 const MESSAGE_ID_INVALID_EXPORT = 'invalidExport';
 const MESSAGE_ID_DO_NOT_PASS_MESSAGE_TO_SUPER = 'doNotPassMessageToSuper';
@@ -51,6 +52,21 @@ const getSuperClassName = superClass => {
 const hasValidSuperClass = node => {
 	const superClassName = getSuperClassName(node.superClass);
 	return Boolean(superClassName) && nameRegexp.test(superClassName);
+};
+
+const isNativeErrorBase = node => {
+	const {superClass} = node;
+
+	if (superClass?.type === 'Identifier') {
+		return builtinErrors.includes(superClass.name);
+	}
+
+	return superClass?.type === 'MemberExpression'
+		&& !superClass.computed
+		&& superClass.object.type === 'Identifier'
+		&& superClass.object.name === 'globalThis'
+		&& superClass.property.type === 'Identifier'
+		&& builtinErrors.includes(superClass.property.name);
 };
 
 const isSuperExpression = node =>
@@ -217,7 +233,7 @@ const hasInlineErrorOptions = (superCallExpression, shouldPassMessageToSuper) =>
 		&& getPropertyName(optionsArgument.properties[0]) === 'cause';
 };
 
-const getErrorOptionsProblem = (context, constructor, superExpression, hasMessageAccessor) => {
+const getErrorOptionsProblem = (context, constructor, superExpression, errorDefinition) => {
 	const parameters = constructor.value.params;
 	const firstParameter = parameters[0];
 	const firstParameterIdentifier = getParameterIdentifier(firstParameter);
@@ -229,7 +245,12 @@ const getErrorOptionsProblem = (context, constructor, superExpression, hasMessag
 		return;
 	}
 
+	const {hasMessageGetter, hasMessageSetter, isCustomErrorBase} = errorDefinition;
+	const hasMessageAccessor = hasMessageGetter || hasMessageSetter;
 	const superCallExpression = superExpression.expression;
+	if (isCustomErrorBase && superCallExpression.arguments.length >= 2) {
+		return;
+	}
 
 	if (isOptionsIdentifier(firstParameter)) {
 		if (!isOptionsIdentifier(superCallExpression.arguments[1])) {
@@ -319,7 +340,7 @@ function * getConstructorBodyProblems(context, constructor, errorDefinition) {
 	}
 
 	const constructorBody = constructorBodyNode.body;
-	const {hasMessageGetter, hasMessageSetter, checkOptions} = errorDefinition;
+	const {hasMessageGetter, hasMessageSetter, checkOptions, isCustomErrorBase} = errorDefinition;
 
 	const superExpression = constructorBody.find(bodyNode => isSuperExpression(bodyNode));
 	const superExpressionIndex = constructorBody.findIndex(bodyNode => isSuperExpression(bodyNode));
@@ -412,7 +433,7 @@ function * getConstructorBodyProblems(context, constructor, errorDefinition) {
 	}
 
 	if (hasValidName && checkOptions && !hasConstructorBodyProblem) {
-		const errorOptionsProblem = getErrorOptionsProblem(context, constructor, superExpression, hasMessageAccessor);
+		const errorOptionsProblem = getErrorOptionsProblem(context, constructor, superExpression, errorDefinition);
 
 		if (errorOptionsProblem) {
 			yield errorOptionsProblem;
@@ -480,6 +501,7 @@ function * customErrorDefinition(context, node) {
 		hasMessageGetter,
 		hasMessageSetter,
 		checkOptions: name === className,
+		isCustomErrorBase: !isNativeErrorBase(node),
 	});
 }
 

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -340,7 +340,7 @@ function * getConstructorBodyProblems(context, constructor, errorDefinition) {
 	}
 
 	const constructorBody = constructorBodyNode.body;
-	const {hasMessageGetter, hasMessageSetter, checkOptions, isCustomErrorBase} = errorDefinition;
+	const {hasMessageGetter, hasMessageSetter, checkOptions} = errorDefinition;
 
 	const superExpression = constructorBody.find(bodyNode => isSuperExpression(bodyNode));
 	const superExpressionIndex = constructorBody.findIndex(bodyNode => isSuperExpression(bodyNode));

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -3,6 +3,7 @@ import {
 	upperFirst,
 	getParenthesizedText,
 	isNodeMatchesNameOrPath,
+	unwrapTypeScriptExpression,
 } from './utils/index.js';
 import {
 	getStaticStringValue,
@@ -52,18 +53,20 @@ const getSuperClassName = superClass => {
 };
 
 const hasValidSuperClass = node => {
-	const superClassName = getSuperClassName(node.superClass);
+	const superClass = unwrapTypeScriptExpression(node.superClass);
+	const superClassName = getSuperClassName(superClass);
 	return Boolean(superClassName) && nameRegexp.test(superClassName);
 };
 
 const isNativeErrorBaseWithStandardOptions = node => {
-	const superClassName = getSuperClassName(node.superClass);
+	const superClass = unwrapTypeScriptExpression(node.superClass);
+	const superClassName = getSuperClassName(superClass);
 
 	return builtinErrors.includes(superClassName)
 		&& !errorBasesWithoutStandardOptions.has(superClassName)
 		&& (
-			node.superClass.type === 'Identifier'
-			|| isNodeMatchesNameOrPath(node.superClass, `globalThis.${superClassName}`)
+			superClass.type === 'Identifier'
+			|| isNodeMatchesNameOrPath(superClass, `globalThis.${superClassName}`)
 		);
 };
 

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -28,6 +28,8 @@ const messages = {
 };
 
 const nameRegexp = /^(?:[A-Z][\da-z]*)*Error$/;
+// `AggregateError` uses the third argument for `ErrorOptions`; `SuppressedError` does not accept it.
+const errorOptionsUnsupportedBases = new Set(['AggregateError', 'SuppressedError']);
 
 const getClassName = name => upperFirst(name).replace(/(?:error)?$/i, 'Error');
 
@@ -54,19 +56,24 @@ const hasValidSuperClass = node => {
 	return Boolean(superClassName) && nameRegexp.test(superClassName);
 };
 
-const isNativeErrorBase = node => {
+const isErrorOptionsBase = node => {
 	const {superClass} = node;
 
 	if (superClass?.type === 'Identifier') {
-		return builtinErrors.includes(superClass.name);
+		return builtinErrors.includes(superClass.name)
+			&& !errorOptionsUnsupportedBases.has(superClass.name);
 	}
 
-	return superClass?.type === 'MemberExpression'
-		&& !superClass.computed
+	if (superClass?.type !== 'MemberExpression') {
+		return false;
+	}
+
+	return !superClass.computed
 		&& superClass.object.type === 'Identifier'
 		&& superClass.object.name === 'globalThis'
 		&& superClass.property.type === 'Identifier'
-		&& builtinErrors.includes(superClass.property.name);
+		&& builtinErrors.includes(superClass.property.name)
+		&& !errorOptionsUnsupportedBases.has(superClass.property.name);
 };
 
 const isSuperExpression = node =>
@@ -233,7 +240,7 @@ const hasInlineErrorOptions = (superCallExpression, shouldPassMessageToSuper) =>
 		&& getPropertyName(optionsArgument.properties[0]) === 'cause';
 };
 
-const getErrorOptionsProblem = (context, constructor, superExpression, errorDefinition) => {
+const getErrorOptionsProblem = (context, constructor, superExpression, hasMessageAccessor) => {
 	const parameters = constructor.value.params;
 	const firstParameter = parameters[0];
 	const firstParameterIdentifier = getParameterIdentifier(firstParameter);
@@ -245,12 +252,7 @@ const getErrorOptionsProblem = (context, constructor, superExpression, errorDefi
 		return;
 	}
 
-	const {hasMessageGetter, hasMessageSetter, isCustomErrorBase} = errorDefinition;
-	const hasMessageAccessor = hasMessageGetter || hasMessageSetter;
 	const superCallExpression = superExpression.expression;
-	if (isCustomErrorBase && superCallExpression.arguments.length >= 2) {
-		return;
-	}
 
 	if (isOptionsIdentifier(firstParameter)) {
 		if (!isOptionsIdentifier(superCallExpression.arguments[1])) {
@@ -433,7 +435,7 @@ function * getConstructorBodyProblems(context, constructor, errorDefinition) {
 	}
 
 	if (hasValidName && checkOptions && !hasConstructorBodyProblem) {
-		const errorOptionsProblem = getErrorOptionsProblem(context, constructor, superExpression, errorDefinition);
+		const errorOptionsProblem = getErrorOptionsProblem(context, constructor, superExpression, hasMessageAccessor);
 
 		if (errorOptionsProblem) {
 			yield errorOptionsProblem;
@@ -500,8 +502,7 @@ function * customErrorDefinition(context, node) {
 		nameProperty,
 		hasMessageGetter,
 		hasMessageSetter,
-		checkOptions: name === className,
-		isCustomErrorBase: !isNativeErrorBase(node),
+		checkOptions: name === className && isErrorOptionsBase(node),
 	});
 }
 

--- a/rules/custom-error-definition.js
+++ b/rules/custom-error-definition.js
@@ -28,8 +28,8 @@ const messages = {
 };
 
 const nameRegexp = /^(?:[A-Z][\da-z]*)*Error$/;
-// `AggregateError` uses the third argument for `ErrorOptions`; `SuppressedError` does not accept it.
-const errorOptionsUnsupportedBases = new Set(['AggregateError', 'SuppressedError']);
+// `AggregateError` accepts `ErrorOptions` as its third argument, and `SuppressedError` does not accept it.
+const errorBasesWithoutStandardOptions = new Set(['AggregateError', 'SuppressedError']);
 
 const getClassName = name => upperFirst(name).replace(/(?:error)?$/i, 'Error');
 
@@ -56,24 +56,15 @@ const hasValidSuperClass = node => {
 	return Boolean(superClassName) && nameRegexp.test(superClassName);
 };
 
-const isErrorOptionsBase = node => {
-	const {superClass} = node;
+const isNativeErrorBaseWithStandardOptions = node => {
+	const superClassName = getSuperClassName(node.superClass);
 
-	if (superClass?.type === 'Identifier') {
-		return builtinErrors.includes(superClass.name)
-			&& !errorOptionsUnsupportedBases.has(superClass.name);
-	}
-
-	if (superClass?.type !== 'MemberExpression') {
-		return false;
-	}
-
-	return !superClass.computed
-		&& superClass.object.type === 'Identifier'
-		&& superClass.object.name === 'globalThis'
-		&& superClass.property.type === 'Identifier'
-		&& builtinErrors.includes(superClass.property.name)
-		&& !errorOptionsUnsupportedBases.has(superClass.property.name);
+	return builtinErrors.includes(superClassName)
+		&& !errorBasesWithoutStandardOptions.has(superClassName)
+		&& (
+			node.superClass.type === 'Identifier'
+			|| isNodeMatchesNameOrPath(node.superClass, `globalThis.${superClassName}`)
+		);
 };
 
 const isSuperExpression = node =>
@@ -502,7 +493,7 @@ function * customErrorDefinition(context, node) {
 		nameProperty,
 		hasMessageGetter,
 		hasMessageSetter,
-		checkOptions: name === className && isErrorOptionsBase(node),
+		checkOptions: name === className && isNativeErrorBaseWithStandardOptions(node),
 	});
 }
 

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -1412,5 +1412,81 @@ test.typescript({
 				}
 			`,
 		},
+		{
+			code: outdent`
+				class FooError extends (globalThis.Error as typeof Error) {
+					constructor(message) {
+						super(message);
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [missingOptionsParameterError],
+			output: outdent`
+				class FooError extends (globalThis.Error as typeof Error) {
+					constructor(message, options) {
+						super(message, options);
+						this.name = 'FooError';
+					}
+				}
+			`,
+		},
+		{
+			code: outdent`
+				class FooError extends (Error satisfies typeof Error) {
+					constructor(message) {
+						super(message);
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [missingOptionsParameterError],
+			output: outdent`
+				class FooError extends (Error satisfies typeof Error) {
+					constructor(message, options) {
+						super(message, options);
+						this.name = 'FooError';
+					}
+				}
+			`,
+		},
+		{
+			code: outdent`
+				class FooError extends (Error!) {
+					constructor(message) {
+						super(message);
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [missingOptionsParameterError],
+			output: outdent`
+				class FooError extends (Error!) {
+					constructor(message, options) {
+						super(message, options);
+						this.name = 'FooError';
+					}
+				}
+			`,
+		},
+		{
+			code: outdent`
+				class FooError extends (<typeof Error>Error) {
+					constructor(message) {
+						super(message);
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [missingOptionsParameterError],
+			output: outdent`
+				class FooError extends (<typeof Error>Error) {
+					constructor(message, options) {
+						super(message, options);
+						this.name = 'FooError';
+					}
+				}
+			`,
+		},
 	],
 });

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -134,6 +134,23 @@ const tests = {
 				}
 			}
 		`,
+		// The second argument of a custom error base class is not necessarily `ErrorOptions`
+		outdent`
+			class UserNotFoundError extends GraphQLError {
+				constructor(userId) {
+					super(\`User "\${userId}" does not exist\`, {extensions: {code: 'NOT_FOUND'}});
+					this.name = 'UserNotFoundError';
+				}
+			}
+		`,
+		outdent`
+			class FooError extends GraphQLError {
+				constructor(message) {
+					super(message, {extensions: {code: 'CUSTOM'}});
+					this.name = 'FooError';
+				}
+			}
+		`,
 		outdent`
 			class FooError extends Error {
 				constructor() {
@@ -1043,6 +1060,40 @@ const tests = {
 			errors: [
 				invalidOptionsParameterError,
 			],
+		},
+		{
+			code: outdent`
+				class FooError extends globalThis.Error {
+					constructor(message, details) {
+						super(message, details);
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [
+				invalidOptionsParameterError,
+			],
+		},
+		{
+			code: outdent`
+				class FooError extends GraphQLError {
+					constructor(message) {
+						super(message);
+						this.name = 'FooError';
+					}
+				}
+			`,
+			errors: [
+				missingOptionsParameterError,
+			],
+			output: outdent`
+				class FooError extends GraphQLError {
+					constructor(message, options) {
+						super(message, options);
+						this.name = 'FooError';
+					}
+				}
+			`,
 		},
 		{
 			// Second parameter named `opts` instead of `options`

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -1488,5 +1488,29 @@ test.typescript({
 				}
 			`,
 		},
+		{
+			code: 'class FooError extends (GraphQLError as typeof GraphQLError) { name = \'WrongError\'; }',
+			errors: [invalidNameError('FooError')],
+			output: 'class FooError extends (GraphQLError as typeof GraphQLError) { name = \'FooError\'; }',
+		},
+		{
+			code: outdent`
+				exports.fooError = class FooError extends (GraphQLError as typeof GraphQLError) {
+					constructor(message) {
+						super(message);
+						this.name = 'FooError';
+					}
+				};
+			`,
+			errors: [invalidExportError],
+			output: outdent`
+				exports.FooError = class FooError extends (GraphQLError as typeof GraphQLError) {
+					constructor(message) {
+						super(message);
+						this.name = 'FooError';
+					}
+				};
+			`,
+		},
 	],
 });

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -116,7 +116,7 @@ const tests = {
 				}
 			}
 		`,
-		// Inline options with a hard-coded message built from a template literal
+		// Inline options with a hard-coded message provided as a no-substitution template literal
 		outdent`
 			class FooError extends Error {
 				constructor(cause) {
@@ -145,16 +145,33 @@ const tests = {
 		`,
 		outdent`
 			class FooError extends GraphQLError {
-				constructor(message) {
-					super(message, {extensions: {code: 'CUSTOM'}});
+				constructor(message, extensions) {
+					super(message, extensions);
 					this.name = 'FooError';
 				}
 			}
 		`,
 		outdent`
 			class FooError extends GraphQLError {
-				constructor(message, extensions) {
-					super(message, extensions);
+				constructor(message, details) {
+					super(message);
+					this.details = details;
+					this.name = 'FooError';
+				}
+			}
+		`,
+		outdent`
+			class FooError extends AggregateError {
+				constructor(errors, message, options) {
+					super(errors, message, options);
+					this.name = 'FooError';
+				}
+			}
+		`,
+		outdent`
+			class FooError extends SuppressedError {
+				constructor(error, suppressed, message) {
+					super(error, suppressed, message);
 					this.name = 'FooError';
 				}
 			}
@@ -1084,24 +1101,16 @@ const tests = {
 		},
 		{
 			code: outdent`
-				class FooError extends GraphQLError {
-					constructor(message) {
-						super(message);
+				class FooError extends TypeError {
+					constructor(message, details) {
+						super(message, details);
 						this.name = 'FooError';
 					}
 				}
 			`,
 			errors: [
-				missingOptionsParameterError,
+				invalidOptionsParameterError,
 			],
-			output: outdent`
-				class FooError extends GraphQLError {
-					constructor(message, options) {
-						super(message, options);
-						this.name = 'FooError';
-					}
-				}
-			`,
 		},
 		{
 			// Second parameter named `opts` instead of `options`

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -125,7 +125,7 @@ const tests = {
 				}
 			}
 		`,
-		// Inline options forwarded to a custom `*Error` super class (the reported real-world case)
+		// Inline options forwarded to a custom `*Error` superclass (the reported real-world case)
 		outdent`
 			class TimeoutError extends FetchError {
 				constructor(cause) {
@@ -147,6 +147,14 @@ const tests = {
 			class FooError extends GraphQLError {
 				constructor(message) {
 					super(message, {extensions: {code: 'CUSTOM'}});
+					this.name = 'FooError';
+				}
+			}
+		`,
+		outdent`
+			class FooError extends GraphQLError {
+				constructor(message, extensions) {
+					super(message, extensions);
 					this.name = 'FooError';
 				}
 			}
@@ -1300,6 +1308,14 @@ test.typescript({
 				constructor(message: string, options: ErrorOptions) {
 					super(message, options);
 					this.name = 'FooError';
+				}
+			}
+		`,
+		outdent`
+			class UserNotFoundError extends GraphQLError {
+				constructor(userId: string) {
+					super(\`User "\${userId}" does not exist\`, {extensions: {code: 'NOT_FOUND'}});
+					this.name = 'UserNotFoundError';
 				}
 			}
 		`,

--- a/test/custom-error-definition.js
+++ b/test/custom-error-definition.js
@@ -161,6 +161,14 @@ const tests = {
 			}
 		`,
 		outdent`
+			class FooError extends Custom.Error {
+				constructor(message) {
+					super(message);
+					this.name = 'FooError';
+				}
+			}
+		`,
+		outdent`
 			class FooError extends AggregateError {
 				constructor(errors, message, options) {
 					super(errors, message, options);
@@ -172,6 +180,14 @@ const tests = {
 			class FooError extends SuppressedError {
 				constructor(error, suppressed, message) {
 					super(error, suppressed, message);
+					this.name = 'FooError';
+				}
+			}
+		`,
+		outdent`
+			class FooError extends globalThis.AggregateError {
+				constructor(errors, message, options) {
+					super(errors, message, options);
 					this.name = 'FooError';
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3614