### PR TITLE
`consistent-boolean-name`: Support possibly async boolean callbacks

### DIFF
--- a/docs/rules/consistent-boolean-name.md
+++ b/docs/rules/consistent-boolean-name.md
@@ -21,6 +21,8 @@ Boolean names should start with a prefix that makes the boolean meaning clear.
 
 Names that start with a boolean prefix should also refer to booleans or boolean-returning functions. Unknown values are ignored.
 
+Callable type annotations returning `boolean`, `Promise<boolean>`, `PromiseLike<boolean>`, or unions of these are considered boolean-returning.
+
 When type information is unavailable, unannotated async functions are not considered boolean-returning when requiring a prefix.
 
 Configured wrapper bindings may use boolean prefixes when a configured property or method provides a boolean-like value. This applies only to variables and parameters that are not reassigned.

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"markdownlint-cli": "^0.49.0",
 		"nano-spawn": "^2.1.0",
 		"node-style-text": "^2.1.2",
-		"npm-package-json-lint": "^10.4.1",
+		"npm-package-json-lint": "10.4.1",
 		"npm-run-all2": "^9.0.2",
 		"open-editor": "^6.0.0",
 		"outdent": "^0.8.0",

--- a/rules/consistent-boolean-name.js
+++ b/rules/consistent-boolean-name.js
@@ -677,10 +677,24 @@ function getPromisedTypeInformationBooleanState(node, context, allowNullish = tr
 			return unknown;
 		}
 
-		return getPromisedTypeBooleanState(nonNullableType, checker);
+		return nonNullableType.isUnion()
+			? getPossiblyPromisedTypeBooleanState(nonNullableType, checker, allowNullish)
+			: getPromisedTypeBooleanState(nonNullableType, checker);
 	} catch {
 		return unknown;
 	}
