### PR TITLE
`consistent-arrow-return-style`: Fix indentation and `in` operator handling

### DIFF
--- a/rules/consistent-arrow-return-style.js
+++ b/rules/consistent-arrow-return-style.js
@@ -1,3 +1,4 @@
+import detectIndent from 'detect-indent';
 import {
 	getParenthesizedRange,
 	getParenthesizedText,
@@ -121,7 +122,7 @@ const hasMultilineSignificantWhitespace = (node, sourceCode) =>
 		tokensWithSignificantWhitespace.has(token.type)
 		&& sourceCode.getLoc(token).start.line !== sourceCode.getLoc(token).end.line);
 
-const getBodyText = (text, shouldIndent) => {
+const getBodyText = (text, shouldIndent, indentationUnit) => {
 	if (!shouldIndent) {
 		return text;
 	}
@@ -130,7 +131,7 @@ const getBodyText = (text, shouldIndent) => {
 	const linebreaks = text.match(/\r\n|[\n\r\u2028\u2029]/g);
 	let result = lines[0];
 	for (const [index, line] of lines.slice(1).entries()) {
-		result += linebreaks[index] + (line ? `\t${line}` : line);
+		result += linebreaks[index] + (line ? indentationUnit + line : line);
 	}
 
 	return result;
@@ -139,7 +140,7 @@ const getBodyText = (text, shouldIndent) => {
 const getLinebreak = (sourceCode, range) =>
 	sourceCode.text.slice(...range).match(linebreakPattern)?.[0] ?? '\n';
 
-const getExplicitReturnFix = (node, context) => {
+const getExplicitReturnFix = (node, context, indentationUnit) => {
 	const {sourceCode} = context;
 	const arrowToken = getArrowToken(node, context);
 	const bodyRange = getParenthesizedRange(node.body, context);
@@ -154,9 +155,10 @@ const getExplicitReturnFix = (node, context) => {
 	const bodyText = getBodyText(
 		node.body.type === 'ObjectExpression' ? sourceCode.getText(node.body) : sourceCode.text.slice(...bodyRange),
 		bodyStartsOnArrowLine,
+		indentationUnit,
 	);
 	const indentation = getLineIndent(sourceCode, arrowToken);
-	const replacement = `{${linebreak}${indentation}\treturn ${bodyText};${linebreak}${indentation}}`;
+	const replacement = `{${linebreak}${indentation}${indentationUnit}return ${bodyText};${linebreak}${indentation}}`;
 
 	return fixer => fixer.replaceTextRange([arrowEnd, bodyRange[1]], ` ${replacement}`);
 };
@@ -176,6 +178,8 @@ const getImplicitReturnFix = (node, returnStatement, context) => {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {sourceCode} = context;
+	const detectedIndentation = detectIndent(sourceCode.lines.join('\n'));
+	const indentationUnit = detectedIndentation.type === 'tab' ? '\t' : detectedIndentation.indent || '\t';
 
 	context.on('ArrowFunctionExpression', node => {
 		if (hasCommentsInside(node, sourceCode)) {
@@ -200,7 +204,7 @@ const create = context => {
 			return;
 		}
 
-		const fix = getExplicitReturnFix(node, context);
+		const fix = getExplicitReturnFix(node, context, indentationUnit);
 		return {
 			node,
 			messageId: MESSAGE_ID_EXPLICIT,

--- a/rules/consistent-arrow-return-style.js
+++ b/rules/consistent-arrow-return-style.js
@@ -189,7 +189,7 @@ const getImplicitReturnFix = (node, returnStatement, context) => {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {sourceCode} = context;
-	const indentationUnit = getIndentationUnit(sourceCode);
+	let indentationUnit;
 
 	context.on('ArrowFunctionExpression', node => {
 		if (hasCommentsInside(node, sourceCode)) {
@@ -214,6 +214,7 @@ const create = context => {
 			return;
 		}
 
+		indentationUnit ??= getIndentationUnit(sourceCode);
 		const fix = getExplicitReturnFix(node, context, indentationUnit);
 		return {
 			node,

--- a/rules/consistent-arrow-return-style.js
+++ b/rules/consistent-arrow-return-style.js
@@ -65,10 +65,22 @@ const getReturnStatement = node => {
 const hasCommentsInside = (node, sourceCode) => sourceCode.getCommentsInside(node).length > 0;
 
 const getLineIndent = (sourceCode, node) => {
-	const [start] = sourceCode.getRange(node);
-	const {line, column} = sourceCode.getLocFromIndex(start);
+	const {line, column} = sourceCode.getLoc(node).start;
 
 	return /^[\t ]*/.exec(sourceCode.lines[line - 1].slice(0, column))[0];
+};
+
+const getIndentationUnit = sourceCode => {
+	const lines = [...sourceCode.lines];
+	for (const token of sourceCode.getTokens(sourceCode.ast, {includeComments: true})) {
+		const {start, end} = sourceCode.getLoc(token);
+		if (start.line !== end.line) {
+			lines.fill('', start.line, end.line);
+		}
+	}
+
+	const {type, indent} = detectIndent(lines.join('\n'));
+	return type === 'space' ? indent : '\t';
 };
 
 const getArrowToken = (node, context) => {
@@ -105,9 +117,8 @@ const getReturnArgumentText = (returnArgument, context) => {
 	const needsParentheses = text.trimStart().startsWith('{')
 		|| returnArgumentTypesRequiringParentheses.has(underlyingExpression.type)
 		|| (
-			underlyingExpression.type === 'BinaryExpression'
-			&& underlyingExpression.operator === 'in'
-			&& isInsideForStatementInitializer(returnArgument)
+			isInsideForStatementInitializer(returnArgument)
+			&& context.sourceCode.getTokens(returnArgument).some(token => token.type === 'Keyword' && token.value === 'in')
 		);
 
 	if (isParenthesized(returnArgument, context) || !needsParentheses) {
@@ -178,8 +189,7 @@ const getImplicitReturnFix = (node, returnStatement, context) => {
 /** @param {import('eslint').Rule.RuleContext} context */
 const create = context => {
 	const {sourceCode} = context;
-	const detectedIndentation = detectIndent(sourceCode.lines.join('\n'));
-	const indentationUnit = detectedIndentation.type === 'tab' ? '\t' : detectedIndentation.indent || '\t';
+	const indentationUnit = getIndentationUnit(sourceCode);
 
 	context.on('ArrowFunctionExpression', node => {
 		if (hasCommentsInside(node, sourceCode)) {

--- a/test/consistent-arrow-return-style.js
+++ b/test/consistent-arrow-return-style.js
@@ -97,6 +97,14 @@ ruleTest({
 		languageOptions: {parser: parsers.typescript},
 		errors: [{messageId: 'useImplicitReturn'}],
 	}, {
+		code: 'for (const value = () => { return foo || bar in baz; }; ; ) {}',
+		output: 'for (const value = () => (foo || bar in baz); ; ) {}',
+		errors: [{messageId: 'useImplicitReturn'}],
+	}, {
+		code: 'for (const value = () => { return () => foo in bar; }; ; ) {}',
+		output: 'for (const value = () => (() => foo in bar); ; ) {}',
+		errors: [{messageId: 'useImplicitReturn'}],
+	}, {
 		code: 'const value = () => foo(\n\t() => {\n\t\treturn bar;\n\t},\n);',
 		output: 'const value = () => {\n\treturn foo(\n\t\t() => {\n\t\t\treturn bar;\n\t\t},\n\t);\n};',
 		errors: [
@@ -118,6 +126,18 @@ ruleTest({
 	}, {
 		code: 'const value = (data, status) =>\n  Response.json(data, {\n    status,\n    statusText: \'OK\',\n  });',
 		output: 'const value = (data, status) => {\n  return Response.json(data, {\n    status,\n    statusText: \'OK\',\n  });\n};',
+		errors: [{messageId: 'useExplicitReturn'}],
+	}, {
+		code: 'const template = `\n        content\n        content\n`;\nconst value = () => foo(\n  bar,\n);',
+		output: 'const template = `\n        content\n        content\n`;\nconst value = () => {\n  return foo(\n    bar,\n  );\n};',
+		errors: [{messageId: 'useExplicitReturn'}],
+	}, {
+		code: '/*\n        content\n        content\n*/\nconst value = () => foo(\n  bar,\n);',
+		output: '/*\n        content\n        content\n*/\nconst value = () => {\n  return foo(\n    bar,\n  );\n};',
+		errors: [{messageId: 'useExplicitReturn'}],
+	}, {
+		code: 'if (condition) {\n    const value = () => foo(\n        bar,\n    );\n}',
+		output: 'if (condition) {\n    const value = () => {\n        return foo(\n            bar,\n        );\n    };\n}',
 		errors: [{messageId: 'useExplicitReturn'}],
 	}, {
 		code: 'const values = [\r\t() => foo(\r\t\tbar,\r\t),\r];',

--- a/test/consistent-arrow-return-style.js
+++ b/test/consistent-arrow-return-style.js
@@ -112,6 +112,14 @@ ruleTest({
 		output: 'const value = () => {\r\n\treturn foo(\r\n\t\t\tbar,\r\n\t\t);\r\n};',
 		errors: [{messageId: 'useExplicitReturn'}],
 	}, {
+		code: 'const value = (data, status) => Response.json(data, {\n  status,\n  statusText: \'OK\',\n});',
+		output: 'const value = (data, status) => {\n  return Response.json(data, {\n    status,\n    statusText: \'OK\',\n  });\n};',
+		errors: [{messageId: 'useExplicitReturn'}],
+	}, {
+		code: 'const value = (data, status) =>\n  Response.json(data, {\n    status,\n    statusText: \'OK\',\n  });',
+		output: 'const value = (data, status) => {\n  return Response.json(data, {\n    status,\n    statusText: \'OK\',\n  });\n};',
+		errors: [{messageId: 'useExplicitReturn'}],
+	}, {
 		code: 'const values = [\r\t() => foo(\r\t\tbar,\r\t),\r];',
 		output: 'const values = [\r\t() => {\r\t\treturn foo(\r\t\t\tbar,\r\t\t);\r\t},\r];',
 		errors: [{messageId: 'useExplicitReturn'}],


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3620