### PR TITLE
`no-array-fill-with-reference-type`: Ignore canvas contexts

### DIFF
--- a/rules/utils/is-array.js
+++ b/rules/utils/is-array.js
@@ -15,21 +15,16 @@ const nonArrayExpressionTypes = new Set([
 	'TemplateLiteral',
 ]);
 
-const keyedCollectionTypeNames = new Set([
+const knownNonIndexedCollectionTypeNames = new Set([
 	'Map',
 	'ReadonlyMap',
 	'WeakMap',
 	'Set',
 	'ReadonlySet',
 	'WeakSet',
-]);
-
-const canvasContextTypeNames = new Set([
 	'CanvasRenderingContext2D',
 	'OffscreenCanvasRenderingContext2D',
 ]);
-
-const knownNonIndexedCollectionTypeNames = keyedCollectionTypeNames.union(canvasContextTypeNames);
 
 const bigIntTypedArrayTypeNames = new Set([
 	'BigInt64Array',

--- a/rules/utils/is-array.js
+++ b/rules/utils/is-array.js
@@ -29,6 +29,8 @@ const canvasContextTypeNames = new Set([
 	'OffscreenCanvasRenderingContext2D',
 ]);
 
+const knownNonIndexedCollectionTypeNames = keyedCollectionTypeNames.union(canvasContextTypeNames);
+
 const bigIntTypedArrayTypeNames = new Set([
 	'BigInt64Array',
 	'BigUint64Array',
@@ -43,8 +45,7 @@ const isBigIntTypedArrayNode = node => isMethodCall(node, {
 
 const knownNonArrayTypeNames = new Set([
 	...typedArray,
-	...keyedCollectionTypeNames,
-	...canvasContextTypeNames,
+	...knownNonIndexedCollectionTypeNames,
 ]);
 
 const isArrayTypeAnnotation = node =>
@@ -109,7 +110,7 @@ const {
 		...arrayTypeCheckerOptions.targetTypeNames,
 		...typedArray,
 	]),
-	nonTargetTypeNames: keyedCollectionTypeNames.union(canvasContextTypeNames),
+	nonTargetTypeNames: knownNonIndexedCollectionTypeNames,
 	targetConstructorNames: ['Array', ...typedArray],
 });
 

--- a/rules/utils/is-array.js
+++ b/rules/utils/is-array.js
@@ -24,6 +24,11 @@ const keyedCollectionTypeNames = new Set([
 	'WeakSet',
 ]);
 
+const canvasContextTypeNames = new Set([
+	'CanvasRenderingContext2D',
+	'OffscreenCanvasRenderingContext2D',
+]);
+
 const bigIntTypedArrayTypeNames = new Set([
 	'BigInt64Array',
 	'BigUint64Array',
@@ -39,6 +44,7 @@ const isBigIntTypedArrayNode = node => isMethodCall(node, {
 const knownNonArrayTypeNames = new Set([
 	...typedArray,
 	...keyedCollectionTypeNames,
+	...canvasContextTypeNames,
 ]);
 
 const isArrayTypeAnnotation = node =>
@@ -103,7 +109,7 @@ const {
 		...arrayTypeCheckerOptions.targetTypeNames,
 		...typedArray,
 	]),
-	nonTargetTypeNames: keyedCollectionTypeNames,
+	nonTargetTypeNames: keyedCollectionTypeNames.union(canvasContextTypeNames),
 	targetConstructorNames: ['Array', ...typedArray],
 });
 

--- a/test/no-array-fill-with-reference-type.js
+++ b/test/no-array-fill-with-reference-type.js
@@ -67,6 +67,8 @@ test.snapshot({
 		'const foo = new Uint8Array(3); foo.fill({});',
 		// Other known non-array receivers have no `Array#fill()` semantics either
 		'function f(foo: Set<object>) { foo.fill({}); }',
+		'function draw(context: CanvasRenderingContext2D) { const path = new Path2D(); context.fill(path); }',
+		'function draw(context: OffscreenCanvasRenderingContext2D) { const path = new Path2D(); context.fill(path); }',
 	],
 	invalid: [
 		'array.fill({} as Foo)',

--- a/test/unit/is-array.js
+++ b/test/unit/is-array.js
@@ -87,6 +87,16 @@ test('both checkers agree that a keyed collection is neither', t => {
 	}
 });
 
+test('both checkers agree that a canvas context is neither', t => {
+	for (const typeName of ['CanvasRenderingContext2D', 'OffscreenCanvasRenderingContext2D']) {
+		const [annotation] = spellings(typeName);
+		const verdicts = getReceiverVerdicts(annotation);
+
+		t.true(verdicts.isKnownNonArray, `Unexpected verdict for: ${annotation}`);
+		t.true(verdicts.isKnownNonIndexedCollection, `Unexpected verdict for: ${annotation}`);
+	}
+});
+
 test('both checkers agree that an array is neither a non-array nor a non-indexed-collection', t => {
 	for (const code of [
 		'function foo(receiver: string[]) { receiver.method(); }',


### PR DESCRIPTION
Fixes #3632