+}
+
+function getPossiblyPromisedTypeBooleanState(type, checker, allowNullish) {
+	const awaitedType = checker.getAwaitedType(type);
+	if (!awaitedType) {
+		return unknown;
+	}
+
+	const nonNullableType = checker.getNonNullableType(awaitedType);
+	return !allowNullish && nonNullableType !== awaitedType
+		? unknown
+		: getTypeBooleanState(nonNullableType, checker, new Set(), false);
 }
 
 function getTypeReferenceName(typeName) {
@@ -1782,6 +1796,10 @@ function getAsyncFunctionTypeInformationBooleanState(node, context, allowNullish
 				return unknown;
 			}
 
+			if (nonNullableReturnType.isUnion()) {
+				return getPossiblyPromisedTypeBooleanState(nonNullableReturnType, checker, allowNullish);
+			}
+
 			const promisedType = checker.getPromisedTypeOfPromise(nonNullableReturnType);
 			if (!promisedType) {
 				return unknown;
@@ -2083,8 +2101,16 @@ function getDirectTypeAnnotationBooleanState(node, context, scope, typeState) {
 		return stateFromAsyncFunctionType;
 	}
 
+	const isCallable = isCallableTypeAnnotation(node, context, scope);
 	if (
-		isCallableTypeAnnotation(node, context, scope)
+		isCallable
+		&& getPromisedTypeAnnotationBooleanState(node, context, scope, {...normalizedTypeState, allowNullish: true}) === boolean
+	) {
+		return unknown;
+	}
+
+	if (
+		isCallable
 		&& isPromisedTypeAnnotation(node, context, scope)
 	) {
 		return unknown;

--- a/rules/consistent-boolean-name.js
+++ b/rules/consistent-boolean-name.js
@@ -1,7 +1,7 @@
 import {isRegExp} from 'node:util/types';
 import {findVariable, getPropertyName} from '@eslint-community/eslint-utils';
 import {renameVariable} from './fix/index.js';
-import {combineBooleanStates, getPromisedTypeBooleanState, getTypeBooleanState} from './utils/get-type-boolean-state.js';
+import {combineBooleanStates, getTypeBooleanState} from './utils/get-type-boolean-state.js';
 import resolveVariableName from './utils/resolve-variable-name.js';
 import {getBooleanWrapperVariableState} from './utils/get-boolean-wrapper-variable-state.js';
 import {
@@ -677,16 +677,16 @@ function getPromisedTypeInformationBooleanState(node, context, allowNullish = tr
 			return unknown;
 		}
 
-		return nonNullableType.isUnion()
-			? getPossiblyPromisedTypeBooleanState(nonNullableType, checker, allowNullish)
-			: getPromisedTypeBooleanState(nonNullableType, checker);
+		return getPossiblyPromisedTypeBooleanState(nonNullableType, checker, allowNullish);
 	} catch {
 		return unknown;
 	}
 }
 
 function getPossiblyPromisedTypeBooleanState(type, checker, allowNullish) {
-	const awaitedType = checker.getAwaitedType(type);
+	const awaitedType = type.isUnion()
+		? checker.getAwaitedType(type)
+		: checker.getPromisedTypeOfPromise(type);
 	if (!awaitedType) {
 		return unknown;
 	}
@@ -1796,21 +1796,7 @@ function getAsyncFunctionTypeInformationBooleanState(node, context, allowNullish
 				return unknown;
 			}
 
-			if (nonNullableReturnType.isUnion()) {
-				return getPossiblyPromisedTypeBooleanState(nonNullableReturnType, checker, allowNullish);
-			}
-
-			const promisedType = checker.getPromisedTypeOfPromise(nonNullableReturnType);
-			if (!promisedType) {
-				return unknown;
-			}
-
-			const nonNullableType = checker.getNonNullableType(promisedType);
-			if (!allowNullish && nonNullableType !== promisedType) {
-				return unknown;
-			}
-
-			return getTypeBooleanState(nonNullableType, checker, new Set(), false);
+			return getPossiblyPromisedTypeBooleanState(nonNullableReturnType, checker, allowNullish);
 		}));
 	} catch {
 		return unknown;

--- a/rules/consistent-boolean-name.js
+++ b/rules/consistent-boolean-name.js
@@ -1615,7 +1615,7 @@ function getPromisedTypeReferenceBooleanState(node, context, scope, typeState) {
 			return getInterfaceCallSignatureBooleanStates(definition.node, context, definitionScope, {
 				typeState: definitionTypeState,
 				getReturnTypeBooleanState: (returnType, context, scope, typeState) =>
-					getPromisedTypeAnnotationBooleanState(returnType, context, scope, typeState),
+					getPromisedTypeAnnotationBooleanState(returnType, context, scope, {...typeState, functionTypesAreBoolean: false}),
 				visitedInterfaceNames: new Set([name]),
 			});
 		});
@@ -1676,7 +1676,7 @@ function getPromisedTypeAnnotationBooleanState(node, context, scope, typeState) 
 			return unknown;
 		}
 
-		return getPromisedTypeAnnotationBooleanState(node.returnType, context, scope, normalizedTypeState);
+		return getPromisedTypeAnnotationBooleanState(node.returnType, context, scope, {...normalizedTypeState, functionTypesAreBoolean: false});
 	}
 
 	if (node?.type === 'TSUnionType') {
@@ -1709,7 +1709,7 @@ function getPromisedTypeAnnotationBooleanState(node, context, scope, typeState) 
 
 	return node?.type === 'TSTypeReference'
 		? getPromisedTypeReferenceBooleanState(node, context, scope, normalizedTypeState)
-		: unknown;
+		: getTypeAnnotationBooleanState(node, context, scope, {...normalizedTypeState, functionTypesAreBoolean: false});
 }
 
 function getPromisedTypeMembersBooleanState(members, context, scope, typeState) {
@@ -1718,7 +1718,7 @@ function getPromisedTypeMembersBooleanState(members, context, scope, typeState) 
 
 	if (callSignatures.length > 0) {
 		return normalizedTypeState.functionTypesAreBoolean
-			? combineBooleanStates(callSignatures.map(member => getPromisedTypeAnnotationBooleanState(member.returnType, context, scope, normalizedTypeState)))
+			? combineBooleanStates(callSignatures.map(member => getPromisedTypeAnnotationBooleanState(member.returnType, context, scope, {...normalizedTypeState, functionTypesAreBoolean: false})))
 			: nonBoolean;
 	}
 

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -1598,6 +1598,10 @@ test({
 			code: 'type Result<T> = T extends boolean ? T | Promise<T> : never; declare const isReady: () => Result<boolean>;',
 		}),
 		typeAware({
+			name: 'type-aware conditional possibly async PromiseLike aliases preserve boolean prefixes',
+			code: 'type Result<T> = T extends boolean ? T | PromiseLike<T> : never; declare const isReady: () => Result<boolean>;',
+		}),
+		typeAware({
 			name: 'type-aware conditional possibly async aliases with nullable results remain unknown',
 			code: 'type Result<T> = T extends boolean ? T | Promise<T | undefined> : never; declare const completed: () => Result<boolean>; declare const isReady: () => Result<boolean>;',
 		}),
@@ -1796,6 +1800,11 @@ test({
 		typeAware({
 			name: 'type-aware conditional possibly async aliases require prefixes',
 			code: 'type Result<T> = T extends boolean ? T | Promise<T> : never; declare const check: () => Result<boolean>;',
+			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
+		}),
+		typeAware({
+			name: 'type-aware conditional possibly async PromiseLike aliases require prefixes',
+			code: 'type Result<T> = T extends boolean ? T | PromiseLike<T> : never; declare const check: () => Result<boolean>;',
 			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
 		}),
 		typescript({

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -1589,8 +1589,10 @@ test({
 				'declare const completed: () => boolean | Promise<boolean> | undefined;',
 				'declare const isReady: () => boolean | Promise<boolean> | undefined;',
 				'declare const isAvailable: (() => boolean | Promise<boolean>) | undefined;',
+				'declare const available: (() => boolean | Promise<boolean>) | undefined;',
 				'type MaybePromise<T> = T | Promise<T> | undefined;',
 				'declare const hasAccess: () => MaybePromise<boolean>;',
+				'declare const access: () => MaybePromise<boolean>;',
 			].join(' '),
 		}),
 		typeAware({

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -1568,6 +1568,18 @@ test({
 		},
 		typescript({code: 'function download(completed: (() => Promise<boolean>) | undefined) {}', options: [{checkArguments: 'always'}]}),
 		typescript({
+			name: 'possibly async boolean callbacks allow boolean prefixes',
+			code: 'function run(shouldCheck: () => boolean | Promise<boolean>) {}',
+		}),
+		typescript({
+			name: 'possibly async PromiseLike boolean callbacks allow boolean prefixes',
+			code: 'function run(shouldCheck: () => boolean | PromiseLike<boolean>) {}',
+		}),
+		typescript({
+			name: 'generic possibly async boolean callbacks allow boolean prefixes',
+			code: 'type MaybePromise<T> = T | Promise<T>; function run(shouldCheck: () => MaybePromise<boolean>) {}',
+		}),
+		typescript({
 			name: 'nullable generic aliases remain unknown',
 			code: 'type Maybe<T> = T | undefined; const completed: Maybe<boolean> = true;',
 		}),
@@ -1738,6 +1750,46 @@ test({
 			name: 'async functions returning booleans require prefixes',
 			code: 'async function completed(): Promise<boolean> {}',
 			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
+		}),
+		typescript({
+			name: 'possibly async boolean callbacks require prefixes',
+			code: 'function run(check: () => boolean | Promise<boolean>) {}',
+			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
+		}),
+		typescript({
+			name: 'possibly async PromiseLike boolean callbacks require prefixes',
+			code: 'function run(check: () => boolean | PromiseLike<boolean>) {}',
+			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
+		}),
+		typescript({
+			name: 'generic possibly async boolean callbacks require prefixes',
+			code: 'type MaybePromise<T> = T | Promise<T>; function run(check: () => MaybePromise<boolean>) {}',
+			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
+		}),
+		typescript({
+			name: 'possibly async callbacks reject function-valued returns',
+			code: 'const isReady: () => (() => boolean) | Promise<boolean> = getReady;',
+			errors: [{messageId: 'non-boolean-prefix'}],
+		}),
+		typescript({
+			name: 'callable interfaces reject function-valued returns',
+			code: 'interface Predicate { (): () => boolean; } const isReady: Predicate = getReady;',
+			errors: [{messageId: 'non-boolean-prefix'}],
+		}),
+		typescript({
+			name: 'callable type literals reject function-valued returns',
+			code: 'const isReady: {(): () => boolean} = getReady;',
+			errors: [{messageId: 'non-boolean-prefix'}],
+		}),
+		typescript({
+			name: 'possibly async callbacks reject mixed non-boolean returns',
+			code: 'function run(shouldCheck: () => string | Promise<boolean>) {}',
+			errors: [{messageId: 'non-boolean-prefix'}],
+		}),
+		typescript({
+			name: 'possibly async callbacks reject non-boolean Promise returns',
+			code: 'function run(shouldCheck: () => boolean | Promise<string>) {}',
+			errors: [{messageId: 'non-boolean-prefix'}],
 		}),
 		typescript({
 			name: 'async arrow functions resolve Promise aliases',

--- a/test/consistent-boolean-name.js
+++ b/test/consistent-boolean-name.js
@@ -1580,6 +1580,28 @@ test({
 			code: 'type MaybePromise<T> = T | Promise<T>; function run(shouldCheck: () => MaybePromise<boolean>) {}',
 		}),
 		typescript({
+			name: 'possibly async callable interface overloads allow boolean prefixes',
+			code: 'interface Predicate { (): boolean; (value: string): Promise<boolean>; } declare const shouldCheck: Predicate;',
+		}),
+		typescript({
+			name: 'nullable possibly async callbacks remain unknown',
+			code: [
+				'declare const completed: () => boolean | Promise<boolean> | undefined;',
+				'declare const isReady: () => boolean | Promise<boolean> | undefined;',
+				'declare const isAvailable: (() => boolean | Promise<boolean>) | undefined;',
+				'type MaybePromise<T> = T | Promise<T> | undefined;',
+				'declare const hasAccess: () => MaybePromise<boolean>;',
+			].join(' '),
+		}),
+		typeAware({
+			name: 'type-aware conditional possibly async aliases preserve boolean prefixes',
+			code: 'type Result<T> = T extends boolean ? T | Promise<T> : never; declare const isReady: () => Result<boolean>;',
+		}),
+		typeAware({
+			name: 'type-aware conditional possibly async aliases with nullable results remain unknown',
+			code: 'type Result<T> = T extends boolean ? T | Promise<T | undefined> : never; declare const completed: () => Result<boolean>; declare const isReady: () => Result<boolean>;',
+		}),
+		typescript({
 			name: 'nullable generic aliases remain unknown',
 			code: 'type Maybe<T> = T | undefined; const completed: Maybe<boolean> = true;',
 		}),
@@ -1764,6 +1786,16 @@ test({
 		typescript({
 			name: 'generic possibly async boolean callbacks require prefixes',
 			code: 'type MaybePromise<T> = T | Promise<T>; function run(check: () => MaybePromise<boolean>) {}',
+			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
+		}),
+		typescript({
+			name: 'possibly async callable interface overloads require prefixes',
+			code: 'interface Predicate { (): boolean; (value: string): Promise<boolean>; } declare const check: Predicate;',
+			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
+		}),
+		typeAware({
+			name: 'type-aware conditional possibly async aliases require prefixes',
+			code: 'type Result<T> = T extends boolean ? T | Promise<T> : never; declare const check: () => Result<boolean>;',
 			errors: [{messageId: 'consistent-boolean-name', suggestions: 11}],
 		}),
 		typescript({


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/3622